### PR TITLE
feat: implement the via withdrawal client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "arrayvec 0.7.6",
  "bytes",
@@ -3217,7 +3217,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3236,7 +3236,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3285,6 +3285,12 @@ dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -3692,12 +3698,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -4228,7 +4234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5318,7 +5324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -6860,7 +6866,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -7220,7 +7226,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "ipnetwork",
  "log",
  "memchr",
@@ -7962,7 +7968,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7973,7 +7979,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8597,6 +8603,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "via_withdrawal_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "byteorder",
+ "hex",
+ "rand 0.8.5",
+ "zksync_basic_types",
+ "zksync_config",
+ "zksync_da_client",
+ "zksync_types",
+ "zksync_utils",
+]
+
+[[package]]
 name = "vise"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8853,7 +8875,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "core/node/via_btc_sender",
     "core/node/via_fee_model",
     "core/node/via_state_keeper",
+    "core/lib/via_withdrawal_client",
 
 ]
 
@@ -315,6 +316,7 @@ zksync_logs_bloom_backfill = { version = "0.1.0", path = "core/node/logs_bloom_b
 
 # VIA Protocol Related Components
 via_btc_client= { version = "0.1.0", path = "core/lib/via_btc_client" }
+via_withdrawal_client = { version = "0.1.0", path = "core/lib/via_withdrawal_client" }
 via_da_clients = { version = "0.1.0", path = "core/lib/via_da_clients" }
 via_btc_watch = { version = "0.1.0", path = "core/node/via_btc_watch" }
 via_da_dispatcher = { version = "0.1.0", path = "core/node/via_da_dispatcher" }

--- a/core/lib/via_withdrawal_client/Cargo.toml
+++ b/core/lib/via_withdrawal_client/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "via_withdrawal_client"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+hex.workspace = true
+anyhow.workspace = true
+zksync_basic_types.workspace = true
+zksync_da_client.workspace = true
+zksync_config.workspace = true
+zksync_types.workspace = true
+zksync_utils.workspace = true
+
+bitcoin = { version = "0.32.2", features = ["serde"] }
+byteorder = "1.4"
+
+[dev-dependencies]
+rand = "0.8"

--- a/core/lib/via_withdrawal_client/src/client.rs
+++ b/core/lib/via_withdrawal_client/src/client.rs
@@ -1,0 +1,80 @@
+use std::{collections::HashMap, str::FromStr};
+
+use zksync_da_client::DataAvailabilityClient;
+use zksync_types::{web3::keccak256, H160, H256};
+
+use crate::{
+    pubdata::Pubdata,
+    types::{L2BridgeLogMetadata, WithdrawalRequest, L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR},
+    withdraw::parse_l2_withdrawal_message,
+};
+
+#[derive(Debug)]
+pub struct WithdrawalClient {
+    client: Box<dyn DataAvailabilityClient>,
+}
+
+impl WithdrawalClient {
+    pub async fn get_withdrawals(&self, blob_id: &str) -> anyhow::Result<Vec<WithdrawalRequest>> {
+        let pubdata_bytes = self._fetch_pubdata(blob_id).await?;
+        let pubdata = Pubdata::decode_pubdata(pubdata_bytes)?;
+        let l2_bridge_metadata = self._list_l2_bridge_metadata(pubdata);
+        let withdrawals = self._get_valid_withdrawals(l2_bridge_metadata);
+        Ok(withdrawals)
+    }
+
+    async fn _fetch_pubdata(&self, blob_id: &str) -> anyhow::Result<Vec<u8>> {
+        let response = self.client.get_inclusion_data(blob_id).await?;
+        if let Some(inclusion_data) = response {
+            return Ok(inclusion_data.data);
+        };
+        Ok(Vec::new())
+    }
+
+    fn _l2_to_l1_messages_hashmap(&self, pubdata: &Pubdata) -> HashMap<H256, Vec<u8>> {
+        let mut hashes: HashMap<H256, Vec<u8>> = HashMap::new();
+        for message in &pubdata.l2_to_l1_messages {
+            let hash = H256::from(keccak256(hex::encode(&message).as_bytes()));
+            hashes.insert(hash, message.clone());
+        }
+        hashes
+    }
+
+    fn _list_l2_bridge_metadata(&self, pubdata: Pubdata) -> Vec<L2BridgeLogMetadata> {
+        let mut withdrawals: Vec<L2BridgeLogMetadata> = Vec::new();
+        let l2_bridges_hash =
+            H256::from(H160::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap());
+        let l2_to_l1_messages_hashmap = self._l2_to_l1_messages_hashmap(&pubdata);
+        for log in pubdata.user_logs.clone() {
+            // Ignore the logs if not from emitted from the L2 bridge contract
+            if log.key != l2_bridges_hash {
+                continue;
+            };
+
+            if log.key != l2_bridges_hash {
+                continue;
+            };
+            withdrawals.push(L2BridgeLogMetadata {
+                message: l2_to_l1_messages_hashmap[&log.value].clone(),
+                log,
+            });
+        }
+        withdrawals
+    }
+
+    fn _get_valid_withdrawals(
+        &self,
+        l2_bridge_logs_metadata: Vec<L2BridgeLogMetadata>,
+    ) -> Vec<WithdrawalRequest> {
+        let mut withdrawal_requests: Vec<WithdrawalRequest> = Vec::new();
+        for l2_bridge_log_metadata in l2_bridge_logs_metadata {
+            let withdrawal_request = parse_l2_withdrawal_message(l2_bridge_log_metadata.message);
+
+            match withdrawal_request {
+                Ok(req) => withdrawal_requests.push(req),
+                Err(_) => (),
+            }
+        }
+        withdrawal_requests
+    }
+}

--- a/core/lib/via_withdrawal_client/src/lib.rs
+++ b/core/lib/via_withdrawal_client/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod client;
+mod pubdata;
+mod types;
+mod withdraw;

--- a/core/lib/via_withdrawal_client/src/pubdata.rs
+++ b/core/lib/via_withdrawal_client/src/pubdata.rs
@@ -1,0 +1,208 @@
+use std::io::{Cursor, Read};
+
+use anyhow::Context;
+use byteorder::{BigEndian, ReadBytesExt};
+use zksync_types::writes::StateDiffRecord;
+
+use crate::types::L1MessengerL2ToL1Log;
+
+#[derive(Debug, Clone, Default)]
+pub struct Pubdata {
+    pub user_logs: Vec<L1MessengerL2ToL1Log>,
+    pub l2_to_l1_messages: Vec<Vec<u8>>,
+    pub published_bytecodes: Vec<Vec<u8>>,
+    pub state_diffs: Vec<StateDiffRecord>,
+}
+
+impl Pubdata {
+    pub fn _encode_pubdata(self) -> Vec<u8> {
+        let mut l1_messenger_pubdata = vec![];
+
+        // Encoding user L2->L1 logs.
+        // Format: `[(numberOfL2ToL1Logs as u32) || l2tol1logs[1] || ... || l2tol1logs[n]]`
+        l1_messenger_pubdata.extend((self.user_logs.len() as u32).to_be_bytes());
+        for l2tol1log in self.user_logs {
+            l1_messenger_pubdata.extend(l2tol1log.encode_packed());
+        }
+
+        // Encoding L2->L1 messages
+        // Format: `[(numberOfMessages as u32) || (messages[1].len() as u32) || messages[1] || ... || (messages[n].len() as u32) || messages[n]]`
+        l1_messenger_pubdata.extend((self.l2_to_l1_messages.len() as u32).to_be_bytes());
+        for message in self.l2_to_l1_messages {
+            l1_messenger_pubdata.extend((message.len() as u32).to_be_bytes());
+            l1_messenger_pubdata.extend(message);
+        }
+
+        l1_messenger_pubdata
+    }
+
+    pub fn decode_pubdata(pubdata: Vec<u8>) -> anyhow::Result<Pubdata> {
+        let mut cursor = Cursor::new(pubdata);
+        let mut user_logs = Vec::new();
+        let mut l2_to_l1_messages = Vec::new();
+        let published_bytecodes = Vec::new();
+        let state_diffs = Vec::new();
+
+        // Decode user L2->L1 logs
+        let num_user_logs = cursor
+            .read_u32::<BigEndian>()
+            .context("Failed to decode num user logs")? as usize;
+        for _ in 0..num_user_logs {
+            let log = L1MessengerL2ToL1Log::decode_packed(&mut cursor)?;
+            user_logs.push(log);
+        }
+
+        // Decode L2->L1 messages
+        let num_messages = cursor.read_u32::<BigEndian>()? as usize;
+        for _ in 0..num_messages {
+            let message_len = cursor.read_u32::<BigEndian>()? as usize;
+            let mut message = vec![0u8; message_len];
+            cursor
+                .read_exact(&mut message)
+                .context("Read l2 to l1 message")?;
+            l2_to_l1_messages.push(message);
+        }
+
+        Ok(Pubdata {
+            user_logs,
+            l2_to_l1_messages,
+            published_bytecodes,
+            state_diffs,
+        })
+    }
+}
+
+/// Helper function to read a specific number of bytes
+fn _read_bytes<R: Read>(reader: &mut R, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = vec![0u8; num_bytes];
+    reader.read_exact(&mut buffer)?;
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use hex::encode;
+    use rand;
+    use zksync_types::{Address, H256};
+
+    use super::*;
+    use crate::types::L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR;
+
+    fn generate_random_hex(len: usize) -> String {
+        // Generate random bytes
+        let random_bytes: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+
+        // Convert bytes to hex and return it
+        encode(random_bytes)
+    }
+
+    #[test]
+    fn test_decode_l1_messager_l2_to_l1_log() {
+        let message = L1MessengerL2ToL1Log {
+            l2_shard_id: 0,
+            is_service: true,
+            tx_number_in_block: 5,
+            sender: Address::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap(),
+            key: H256::random(),
+            value: H256::random(),
+        };
+        let encoded_messages = message.encode_packed();
+
+        let mut cursor = Cursor::new(encoded_messages);
+        let decoded = L1MessengerL2ToL1Log::decode_packed(&mut cursor).unwrap();
+        assert_eq!(message.l2_shard_id, decoded.l2_shard_id);
+        assert_eq!(message.is_service, decoded.is_service);
+        assert_eq!(message.tx_number_in_block, decoded.tx_number_in_block);
+        assert_eq!(message.sender, decoded.sender);
+        assert_eq!(message.key, decoded.key);
+        assert_eq!(message.value, decoded.value);
+    }
+
+    #[test]
+    fn test_decode_pubdata_with_single_l1_messager_l2_to_l1_log() {
+        let message = L1MessengerL2ToL1Log {
+            l2_shard_id: 0,
+            is_service: true,
+            tx_number_in_block: 5,
+            sender: Address::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap(),
+            key: H256::random(),
+            value: H256::random(),
+        };
+
+        let pubdata = Pubdata {
+            user_logs: vec![message.clone()],
+            l2_to_l1_messages: vec![hex::decode("deadbeef").unwrap()],
+            published_bytecodes: Vec::new(),
+            state_diffs: Vec::new(),
+        };
+
+        let encoded_pubdata = pubdata._encode_pubdata();
+        let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let decoded_message = pubdata_input.user_logs[0].clone();
+        assert_eq!(pubdata_input.user_logs.len(), 1);
+        assert_eq!(decoded_message.l2_shard_id, message.clone().l2_shard_id);
+        assert_eq!(decoded_message.is_service, message.clone().is_service);
+        assert_eq!(
+            decoded_message.tx_number_in_block,
+            message.clone().tx_number_in_block
+        );
+        assert_eq!(decoded_message.sender, message.clone().sender);
+        assert_eq!(decoded_message.key, message.clone().key);
+        assert_eq!(decoded_message.value, message.clone().value);
+    }
+
+    #[test]
+    fn test_decode_pubdata_with_many_l1_messager_l2_to_l1_log() {
+        let len: usize = 5;
+        let mut user_logs: Vec<L1MessengerL2ToL1Log> = Vec::new();
+        let mut l2_to_l1_messages: Vec<Vec<u8>> = Vec::new();
+        for _ in 0..len {
+            let log = L1MessengerL2ToL1Log {
+                l2_shard_id: 0,
+                is_service: true,
+                tx_number_in_block: 5,
+                sender: Address::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap(),
+                key: H256::from_str(&generate_random_hex(32)).unwrap(),
+                value: H256::from_str(&generate_random_hex(32)).unwrap(),
+            };
+            user_logs.push(log.clone());
+            l2_to_l1_messages.push(hex::decode("deadbeef").unwrap());
+        }
+
+        let pubdata = Pubdata {
+            user_logs: user_logs.clone(),
+            l2_to_l1_messages: l2_to_l1_messages,
+            published_bytecodes: Vec::new(),
+            state_diffs: Vec::new(),
+        };
+
+        let encoded_pubdata = pubdata._encode_pubdata();
+        let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let decoded_logs = pubdata_input.user_logs.clone();
+        let decoded_messages = pubdata_input.l2_to_l1_messages.clone();
+        assert_eq!(pubdata_input.user_logs.len(), len);
+        assert_eq!(pubdata_input.l2_to_l1_messages.len(), len);
+        for i in 0..len {
+            let decoded_log = decoded_logs[i].clone();
+            let msg_log = user_logs[i].clone();
+
+            assert_eq!(decoded_log.l2_shard_id, msg_log.clone().l2_shard_id);
+            assert_eq!(decoded_log.is_service, msg_log.clone().is_service);
+            assert_eq!(
+                decoded_log.tx_number_in_block,
+                msg_log.clone().tx_number_in_block
+            );
+            assert_eq!(decoded_log.sender, msg_log.clone().sender);
+            assert_eq!(decoded_log.key, msg_log.clone().key);
+            assert_eq!(decoded_log.value, msg_log.clone().value);
+
+            // l2 to l1 message
+            let decoded_message = decoded_messages[i].clone();
+            assert_eq!(decoded_message, hex::decode("deadbeef").unwrap());
+        }
+    }
+}

--- a/core/lib/via_withdrawal_client/src/types.rs
+++ b/core/lib/via_withdrawal_client/src/types.rs
@@ -1,0 +1,114 @@
+use std::io::Read;
+
+use anyhow::Context;
+use bitcoin::{address::NetworkUnchecked, Address as BitcoinAddress};
+use byteorder::{BigEndian, ReadBytesExt};
+use zksync_types::{Address, H160, H256, U256};
+use zksync_utils::{u256_to_bytes_be, u256_to_h256};
+
+/// The function selector used in L2 to compute the message.
+pub const WITHDRAW_FUNC_SIG: &str = "finalizeEthWithdrawal(uint256,uint256,uint16,bytes,bytes32[])";
+
+/// The L2 system bridge address.
+pub const L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR: &str = "000000000000000000000000000000000000800a";
+
+#[derive(Clone, Debug, Default)]
+pub struct L2BridgeLogMetadata {
+    pub log: L1MessengerL2ToL1Log,
+    pub message: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WithdrawalRequest {
+    /// The receiver l1 address.
+    pub address: BitcoinAddress<NetworkUnchecked>,
+    /// The amount user will receive.
+    pub amount: U256,
+}
+
+/// Corresponds to the following solidity event:
+/// ```solidity
+/// struct L2ToL1Log {
+///     uint8 l2ShardId;
+///     bool isService;
+///     uint16 txNumberInBlock;
+///     address sender;
+///     bytes32 key;
+///     bytes32 value;
+/// }
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct L1MessengerL2ToL1Log {
+    /// l2ShardId The shard identifier, 0 - rollup, 1 - porter
+    /// All other values are not used but are reserved for the future
+    pub l2_shard_id: u8,
+    /// isService A boolean flag that is part of the log along with `key`, `value`, and `sender` address.
+    /// This field is required formally but does not have any special meaning
+    pub is_service: bool,
+    /// txNumberInBatch The L2 transaction number in a Batch, in which the log was sent
+    pub tx_number_in_block: u16,
+    /// sender The L2 address which sent the log
+    pub sender: H160,
+    /// key The 32 bytes of information that was sent in the log
+    pub key: H256,
+    /// value The 32 bytes of information that was sent in the log
+    pub value: H256,
+}
+
+impl L1MessengerL2ToL1Log {
+    pub fn encode_packed(&self) -> Vec<u8> {
+        let mut res: Vec<u8> = vec![];
+        res.push(self.l2_shard_id);
+        res.push(self.is_service as u8);
+        res.extend_from_slice(&self.tx_number_in_block.to_be_bytes());
+        res.extend_from_slice(self.sender.as_bytes());
+        res.extend(u256_to_bytes_be(&U256::from_big_endian(&self.key.0)));
+        res.extend(u256_to_bytes_be(&U256::from_big_endian(&self.value.0)));
+        res
+    }
+
+    pub fn decode_packed<R: Read>(reader: &mut R) -> anyhow::Result<Self> {
+        // Read `l2_shard_id` (1 byte)
+        let l2_shard_id = reader.read_u8().context("Failed to read l2_shard_id")?;
+
+        // Read `is_service` (1 byte, a boolean stored as 0 or 1)
+        let is_service_byte = reader.read_u8().context("Failed to read is_service byte")?;
+        let is_service = is_service_byte != 0; // 0 -> false, non-zero -> true
+
+        // Read `tx_number_in_block` (2 bytes, u16)
+        let tx_number_in_block = reader
+            .read_u16::<BigEndian>()
+            .context("Failed to read tx_number_in_block")?;
+
+        // Read `sender` (address is 20 bytes)
+        let mut sender_bytes = [0u8; 20];
+        reader
+            .read_exact(&mut sender_bytes)
+            .context("Failed to read sender address")?;
+        let sender = Address::from(sender_bytes);
+
+        // Read `key` (U256 is 32 bytes)
+        let key_bytes = _read_bytes(reader, 32).context("Failed to read key bytes")?;
+        let key = u256_to_h256(U256::from_big_endian(&key_bytes));
+
+        // Read `value` (U256 is 32 bytes)
+        let value_bytes = _read_bytes(reader, 32).context("Failed to read value bytes")?;
+        let value = u256_to_h256(U256::from_big_endian(&value_bytes));
+
+        Ok(L1MessengerL2ToL1Log {
+            l2_shard_id,
+            is_service,
+            tx_number_in_block,
+            sender,
+            key,
+            value,
+        })
+    }
+}
+
+/// Helper function to read a specific number of bytes
+fn _read_bytes<R: Read>(reader: &mut R, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = vec![0u8; num_bytes];
+    reader.read_exact(&mut buffer)?;
+    Ok(buffer)
+}

--- a/core/lib/via_withdrawal_client/src/withdraw.rs
+++ b/core/lib/via_withdrawal_client/src/withdraw.rs
@@ -1,0 +1,76 @@
+use std::str::FromStr;
+
+use anyhow::Context;
+use bitcoin::Address as BitcoinAddress;
+use zksync_basic_types::{web3::keccak256, U256};
+
+use crate::types::{WithdrawalRequest, WITHDRAW_FUNC_SIG};
+
+pub fn parse_l2_withdrawal_message(l2_to_l1_message: Vec<u8>) -> anyhow::Result<WithdrawalRequest> {
+    // We check that the message is long enough to read the data.
+    // Please note that there are two versions of the message:
+    // The message that is sent by `withdraw(address _l1Receiver)`
+    // It should be equal to the length of the bytes4 function signature + bytes l1Receiver + uint256 amount = 4 + X + 32.
+    let message_len = l2_to_l1_message.len();
+    let address_size = message_len - 36;
+    if message_len <= 36 {
+        return Err(anyhow::format_err!("Invalid message length."));
+    }
+
+    let func_selector_bytes = &l2_to_l1_message[0..4];
+    if func_selector_bytes != _get_withdraw_function_selector() {
+        return Err(anyhow::format_err!("Invalid message function selector."));
+    }
+
+    // The address bytes represent the l1 receiver
+    let address_bytes = &l2_to_l1_message[4..4 + address_size];
+    let address_str =
+        String::from_utf8(address_bytes.to_vec()).context("Parse address to string")?;
+    let address = BitcoinAddress::from_str(&address_str).context("parse bitcoin address")?;
+
+    // The last 32 bytes represent the amount (uint256)
+    let amount_bytes = &l2_to_l1_message[address_size + 4..];
+    let amount = U256::from_big_endian(amount_bytes);
+
+    return Ok(WithdrawalRequest { address, amount });
+}
+
+/// Get the withdrawal function selector.
+fn _get_withdraw_function_selector() -> Vec<u8> {
+    let hash = keccak256(WITHDRAW_FUNC_SIG.as_bytes());
+    hash[0..4].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_l2_withdrawal_message_when_address_bech32m() {
+        // Example transaction: https://etherscan.io/tx/0x70afe07734e9b0c2d8393ab2a51fda5ac2cfccc80a01cc4a5cf587eaea3c4610
+        let l2_to_l1_message = hex::decode("6c0960f96263317179383267617732687466643573736c706c70676d7a346b74663979336b37706163323232366b30776c6a6c6d7733617466773571776d346176340000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
+        let expected_receiver = BitcoinAddress::from_str(
+            &"bc1qy82gaw2htfd5sslplpgmz4ktf9y3k7pac2226k0wljlmw3atfw5qwm4av4",
+        )
+        .unwrap();
+        let expected_amount = U256::from_dec_str("1000000000000000000").unwrap();
+        let res = parse_l2_withdrawal_message(l2_to_l1_message).unwrap();
+
+        assert_eq!(res.address, expected_receiver);
+        assert_eq!(res.amount, expected_amount);
+    }
+
+    #[test]
+    fn test_parse_l2_withdrawal_message_when_address_p2pkh() {
+        let l2_to_l1_message = hex::decode("6c0960f93141317a5031655035514765666932444d505466544c35534c6d7637446976664e610000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
+        let expected_receiver =
+            BitcoinAddress::from_str(&"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").unwrap();
+        let expected_amount = U256::from_dec_str("1000000000000000000").unwrap();
+        let res = parse_l2_withdrawal_message(l2_to_l1_message).unwrap();
+
+        assert_eq!(res.address, expected_receiver);
+        assert_eq!(res.amount, expected_amount);
+    }
+}


### PR DESCRIPTION
## What ❔

Implement the via withdrawal client, the logic responsible to fetch the pubdata, decode it to recover the L2->L1 withdrawals.
1. Fetch the pubdata from the DA layer.
2. Decode the pub data and extract the L2->L1 Messager logs.
3. Filter the messages and select only the request withdrawals.
4. Decode the bytes to Bitcoin address.

## Why ❔

This client is required to process the withdrawals.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
