### PR TITLE
Impl/basic via l1 gas layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8522,6 +8522,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "via_fee_model"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "tokio",
+ "tracing",
+ "vise",
+ "zksync_config",
+ "zksync_node_fee_model",
+ "zksync_types",
+ "zksync_utils",
+]
+
+[[package]]
 name = "via_server"
 version = "0.1.0"
 dependencies = [
@@ -10395,6 +10410,7 @@ dependencies = [
  "via_btc_sender",
  "via_btc_watch",
  "via_da_dispatcher",
+ "via_fee_model",
  "zksync_base_token_adjuster",
  "zksync_block_reverter",
  "zksync_circuit_breaker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "core/node/via_da_dispatcher",
     "core/bin/via_server",
     "core/node/via_btc_sender",
+    "core/node/via_fee_model",
 ]
 
 resolver = "2"
@@ -316,3 +317,4 @@ via_da_clients = { version = "0.1.0", path = "core/lib/via_da_clients" }
 via_btc_watch = { version = "0.1.0", path = "core/node/via_btc_watch" }
 via_da_dispatcher = { version = "0.1.0", path = "core/node/via_da_dispatcher" }
 via_btc_sender = { version = "0.1.0", path = "core/node/via_btc_sender" }
+via_fee_model = { version = "0.1.0", path = "core/node/via_fee_model" }

--- a/core/bin/via_server/src/config.rs
+++ b/core/bin/via_server/src/config.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use zksync_config::{
     configs::{
-        chain::CircuitBreakerConfig,
+        chain::{CircuitBreakerConfig, StateKeeperConfig},
         consensus::{ConsensusConfig, ConsensusSecrets},
         fri_prover_group::FriProverGroupConfig,
         house_keeper::HouseKeeperConfig,
@@ -48,7 +48,7 @@ pub(crate) fn load_env_config() -> anyhow::Result<TempConfigStore> {
         network_config: None,
         contract_verifier: None,
         operations_manager_config: None,
-        state_keeper_config: None,
+        state_keeper_config: StateKeeperConfig::from_env().ok(),
         house_keeper_config: HouseKeeperConfig::from_env().ok(),
         fri_proof_compressor_config: FriProofCompressorConfig::from_env().ok(),
         fri_prover_config: FriProverConfig::from_env().ok(),

--- a/core/bin/via_server/src/node_builder.rs
+++ b/core/bin/via_server/src/node_builder.rs
@@ -17,6 +17,7 @@ use zksync_node_framework::{
             aggregator::ViaBtcInscriptionAggregatorLayer, manager::ViaInscriptionManagerLayer,
         },
         via_btc_watch::BtcWatchLayer,
+        via_l1_gas::ViaL1GasLayer,
     },
     service::{ZkStackService, ZkStackServiceBuilder},
 };
@@ -120,6 +121,13 @@ impl ViaNodeBuilder {
         Ok(self)
     }
 
+    fn add_l1_gas_layer(mut self) -> anyhow::Result<Self> {
+        let state_keeper_config = try_load_config!(self.configs.state_keeper_config);
+        let l1_gas_layer = ViaL1GasLayer::new(state_keeper_config);
+        self.node.add_layer(l1_gas_layer);
+        Ok(self)
+    }
+
     pub fn build(self) -> anyhow::Result<ZkStackService> {
         Ok(self
             .add_pools_layer()?
@@ -131,6 +139,7 @@ impl ViaNodeBuilder {
             // VIA layers
             .add_btc_watcher_layer()?
             .add_btc_sender_layer()?
+            .add_l1_gas_layer()?
             .node
             .build())
     }

--- a/core/node/node_framework/Cargo.toml
+++ b/core/node/node_framework/Cargo.toml
@@ -61,6 +61,7 @@ via_da_dispatcher.workspace = true
 via_btc_watch.workspace = true
 via_btc_client.workspace = true
 via_btc_sender.workspace = true
+via_fee_model.workspace = true
 
 pin-project-lite.workspace = true
 tracing.workspace = true

--- a/core/node/node_framework/src/implementations/layers/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/mod.rs
@@ -38,5 +38,6 @@ pub mod validate_chain_ids;
 pub mod via_btc_sender;
 pub mod via_btc_watch;
 pub mod via_da_dispatcher;
+pub mod via_l1_gas;
 pub mod vm_runner;
 pub mod web3_api;

--- a/core/node/node_framework/src/implementations/layers/via_l1_gas.rs
+++ b/core/node/node_framework/src/implementations/layers/via_l1_gas.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use via_fee_model::{ViaApiFeeInputProvider, ViaMainNodeFeeInputProvider};
+use zksync_config::configs::chain::StateKeeperConfig;
+use zksync_types::fee_model::FeeModelConfig;
+
+use crate::{
+    implementations::resources::fee_input::{ApiFeeInputResource, SequencerFeeInputResource},
+    wiring_layer::{WiringError, WiringLayer},
+    IntoContext,
+};
+
+/// Wiring layer for L1 gas interfaces.
+/// Adds several resources that depend on L1 gas price.
+#[derive(Debug)]
+pub struct ViaL1GasLayer {
+    state_keeper_config: StateKeeperConfig,
+}
+
+#[derive(Debug, IntoContext)]
+#[context(crate = crate)]
+pub struct Output {
+    pub sequencer_fee_input: SequencerFeeInputResource,
+    pub api_fee_input: ApiFeeInputResource,
+}
+
+impl ViaL1GasLayer {
+    pub fn new(state_keeper_config: StateKeeperConfig) -> Self {
+        Self {
+            state_keeper_config,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for ViaL1GasLayer {
+    type Input = ();
+    type Output = Output;
+
+    fn layer_name(&self) -> &'static str {
+        "via_l1_gas_layer"
+    }
+
+    async fn wire(self, _input: Self::Input) -> Result<Self::Output, WiringError> {
+        let main_fee_input_provider = Arc::new(ViaMainNodeFeeInputProvider::new(
+            FeeModelConfig::from_state_keeper_config(&self.state_keeper_config),
+        )?);
+
+        let api_fee_input_provider =
+            Arc::new(ViaApiFeeInputProvider::new(main_fee_input_provider.clone()));
+
+        Ok(Output {
+            sequencer_fee_input: main_fee_input_provider.into(),
+            api_fee_input: api_fee_input_provider.into(),
+        })
+    }
+}

--- a/core/node/via_fee_model/Cargo.toml
+++ b/core/node/via_fee_model/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "via_fee_model"
+description = "Via fee model"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+vise.workspace = true
+zksync_types.workspace = true
+zksync_config.workspace = true
+zksync_utils.workspace = true
+zksync_node_fee_model.workspace = true
+
+tokio = { workspace = true, features = ["time"] }
+anyhow.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]

--- a/core/node/via_fee_model/src/lib.rs
+++ b/core/node/via_fee_model/src/lib.rs
@@ -1,0 +1,79 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use zksync_node_fee_model::BatchFeeModelInputProvider;
+use zksync_types::fee_model::{
+    BaseTokenConversionRatio, BatchFeeInput, FeeModelConfig, FeeModelConfigV2, FeeParams,
+    FeeParamsV2,
+};
+
+#[derive(Debug)]
+pub struct ViaMainNodeFeeInputProvider {
+    fee_model_config: FeeModelConfigV2,
+}
+
+impl ViaMainNodeFeeInputProvider {
+    pub fn new(config: FeeModelConfig) -> anyhow::Result<Self> {
+        match config {
+            FeeModelConfig::V2(fee_model_config) => Ok(Self { fee_model_config }),
+            FeeModelConfig::V1(_) => Err(anyhow::anyhow!("Via fee model must be inited using V2")),
+        }
+    }
+}
+
+#[async_trait]
+impl BatchFeeModelInputProvider for ViaMainNodeFeeInputProvider {
+    async fn get_batch_fee_input_scaled(
+        &self,
+        _l1_gas_price_scale_factor: f64,
+        _l1_pubdata_price_scale_factor: f64,
+    ) -> anyhow::Result<BatchFeeInput> {
+        Ok(BatchFeeInput::pubdata_independent(
+            self.fee_model_config.minimal_l2_gas_price * 100,
+            self.fee_model_config.minimal_l2_gas_price,
+            self.fee_model_config.max_pubdata_per_batch,
+        ))
+    }
+
+    fn get_fee_model_params(&self) -> FeeParams {
+        FeeParams::V2(FeeParamsV2::new(
+            self.fee_model_config,
+            self.fee_model_config.minimal_l2_gas_price * 100,
+            self.fee_model_config.max_pubdata_per_batch,
+            BaseTokenConversionRatio::default(),
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub struct ViaApiFeeInputProvider {
+    inner: Arc<dyn BatchFeeModelInputProvider>,
+}
+
+impl ViaApiFeeInputProvider {
+    pub fn new(inner: Arc<dyn BatchFeeModelInputProvider>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl BatchFeeModelInputProvider for ViaApiFeeInputProvider {
+    async fn get_batch_fee_input_scaled(
+        &self,
+        _l1_gas_price_scale_factor: f64,
+        _l1_pubdata_price_scale_factor: f64,
+    ) -> anyhow::Result<BatchFeeInput> {
+        if let FeeParams::V2(params_v2) = self.inner.get_fee_model_params() {
+            return Ok(BatchFeeInput::pubdata_independent(
+                params_v2.l1_gas_price(),
+                params_v2.l1_gas_price(),
+                params_v2.l1_pubdata_price(),
+            ));
+        }
+        Err(anyhow::Error::msg("Via batch fee must be v2"))
+    }
+
+    fn get_fee_model_params(&self) -> FeeParams {
+        self.inner.get_fee_model_params()
+    }
+}


### PR DESCRIPTION
## What ❔

- Implement a mock via l1 gas fee model. The reason of putting the logic is because later we will need to fetch fee price from L1 and DA through a task.
- Integrated the layer to the via server.

## Why ❔

- The via fee model is required by the tx_sender and the some state keeper layers.
- Instead of create a new config struct, I use the statekeeper config to set the constant values like the l2 gas fee a tx should pay.

## Testing
Use `via` CLI  to start the via server.
![test](https://github.com/user-attachments/assets/7f89db5d-acde-4db6-865c-bf3241240d32)

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
