### PR TITLE
feat(btc_client): Add bootloader hash and AA hash to the bootstraping inscription

### DIFF
--- a/core/lib/via_btc_client/DEV.md
+++ b/core/lib/via_btc_client/DEV.md
@@ -97,6 +97,8 @@ Votable : No
 |      OP_PUSHBYTES_32  b"verifier_6_p2wpkh_address"          |
 |      OP_PUSHBYTES_32  b"verifier_7_p2wpkh_address"          |
 |      OP_PUSHBYTES_32  b"bridge_p2wpkh_mpc_address"          |
+|      OP_PUSHBYTES_32  b"Str('bootloader_hash')"             |
+|      OP_PUSHBYTES_32  b"Str('abstract_account_hash')"       |
 |      OP_ENDIF                                               |
 |-------------------------------------------------------------|
 

--- a/core/lib/via_btc_client/src/indexer/mod.rs
+++ b/core/lib/via_btc_client/src/indexer/mod.rs
@@ -7,6 +7,7 @@ use tracing::{debug, error, info, instrument, warn};
 mod parser;
 use parser::MessageParser;
 pub use parser::{get_btc_address, get_eth_address};
+use zksync_types::H256;
 
 use crate::{
     client::BitcoinClient,
@@ -24,6 +25,8 @@ struct BootstrapState {
     sequencer_votes: HashMap<Address, Vote>,
     bridge_address: Option<Address>,
     starting_block_number: u32,
+    bootloader_hash: Option<H256>,
+    abstract_account_hash: Option<H256>,
 }
 
 impl BootstrapState {
@@ -35,6 +38,8 @@ impl BootstrapState {
             sequencer_votes: HashMap::new(),
             bridge_address: None,
             starting_block_number: 0,
+            bootloader_hash: None,
+            abstract_account_hash: None,
         }
     }
 
@@ -44,6 +49,8 @@ impl BootstrapState {
             && self.bridge_address.is_some()
             && self.starting_block_number > 0
             && self.has_majority_votes()
+            && self.bootloader_hash.is_some()
+            && self.abstract_account_hash.is_some()
     }
 
     fn has_majority_votes(&self) -> bool {
@@ -285,6 +292,8 @@ impl BitcoinInscriptionIndexer {
                     .unwrap();
                 state.bridge_address = Some(bridge_address);
                 state.starting_block_number = sb.input.start_block_height;
+                state.bootloader_hash = Some(sb.input.bootloader_hash);
+                state.abstract_account_hash = Some(sb.input.abstract_account_hash);
             }
             FullInscriptionMessage::ProposeSequencer(ps) => {
                 debug!("Processing ProposeSequencer message");
@@ -542,6 +551,8 @@ mod tests {
                         .as_unchecked()
                         .to_owned(),
                     verifier_p2wpkh_addresses: vec![],
+                    bootloader_hash: H256::zero(),
+                    abstract_account_hash: H256::zero(),
                 },
             });
         assert!(indexer.is_valid_message(&system_bootstrapping));

--- a/core/lib/via_btc_client/src/indexer/parser.rs
+++ b/core/lib/via_btc_client/src/indexer/parser.rs
@@ -21,7 +21,7 @@ use crate::{
 
 // Using constants to define the minimum number of instructions can help to make parsing more quick
 const MIN_WITNESS_LENGTH: usize = 3;
-const MIN_SYSTEM_BOOTSTRAPPING_INSTRUCTIONS: usize = 5;
+const MIN_SYSTEM_BOOTSTRAPPING_INSTRUCTIONS: usize = 7;
 const MIN_PROPOSE_SEQUENCER_INSTRUCTIONS: usize = 3;
 const MIN_VALIDATOR_ATTESTATION_INSTRUCTIONS: usize = 4;
 const MIN_L1_BATCH_DA_REFERENCE_INSTRUCTIONS: usize = 6;
@@ -196,7 +196,7 @@ impl MessageParser {
 
         debug!("Parsed {} verifier addresses", verifier_addresses.len());
 
-        let bridge_address = instructions.last().and_then(|instr| {
+        let bridge_address = instructions.get(instructions.len() - 3).and_then(|instr| {
             if let Instruction::PushBytes(bytes) = instr {
                 std::str::from_utf8(bytes.as_bytes()).ok().and_then(|s| {
                     s.parse::<Address<NetworkUnchecked>>()
@@ -218,12 +218,27 @@ impl MessageParser {
                 .map(|a| a.as_unchecked().clone())
                 .collect();
 
+        let bootloader_hash = H256::from_slice(
+            instructions
+                .get(instructions.len() - 2)?
+                .push_bytes()?
+                .as_bytes(),
+        );
+
+        debug!("Parsed bootloader hash");
+
+        let abstract_account_hash = H256::from_slice(instructions.last()?.push_bytes()?.as_bytes());
+
+        debug!("Parsed abstract account hash");
+
         Some(Message::SystemBootstrapping(SystemBootstrapping {
             common: common_fields.clone(),
             input: SystemBootstrappingInput {
                 start_block_height,
                 bridge_p2wpkh_mpc_address: bridge_address.as_unchecked().clone(),
                 verifier_p2wpkh_addresses: network_unchecked_verifier_addresses,
+                bootloader_hash,
+                abstract_account_hash,
             },
         }))
     }

--- a/core/lib/via_btc_client/src/inscriber/script_builder.rs
+++ b/core/lib/via_btc_client/src/inscriber/script_builder.rs
@@ -236,7 +236,16 @@ impl InscriptionData {
             .require_network(network)?;
         let bridge_address_encoded = Self::encode_push_bytes(bridge_address.to_string().as_bytes());
 
-        Ok(script.push_slice(bridge_address_encoded))
+        let boostloader_hash =
+            Self::encode_push_bytes(input.bootloader_hash.to_string().as_bytes());
+
+        let abstract_account_hash =
+            Self::encode_push_bytes(input.abstract_account_hash.to_string().as_bytes());
+
+        Ok(script
+            .push_slice(bridge_address_encoded)
+            .push_slice(boostloader_hash)
+            .push_slice(abstract_account_hash))
     }
 
     #[instrument(

--- a/core/lib/via_btc_client/src/types.rs
+++ b/core/lib/via_btc_client/src/types.rs
@@ -73,6 +73,8 @@ pub struct SystemBootstrappingInput {
     pub start_block_height: u32,
     pub verifier_p2wpkh_addresses: Vec<BitcoinAddress<NetworkUnchecked>>,
     pub bridge_p2wpkh_mpc_address: BitcoinAddress<NetworkUnchecked>,
+    pub bootloader_hash: H256,
+    pub abstract_account_hash: H256,
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
## What ❔

This PR updates the Bootstraping inscription and introduce the `bootloader_hash` and  the `account_abstraction_hash`. 

## Why ❔

The `bootloader_hash` and the `account_abstraction_hash` are used to compute the L1 batch and will be used to fetch the L1 block to create inscription requests.

## Checklist
- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
