### PR TITLE
Fix/ Code Panic During the genesis phase

### DIFF
--- a/core/bin/via_server/src/main.rs
+++ b/core/bin/via_server/src/main.rs
@@ -16,6 +16,9 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[derive(Debug, Parser)]
 #[command(author = "Via Protocol", version, about = "Via validator/sequencer node", long_about = None)]
 struct Cli {
+    /// Generate genesis block for the first contract deployment using temporary DB.
+    #[arg(long)]
+    genesis: bool,
     /// Path to the YAML config. If set, it will be used instead of env vars.
     #[arg(long)]
     config_path: Option<std::path::PathBuf>,
@@ -111,6 +114,12 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Build the node
+
+    if opt.genesis {
+        let node = node_builder.only_genesis()?;
+        node.run(observability_guard)?;
+        return Ok(());
+    }
 
     let node = node_builder.build()?;
     node.run(observability_guard)?;

--- a/core/bin/via_server/src/node_builder.rs
+++ b/core/bin/via_server/src/node_builder.rs
@@ -358,6 +358,16 @@ impl ViaNodeBuilder {
         Ok(self)
     }
 
+    /// Builds the node with the genesis initialization task only.
+    pub fn only_genesis(mut self) -> anyhow::Result<ZkStackService> {
+        self = self
+            .add_pools_layer()?
+            .add_query_eth_client_layer()?
+            .add_storage_initialization_layer(LayerKind::Task)?;
+
+        Ok(self.node.build())
+    }
+
     pub fn build(self) -> anyhow::Result<ZkStackService> {
         Ok(self
             .add_pools_layer()?
@@ -367,7 +377,7 @@ impl ViaNodeBuilder {
             .add_circuit_breaker_checker_layer()?
             .add_postgres_metrics_layer()?
             .add_query_eth_client_layer()?
-            .add_storage_initialization_layer(LayerKind::Task)?
+            .add_storage_initialization_layer(LayerKind::Precondition)?
             // VIA layers
             .add_btc_watcher_layer()?
             .add_btc_sender_layer()?
@@ -378,6 +388,7 @@ impl ViaNodeBuilder {
             .add_http_web3_api_layer()?
             .add_vm_runner_protective_reads_layer()?
             .add_vm_runner_bwip_layer()?
+            .add_storage_initialization_layer(LayerKind::Task)?
             .add_state_keeper_layer()?
             .add_logs_bloom_backfill_layer()?
             .add_metadata_calculator_layer(true)?


### PR DESCRIPTION
**Fixing the Issue with Code Panic During the First `via server` Execution**

**Approach:**
I’m adopting a similar approach to what zkSync uses. When running the server for the first time, there are two steps 
required:
1. `via server --genesis`
2. `via server`

However, if the **genesis block already exists in the database**, you only need to run:
• `via server`
