### PR TITLE
fix(btc_sender): add auth credentials to connect to the rpc node

### DIFF
--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
@@ -69,7 +69,10 @@ impl WiringLayer for ViaBtcInscriptionAggregatorLayer {
         let inscriber = Inscriber::new(
             self.config.rpc_url(),
             network,
-            NodeAuth::None,
+            NodeAuth::UserPass(
+                self.config.rpc_user().to_string(),
+                self.config.rpc_password().to_string(),
+            ),
             self.config.private_key(),
             None,
         )

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
@@ -67,7 +67,10 @@ impl WiringLayer for ViaInscriptionManagerLayer {
         let inscriber = Inscriber::new(
             self.config.rpc_url(),
             network,
-            NodeAuth::None,
+            NodeAuth::UserPass(
+                self.config.rpc_user().to_string(),
+                self.config.rpc_password().to_string(),
+            ),
             self.config.private_key(),
             None,
         )


### PR DESCRIPTION
## What ❔

- Add auth credentials to connect to the btc rpc node.

## Why ❔

- When the btc_sender calls the btc node it gets HTTP401 due to missing credentials.

## Testing
### Requirements:
- Insert a dummy l1 batch with other data dependencies [here](https://github.com/vianetwork/via-core/blob/90018208e3749f8dc1b01a06eef64e9f60188a51/core/node/via_btc_sender/src/tests/utils.rs#L170)
- Run `via server`

### Outputs
The reveal and commit tx ids are inserted.
![Capture](https://github.com/user-attachments/assets/cde66e3a-3d1a-4616-95af-784718590ed7)

The inscription history is recorded.
![inscription](https://github.com/user-attachments/assets/9bd32a62-fff5-4863-8407-da1d05635917)

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
