### PR TITLE
Fix/via fee model: remove scaling the L1 gas price

### DIFF
--- a/core/node/via_fee_model/src/lib.rs
+++ b/core/node/via_fee_model/src/lib.rs
@@ -29,7 +29,7 @@ impl BatchFeeModelInputProvider for ViaMainNodeFeeInputProvider {
         _l1_pubdata_price_scale_factor: f64,
     ) -> anyhow::Result<BatchFeeInput> {
         Ok(BatchFeeInput::pubdata_independent(
-            self.fee_model_config.minimal_l2_gas_price * 100,
+            self.fee_model_config.minimal_l2_gas_price,
             self.fee_model_config.minimal_l2_gas_price,
             self.fee_model_config.max_pubdata_per_batch,
         ))
@@ -38,7 +38,7 @@ impl BatchFeeModelInputProvider for ViaMainNodeFeeInputProvider {
     fn get_fee_model_params(&self) -> FeeParams {
         FeeParams::V2(FeeParamsV2::new(
             self.fee_model_config,
-            self.fee_model_config.minimal_l2_gas_price * 100,
+            self.fee_model_config.minimal_l2_gas_price,
             self.fee_model_config.max_pubdata_per_batch,
             BaseTokenConversionRatio::default(),
         ))


### PR DESCRIPTION
## What ❔
Remove scaling the L1 gas price to X100 compared to l2 gas price, because it blocks the L2 sealer task to create new miniblocks.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
