### PR TITLE
fix: import via init env instead of the dev

### DIFF
--- a/etc/env/configs/via.toml
+++ b/etc/env/configs/via.toml
@@ -1,4 +1,4 @@
-__imports__ = [ "base", "l2-inits/dev.init.env" ]
+__imports__ = [ "base", "l2-inits/via.init.env" ]
 
 [via_btc_watch]
 confirmations_for_btc_msg = 3


### PR DESCRIPTION
## What ❔
- Update the vial.toml file to import the `via.init.env` instead of the `dev.init.env`.

## Test
If you don't have `via.init.env`, make sure to run the cmd `via config compile` before `via init`

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
