### PR TITLE
feat: metrics

### DIFF
--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -122,10 +122,12 @@ impl BtcWatch {
             match self.loop_iteration(&mut storage).await {
                 Ok(()) => { /* everything went fine */ }
                 Err(MessageProcessorError::Internal(err)) => {
+                    METRICS.errors.inc();
                     tracing::error!("Internal error processing new blocks: {err:?}");
                     return Err(err);
                 }
                 Err(err) => {
+                    METRICS.errors.inc();
                     tracing::error!("Failed to process new blocks: {err}");
                     self.last_processed_bitcoin_block =
                         Self::initialize_state(&self.indexer, &mut storage)

--- a/core/node/via_btc_watch/src/message_processors/l1_to_l2.rs
+++ b/core/node/via_btc_watch/src/message_processors/l1_to_l2.rs
@@ -9,7 +9,7 @@ use zksync_types::{
 
 use crate::{
     message_processors::{MessageProcessor, MessageProcessorError},
-    metrics::METRICS,
+    metrics::{ErrorType, InscriptionStage, METRICS},
 };
 
 #[derive(Debug)]
@@ -71,13 +71,13 @@ impl MessageProcessor for L1ToL2MessageProcessor {
         }
 
         for (new_op, txid) in priority_ops {
-            METRICS.inscriptions_processed.inc();
+            METRICS.inscriptions_processed[&InscriptionStage::Deposit].inc();
             storage
                 .via_transactions_dal()
                 .insert_transaction_l1(&new_op, new_op.eth_block(), txid)
                 .await
                 .map_err(|e| {
-                    METRICS.errors.inc();
+                    METRICS.errors[&ErrorType::DatabaseError].inc();
                     MessageProcessorError::DatabaseError(e.to_string())
                 })?;
         }

--- a/core/node/via_btc_watch/src/message_processors/mod.rs
+++ b/core/node/via_btc_watch/src/message_processors/mod.rs
@@ -10,8 +10,6 @@ pub(super) enum MessageProcessorError {
     Internal(#[from] anyhow::Error),
     #[error("database error: {0}")]
     DatabaseError(String),
-    #[error("ethereum address parsing error")]
-    EthAddressParsingError,
 }
 
 #[async_trait::async_trait]

--- a/core/node/via_btc_watch/src/metrics.rs
+++ b/core/node/via_btc_watch/src/metrics.rs
@@ -7,6 +7,12 @@ use vise::{Counter, Metrics};
 pub(super) struct ViaBtcWatcherMetrics {
     /// Number of times Bitcoin was polled.
     pub btc_poll: Counter,
+
+    /// Number of inscriptions processed.
+    pub inscriptions_processed: Counter,
+
+    /// Number of errors encountered (e.g., network failures, internal issues).
+    pub errors: Counter,
 }
 
 #[vise::register]

--- a/core/node/via_btc_watch/src/metrics.rs
+++ b/core/node/via_btc_watch/src/metrics.rs
@@ -1,0 +1,13 @@
+//! Metrics for Via btc watcher.
+
+use vise::{Counter, Metrics};
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "via_server_btc_watch")]
+pub(super) struct ViaBtcWatcherMetrics {
+    /// Number of times Bitcoin was polled.
+    pub btc_poll: Counter,
+}
+
+#[vise::register]
+pub(super) static METRICS: vise::Global<ViaBtcWatcherMetrics> = vise::Global::new();

--- a/core/node/via_btc_watch/src/metrics.rs
+++ b/core/node/via_btc_watch/src/metrics.rs
@@ -1,19 +1,30 @@
-//! Metrics for Via btc watcher.
+use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Metrics};
 
-use vise::{Counter, Metrics};
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
+#[metrics(label = "stage", rename_all = "snake_case")]
+pub enum InscriptionStage {
+    Deposit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
+#[metrics(label = "error_type", rename_all = "snake_case")]
+pub enum ErrorType {
+    InternalError,
+    DatabaseError,
+}
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "via_server_btc_watch")]
-pub(super) struct ViaBtcWatcherMetrics {
+pub struct ViaBtcWatcherMetrics {
     /// Number of times Bitcoin was polled.
     pub btc_poll: Counter,
 
-    /// Number of inscriptions processed.
-    pub inscriptions_processed: Counter,
+    /// Number of inscriptions processed, labeled by type.
+    pub inscriptions_processed: Family<InscriptionStage, Counter>,
 
-    /// Number of errors encountered (e.g., network failures, internal issues).
-    pub errors: Counter,
+    /// Number of errors encountered, labeled by error type.
+    pub errors: Family<ErrorType, Counter>,
 }
 
 #[vise::register]
-pub(super) static METRICS: vise::Global<ViaBtcWatcherMetrics> = vise::Global::new();
+pub static METRICS: vise::Global<ViaBtcWatcherMetrics> = vise::Global::new();


### PR DESCRIPTION
This PR provides new `via_server_btc_watch` metrics. The list of all edited metrics (prefixes) is:
| zksync    | via |
| -------- | ------- |
| server_da_dispatcher | via_server_da_dispatcher |
| server_state_keeper |  via_server_state_keeper |
| server_tx_aggregation | via_server_tx_aggregation |
| server_state_keeper_l1_batch | via_server_state_keeper_l1_batch |
| server_state_keeper_miniblock | via_server_state_keeper_miniblock |
| batch_tip | via_batch_tip |
| server_state_keeper_updates_manager | via_server_state_keeper_updates_manager |
| server_eth_watch | via_server_btc_watch |