### PR TITLE
feat(http-api): add http api layer

### DIFF
--- a/core/bin/via_server/src/main.rs
+++ b/core/bin/via_server/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use clap::Parser;
 use zksync_config::{
     configs::{via_general, DatabaseSecrets, L1Secrets, Secrets},
-    GenesisConfig, ViaGeneralConfig,
+    ContractsConfig, GenesisConfig, ViaGeneralConfig,
 };
 use zksync_env_config::FromEnv;
 
@@ -23,6 +23,10 @@ struct Cli {
     /// Path to the YAML with secrets. If set, it will be used instead of env vars.
     #[arg(long)]
     secrets_path: Option<std::path::PathBuf>,
+
+    /// Path to the yaml with contracts. If set, it will be used instead of env vars.
+    #[arg(long)]
+    contracts_config_path: Option<std::path::PathBuf>,
 
     /// Path to the wallets config. If set, it will be used instead of env vars.
     #[arg(long)]
@@ -82,12 +86,20 @@ fn main() -> anyhow::Result<()> {
         None => tmp_config.wallets(),
     };
 
+    let contracts_config = match opt.contracts_config_path {
+        Some(_path) => {
+            todo!("Load config from file");
+        }
+        None => ContractsConfig::from_env().context("contracts_config")?,
+    };
+
     let observability_config = configs
         .observability
         .clone()
         .context("Observability config missing")?;
 
-    let node_builder = node_builder::ViaNodeBuilder::new(configs, wallets, secrets, genesis)?;
+    let node_builder =
+        node_builder::ViaNodeBuilder::new(configs, wallets, secrets, genesis, contracts_config)?;
 
     let observability_guard = {
         // Observability initialization should be performed within tokio context.


### PR DESCRIPTION
## What ❔

This PR will enable the http-api RPC server which requires sub layers like:
- The `TreeApiClientLayer` which is required to fetch the Batch proofs.
- The `MempoolCacheLayer` is a layer used to cache the l2 transactions received by the mempool.

This PR depends on the PR #25 

## Why ❔

The RPC server is used to send and query data from the sequencer.

## Testing
- Use the `via server` to run the server.
- Seed a dummy block to the database.
- query using
```sh
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "zks_L1ChainId", "params": [], "id": 1}' http://localhost:3050
```

![Capture](https://github.com/user-attachments/assets/a9addfd1-5245-4e54-b34f-4fc9ffe83adb)


## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
