### PR TITLE
Feat/via withdrawal client lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "arrayvec 0.7.6",
  "bytes",
@@ -2297,6 +2297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,7 +3223,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3236,7 +3242,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3285,6 +3291,12 @@ dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -3692,12 +3704,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -4228,7 +4240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5318,7 +5330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -6860,7 +6872,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -7220,7 +7232,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "ipnetwork",
  "log",
  "memchr",
@@ -7962,7 +7974,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7973,7 +7985,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8597,6 +8609,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "via_withdrawal_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "byteorder",
+ "dotenv",
+ "hex",
+ "rand 0.8.5",
+ "tokio",
+ "tracing",
+ "via_da_clients",
+ "zksync_basic_types",
+ "zksync_config",
+ "zksync_da_client",
+ "zksync_dal",
+ "zksync_types",
+ "zksync_utils",
+]
+
+[[package]]
 name = "vise"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8853,7 +8886,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8620,6 +8620,7 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "via_da_clients",
  "zksync_basic_types",
  "zksync_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "core/node/via_btc_sender",
     "core/node/via_fee_model",
     "core/node/via_state_keeper",
+    "core/lib/via_withdrawal_client",
 
 ]
 
@@ -315,6 +316,7 @@ zksync_logs_bloom_backfill = { version = "0.1.0", path = "core/node/logs_bloom_b
 
 # VIA Protocol Related Components
 via_btc_client= { version = "0.1.0", path = "core/lib/via_btc_client" }
+via_withdrawal_client = { version = "0.1.0", path = "core/lib/via_withdrawal_client" }
 via_da_clients = { version = "0.1.0", path = "core/lib/via_da_clients" }
 via_btc_watch = { version = "0.1.0", path = "core/node/via_btc_watch" }
 via_da_dispatcher = { version = "0.1.0", path = "core/node/via_da_dispatcher" }

--- a/core/lib/dal/.sqlx/query-2108acea7492e6704849a80b866e380dd27b78499c7cef2a267147c7328263fb.json
+++ b/core/lib/dal/.sqlx/query-2108acea7492e6704849a80b866e380dd27b78499c7cef2a267147c7328263fb.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                l1_batch_number,\n                blob_id,\n                inclusion_data,\n                sent_at\n            FROM\n                via_data_availability\n            WHERE\n                inclusion_data IS NOT NULL\n                AND is_proof = FALSE\n                AND l1_batch_number = $1\n            LIMIT\n                1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "blob_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "inclusion_data",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 3,
+        "name": "sent_at",
+        "type_info": "Timestamp"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "2108acea7492e6704849a80b866e380dd27b78499c7cef2a267147c7328263fb"
+}

--- a/core/lib/via_withdrawal_client/Cargo.toml
+++ b/core/lib/via_withdrawal_client/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "via_withdrawal_client"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+hex.workspace = true
+anyhow.workspace = true
+zksync_basic_types.workspace = true
+zksync_da_client.workspace = true
+zksync_config.workspace = true
+zksync_types.workspace = true
+zksync_utils.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+via_da_clients.workspace = true
+
+bitcoin = { version = "0.32.2", features = ["serde"] }
+byteorder = "1.4"
+
+[dev-dependencies]
+rand = "0.8"
+zksync_dal.workspace = true
+dotenv = "0.15"
+
+[[example]]
+name = "withdraw"
+path = "examples/withdraw.rs"

--- a/core/lib/via_withdrawal_client/Cargo.toml
+++ b/core/lib/via_withdrawal_client/Cargo.toml
@@ -20,6 +20,7 @@ zksync_utils.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 via_da_clients.workspace = true
+tracing-subscriber.workspace = true
 
 bitcoin = { version = "0.32.2", features = ["serde"] }
 byteorder = "1.4"

--- a/core/lib/via_withdrawal_client/examples/withdraw.rs
+++ b/core/lib/via_withdrawal_client/examples/withdraw.rs
@@ -15,6 +15,9 @@ const DEFAULT_CELESTIA: &str = "http://0.0.0.0:26658";
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
     let home = env::var("VIA_HOME").context("VIA HOME not set")?;
     let _ = dotenv::from_path(home.clone() + "/etc/env/target/via.env");
 

--- a/core/lib/via_withdrawal_client/examples/withdraw.rs
+++ b/core/lib/via_withdrawal_client/examples/withdraw.rs
@@ -1,0 +1,68 @@
+use std::{env, str::FromStr};
+
+use anyhow::{Context, Result};
+use dotenv;
+use tracing::info;
+use via_da_clients::celestia::client::CelestiaClient;
+use via_withdrawal_client::client::WithdrawalClient;
+use zksync_config::ViaCelestiaConfig;
+use zksync_da_client::DataAvailabilityClient;
+use zksync_dal::{ConnectionPool, Core, CoreDal};
+use zksync_types::{url::SensitiveUrl, L1BatchNumber};
+
+const DEFAULT_DATABASE_URL: &str = "postgres://postgres:notsecurepassword@0.0.0.0:5432/via";
+const DEFAULT_CELESTIA: &str = "http://0.0.0.0:26658";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let home = env::var("VIA_HOME").context("VIA HOME not set")?;
+    let _ = dotenv::from_path(home.clone() + "/etc/env/target/via.env");
+
+    let celestia_auth_token = env::var("VIA_CELESTIA_CLIENT_AUTH_TOKEN")?;
+
+    let args: Vec<String> = env::args().collect();
+    let block_number = args[1].parse::<u32>().unwrap();
+    info!("Fetch withdrawals in block {}", block_number);
+
+    // Connect to db
+    let url = SensitiveUrl::from_str(DEFAULT_DATABASE_URL).unwrap();
+    let connection_pool = ConnectionPool::<Core>::builder(url, 100)
+        .build()
+        .await
+        .unwrap();
+    let l1_batch_number = L1BatchNumber::from(block_number);
+    let mut storage = connection_pool.connection().await.unwrap();
+
+    let header_res = storage
+        .via_data_availability_dal()
+        .get_da_blob(l1_batch_number)
+        .await
+        .unwrap();
+    if header_res.is_none() {
+        info!("DA for block not exists yet");
+        return Ok(());
+    }
+
+    let header = header_res.unwrap();
+
+    let da_config = ViaCelestiaConfig {
+        api_node_url: String::from(DEFAULT_CELESTIA),
+        auth_token: String::from(celestia_auth_token),
+        blob_size_limit: 1973786,
+    };
+
+    // Connect to withdrawl client
+    let client = CelestiaClient::new(da_config).await?;
+    let da_client: Box<dyn DataAvailabilityClient> = Box::new(client);
+    let withdrawal_client = WithdrawalClient::new(da_client);
+
+    let withdrawals = withdrawal_client
+        .get_withdrawals(header.blob_id.as_str())
+        .await?;
+
+    info!("--------------------------------------------------------");
+    info!("Withdrawals {:?}", withdrawals);
+    info!("--------------------------------------------------------");
+
+    Ok(())
+}

--- a/core/lib/via_withdrawal_client/src/client.rs
+++ b/core/lib/via_withdrawal_client/src/client.rs
@@ -55,9 +55,6 @@ impl WithdrawalClient {
                 continue;
             };
 
-            if log.key != l2_bridges_hash {
-                continue;
-            };
             withdrawals.push(L2BridgeLogMetadata {
                 message: l2_to_l1_messages_hashmap[&log.value].clone(),
                 log,

--- a/core/lib/via_withdrawal_client/src/client.rs
+++ b/core/lib/via_withdrawal_client/src/client.rs
@@ -1,0 +1,148 @@
+use std::{collections::HashMap, str::FromStr};
+
+use zksync_da_client::DataAvailabilityClient;
+use zksync_types::{web3::keccak256, H160, H256};
+
+use crate::{
+    pubdata::Pubdata,
+    types::{L2BridgeLogMetadata, WithdrawalRequest, L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR},
+    withdraw::parse_l2_withdrawal_message,
+};
+
+#[derive(Debug)]
+pub struct WithdrawalClient {
+    client: Box<dyn DataAvailabilityClient>,
+}
+
+impl WithdrawalClient {
+    pub fn new(client: Box<dyn DataAvailabilityClient>) -> Self {
+        Self { client }
+    }
+
+    pub async fn get_withdrawals(&self, blob_id: &str) -> anyhow::Result<Vec<WithdrawalRequest>> {
+        let pubdata_bytes = self._fetch_pubdata(blob_id).await?;
+        let pubdata = Pubdata::decode_pubdata(pubdata_bytes)?;
+        let l2_bridge_metadata = WithdrawalClient::_list_l2_bridge_metadata(&pubdata);
+        let withdrawals = WithdrawalClient::_get_valid_withdrawals(l2_bridge_metadata);
+        Ok(withdrawals)
+    }
+
+    async fn _fetch_pubdata(&self, blob_id: &str) -> anyhow::Result<Vec<u8>> {
+        let response = self.client.get_inclusion_data(blob_id).await?;
+        if let Some(inclusion_data) = response {
+            return Ok(inclusion_data.data);
+        };
+        Ok(Vec::new())
+    }
+
+    fn _l2_to_l1_messages_hashmap(pubdata: &Pubdata) -> HashMap<H256, Vec<u8>> {
+        let mut hashes: HashMap<H256, Vec<u8>> = HashMap::new();
+        for message in &pubdata.l2_to_l1_messages {
+            let hash = H256::from(keccak256(&message));
+            hashes.insert(hash, message.clone());
+        }
+        hashes
+    }
+
+    fn _list_l2_bridge_metadata(pubdata: &Pubdata) -> Vec<L2BridgeLogMetadata> {
+        let mut withdrawals: Vec<L2BridgeLogMetadata> = Vec::new();
+        let l2_bridges_hash =
+            H256::from(H160::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap());
+        let l2_to_l1_messages_hashmap = WithdrawalClient::_l2_to_l1_messages_hashmap(&pubdata);
+        for log in pubdata.user_logs.clone() {
+            // Ignore the logs if not from emitted from the L2 bridge contract
+            if log.key != l2_bridges_hash {
+                continue;
+            };
+
+            if log.key != l2_bridges_hash {
+                continue;
+            };
+            withdrawals.push(L2BridgeLogMetadata {
+                message: l2_to_l1_messages_hashmap[&log.value].clone(),
+                log,
+            });
+        }
+        withdrawals
+    }
+
+    fn _get_valid_withdrawals(
+        l2_bridge_logs_metadata: Vec<L2BridgeLogMetadata>,
+    ) -> Vec<WithdrawalRequest> {
+        let mut withdrawal_requests: Vec<WithdrawalRequest> = Vec::new();
+        for l2_bridge_log_metadata in l2_bridge_logs_metadata {
+            let withdrawal_request = parse_l2_withdrawal_message(l2_bridge_log_metadata.message);
+
+            match withdrawal_request {
+                Ok(req) => withdrawal_requests.push(req),
+                Err(_) => (),
+            }
+        }
+        withdrawal_requests
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::Address;
+    use zksync_types::{H256, U256};
+
+    use super::*;
+
+    #[test]
+    fn test_l2_to_l1_messages_hashmap() {
+        let input = "00000001000100000000000000000000000000000000000000008008000000000000000000000000000000000000000000000000000000000000800aa1fd131a17718668a78581197d19972abd907b7b343b9694e02246d18c3801c500000001000000506c0960f962637274317178326c6b30756e756b6d3830716d65706a703439687766397a36786e7a307337336b396a35360000000000000000000000000000000000000000000000000000000005f5e10000000000010001280400032c1818e4770f08c05b28829d7d5f9d401d492c7432c166dfecf4af04238ea323009d7042e8fb0f249338d18505e5ba1d4a546e9d21f47c847ca725ff53ac29f740ca1bbc31cc849a8092a36f9a321e17412dee200b956038af1c2dc83430a0e8b000d3e2c6760d91078e517a2cb882cd3c9551de3ab5f30d554d51b17e3744cf92b0cf368ce957aed709b985423cd3ba11615de01ecafa15eb9a11bc6cdef4f6327900436ef22b96a07224eb06f0eecfecc184033da7db2a5fb58f867f17298b896b55000000420901000000362205f5e1000000003721032b8b14000000382209216c140000003a8901000000000000000000000000000000170000003b8902000000000000000000000000000000170000003e890200000000000000000000000000000017";
+        let encoded_pubdata = hex::decode(input).unwrap();
+        let pubdata = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let hashes = WithdrawalClient::_l2_to_l1_messages_hashmap(&pubdata);
+        let hash = H256::from(pubdata.user_logs[0].value);
+        assert_eq!(hashes[&hash], pubdata.l2_to_l1_messages[0]);
+    }
+
+    #[test]
+    fn test_list_l2_bridge_metadata() {
+        let input = "00000001000100000000000000000000000000000000000000008008000000000000000000000000000000000000000000000000000000000000800aa1fd131a17718668a78581197d19972abd907b7b343b9694e02246d18c3801c500000001000000506c0960f962637274317178326c6b30756e756b6d3830716d65706a703439687766397a36786e7a307337336b396a35360000000000000000000000000000000000000000000000000000000005f5e10000000000010001280400032c1818e4770f08c05b28829d7d5f9d401d492c7432c166dfecf4af04238ea323009d7042e8fb0f249338d18505e5ba1d4a546e9d21f47c847ca725ff53ac29f740ca1bbc31cc849a8092a36f9a321e17412dee200b956038af1c2dc83430a0e8b000d3e2c6760d91078e517a2cb882cd3c9551de3ab5f30d554d51b17e3744cf92b0cf368ce957aed709b985423cd3ba11615de01ecafa15eb9a11bc6cdef4f6327900436ef22b96a07224eb06f0eecfecc184033da7db2a5fb58f867f17298b896b55000000420901000000362205f5e1000000003721032b8b14000000382209216c140000003a8901000000000000000000000000000000170000003b8902000000000000000000000000000000170000003e890200000000000000000000000000000017";
+        let encoded_pubdata = hex::decode(input).unwrap();
+        let pubdata = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let hashes = WithdrawalClient::_l2_to_l1_messages_hashmap(&pubdata);
+        let hash = H256::from(pubdata.user_logs[0].value);
+        assert_eq!(hashes[&hash], pubdata.l2_to_l1_messages[0]);
+
+        let l2_bridge_logs_metadata = WithdrawalClient::_list_l2_bridge_metadata(&pubdata);
+        assert_eq!(l2_bridge_logs_metadata.len(), 1);
+        assert_eq!(
+            l2_bridge_logs_metadata[0].message,
+            pubdata.clone().l2_to_l1_messages[0]
+        );
+        assert_eq!(
+            l2_bridge_logs_metadata[0].log.value,
+            pubdata.user_logs[0].value
+        );
+    }
+
+    #[test]
+    fn test_get_valid_withdrawals() {
+        let input = "00000001000100000000000000000000000000000000000000008008000000000000000000000000000000000000000000000000000000000000800aa1fd131a17718668a78581197d19972abd907b7b343b9694e02246d18c3801c500000001000000506c0960f962637274317178326c6b30756e756b6d3830716d65706a703439687766397a36786e7a307337336b396a35360000000000000000000000000000000000000000000000000000000005f5e10000000000010001280400032c1818e4770f08c05b28829d7d5f9d401d492c7432c166dfecf4af04238ea323009d7042e8fb0f249338d18505e5ba1d4a546e9d21f47c847ca725ff53ac29f740ca1bbc31cc849a8092a36f9a321e17412dee200b956038af1c2dc83430a0e8b000d3e2c6760d91078e517a2cb882cd3c9551de3ab5f30d554d51b17e3744cf92b0cf368ce957aed709b985423cd3ba11615de01ecafa15eb9a11bc6cdef4f6327900436ef22b96a07224eb06f0eecfecc184033da7db2a5fb58f867f17298b896b55000000420901000000362205f5e1000000003721032b8b14000000382209216c140000003a8901000000000000000000000000000000170000003b8902000000000000000000000000000000170000003e890200000000000000000000000000000017";
+        let encoded_pubdata = hex::decode(input).unwrap();
+        let pubdata = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let hashes = WithdrawalClient::_l2_to_l1_messages_hashmap(&pubdata);
+        let hash = H256::from(pubdata.user_logs[0].value);
+        assert_eq!(hashes[&hash], pubdata.l2_to_l1_messages[0]);
+
+        let l2_bridge_logs_metadata = WithdrawalClient::_list_l2_bridge_metadata(&pubdata);
+        let withdrawals = WithdrawalClient::_get_valid_withdrawals(l2_bridge_logs_metadata);
+        let expected_user_address =
+            Address::from_str("bcrt1qx2lk0unukm80qmepjp49hwf9z6xnz0s73k9j56").unwrap();
+        assert_eq!(withdrawals.len(), 1);
+        assert_eq!(withdrawals[0].clone().address, expected_user_address);
+        assert_eq!(
+            withdrawals[0].clone().amount,
+            U256::from_dec_str("100000000").unwrap()
+        );
+    }
+}

--- a/core/lib/via_withdrawal_client/src/lib.rs
+++ b/core/lib/via_withdrawal_client/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod client;
+mod pubdata;
+mod types;
+mod withdraw;

--- a/core/lib/via_withdrawal_client/src/pubdata.rs
+++ b/core/lib/via_withdrawal_client/src/pubdata.rs
@@ -12,7 +12,7 @@ pub struct Pubdata {
 }
 
 impl Pubdata {
-    pub fn _encode_pubdata(self) -> Vec<u8> {
+    pub fn encode_pubdata(self) -> Vec<u8> {
         let mut l1_messenger_pubdata = vec![];
 
         // Encoding user L2->L1 logs.
@@ -66,7 +66,7 @@ impl Pubdata {
 }
 
 /// Helper function to read a specific number of bytes
-fn _read_bytes<R: Read>(reader: &mut R, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
+fn read_bytes<R: Read>(reader: &mut R, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
     let mut buffer = vec![0u8; num_bytes];
     reader.read_exact(&mut buffer)?;
     Ok(buffer)
@@ -129,7 +129,7 @@ mod tests {
             l2_to_l1_messages: vec![hex::decode("deadbeef").unwrap()],
         };
 
-        let encoded_pubdata = pubdata._encode_pubdata();
+        let encoded_pubdata = pubdata.encode_pubdata();
         let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
 
         let decoded_message = pubdata_input.user_logs[0].clone();
@@ -168,7 +168,7 @@ mod tests {
             l2_to_l1_messages: l2_to_l1_messages,
         };
 
-        let encoded_pubdata = pubdata._encode_pubdata();
+        let encoded_pubdata = pubdata.encode_pubdata();
         let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
 
         let decoded_logs = pubdata_input.user_logs.clone();

--- a/core/lib/via_withdrawal_client/src/pubdata.rs
+++ b/core/lib/via_withdrawal_client/src/pubdata.rs
@@ -1,0 +1,207 @@
+use std::io::{Cursor, Read};
+
+use anyhow::Context;
+use byteorder::{BigEndian, ReadBytesExt};
+
+use crate::types::L1MessengerL2ToL1Log;
+
+#[derive(Debug, Clone, Default)]
+pub struct Pubdata {
+    pub user_logs: Vec<L1MessengerL2ToL1Log>,
+    pub l2_to_l1_messages: Vec<Vec<u8>>,
+}
+
+impl Pubdata {
+    pub fn _encode_pubdata(self) -> Vec<u8> {
+        let mut l1_messenger_pubdata = vec![];
+
+        // Encoding user L2->L1 logs.
+        // Format: `[(numberOfL2ToL1Logs as u32) || l2tol1logs[1] || ... || l2tol1logs[n]]`
+        l1_messenger_pubdata.extend((self.user_logs.len() as u32).to_be_bytes());
+        for l2tol1log in self.user_logs {
+            l1_messenger_pubdata.extend(l2tol1log.encode_packed());
+        }
+
+        // Encoding L2->L1 messages
+        // Format: `[(numberOfMessages as u32) || (messages[1].len() as u32) || messages[1] || ... || (messages[n].len() as u32) || messages[n]]`
+        l1_messenger_pubdata.extend((self.l2_to_l1_messages.len() as u32).to_be_bytes());
+        for message in self.l2_to_l1_messages {
+            l1_messenger_pubdata.extend((message.len() as u32).to_be_bytes());
+            l1_messenger_pubdata.extend(message);
+        }
+
+        l1_messenger_pubdata
+    }
+
+    pub fn decode_pubdata(pubdata: Vec<u8>) -> anyhow::Result<Pubdata> {
+        let mut cursor = Cursor::new(pubdata);
+        let mut user_logs = Vec::new();
+        let mut l2_to_l1_messages = Vec::new();
+
+        // Decode user L2->L1 logs
+        let num_user_logs = cursor
+            .read_u32::<BigEndian>()
+            .context("Failed to decode num user logs")? as usize;
+        for _ in 0..num_user_logs {
+            let log = L1MessengerL2ToL1Log::decode_packed(&mut cursor)?;
+            user_logs.push(log);
+        }
+
+        // Decode L2->L1 messages
+        let num_messages = cursor.read_u32::<BigEndian>()? as usize;
+        for _ in 0..num_messages {
+            let message_len = cursor.read_u32::<BigEndian>()? as usize;
+            let mut message = vec![0u8; message_len];
+            cursor
+                .read_exact(&mut message)
+                .context("Read l2 to l1 message")?;
+            l2_to_l1_messages.push(message);
+        }
+
+        Ok(Pubdata {
+            user_logs,
+            l2_to_l1_messages,
+        })
+    }
+}
+
+/// Helper function to read a specific number of bytes
+fn _read_bytes<R: Read>(reader: &mut R, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = vec![0u8; num_bytes];
+    reader.read_exact(&mut buffer)?;
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use hex::encode;
+    use rand;
+    use zksync_types::{web3::keccak256, Address, H256};
+
+    use super::*;
+    use crate::types::L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR;
+
+    fn generate_random_hex(len: usize) -> String {
+        // Generate random bytes
+        let random_bytes: Vec<u8> = (0..len).map(|_| rand::random::<u8>()).collect();
+
+        // Convert bytes to hex and return it
+        encode(random_bytes)
+    }
+
+    #[test]
+    fn test_decode_l1_messager_l2_to_l1_log() {
+        let message = L1MessengerL2ToL1Log {
+            l2_shard_id: 0,
+            is_service: true,
+            tx_number_in_block: 5,
+            sender: Address::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap(),
+            key: H256::random(),
+            value: H256::random(),
+        };
+        let encoded_messages = message.encode_packed();
+
+        let mut cursor = Cursor::new(encoded_messages);
+        let decoded = L1MessengerL2ToL1Log::decode_packed(&mut cursor).unwrap();
+        assert_eq!(message.l2_shard_id, decoded.l2_shard_id);
+        assert_eq!(message.is_service, decoded.is_service);
+        assert_eq!(message.tx_number_in_block, decoded.tx_number_in_block);
+        assert_eq!(message.sender, decoded.sender);
+        assert_eq!(message.key, decoded.key);
+        assert_eq!(message.value, decoded.value);
+    }
+
+    #[test]
+    fn test_decode_pubdata_with_single_l1_messager_l2_to_l1_log() {
+        let message = L1MessengerL2ToL1Log {
+            l2_shard_id: 0,
+            is_service: true,
+            tx_number_in_block: 5,
+            sender: Address::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap(),
+            key: H256::random(),
+            value: H256::random(),
+        };
+
+        let pubdata = Pubdata {
+            user_logs: vec![message.clone()],
+            l2_to_l1_messages: vec![hex::decode("deadbeef").unwrap()],
+        };
+
+        let encoded_pubdata = pubdata._encode_pubdata();
+        let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let decoded_message = pubdata_input.user_logs[0].clone();
+        assert_eq!(pubdata_input.user_logs.len(), 1);
+        assert_eq!(decoded_message.l2_shard_id, message.clone().l2_shard_id);
+        assert_eq!(decoded_message.is_service, message.clone().is_service);
+        assert_eq!(
+            decoded_message.tx_number_in_block,
+            message.clone().tx_number_in_block
+        );
+        assert_eq!(decoded_message.sender, message.clone().sender);
+        assert_eq!(decoded_message.key, message.clone().key);
+        assert_eq!(decoded_message.value, message.clone().value);
+    }
+
+    #[test]
+    fn test_decode_pubdata_with_many_l1_messager_l2_to_l1_log() {
+        let len: usize = 5;
+        let mut user_logs: Vec<L1MessengerL2ToL1Log> = Vec::new();
+        let mut l2_to_l1_messages: Vec<Vec<u8>> = Vec::new();
+        for _ in 0..len {
+            let log = L1MessengerL2ToL1Log {
+                l2_shard_id: 0,
+                is_service: true,
+                tx_number_in_block: 5,
+                sender: Address::from_str(L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR).unwrap(),
+                key: H256::from_str(&generate_random_hex(32)).unwrap(),
+                value: H256::from_str(&generate_random_hex(32)).unwrap(),
+            };
+            user_logs.push(log.clone());
+            l2_to_l1_messages.push(hex::decode("deadbeef").unwrap());
+        }
+
+        let pubdata = Pubdata {
+            user_logs: user_logs.clone(),
+            l2_to_l1_messages: l2_to_l1_messages,
+        };
+
+        let encoded_pubdata = pubdata._encode_pubdata();
+        let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let decoded_logs = pubdata_input.user_logs.clone();
+        let decoded_messages = pubdata_input.l2_to_l1_messages.clone();
+        assert_eq!(pubdata_input.user_logs.len(), len);
+        assert_eq!(pubdata_input.l2_to_l1_messages.len(), len);
+        for i in 0..len {
+            let decoded_log = decoded_logs[i].clone();
+            let msg_log = user_logs[i].clone();
+
+            assert_eq!(decoded_log.l2_shard_id, msg_log.clone().l2_shard_id);
+            assert_eq!(decoded_log.is_service, msg_log.clone().is_service);
+            assert_eq!(
+                decoded_log.tx_number_in_block,
+                msg_log.clone().tx_number_in_block
+            );
+            assert_eq!(decoded_log.sender, msg_log.clone().sender);
+            assert_eq!(decoded_log.key, msg_log.clone().key);
+            assert_eq!(decoded_log.value, msg_log.clone().value);
+
+            // l2 to l1 message
+            let decoded_message = decoded_messages[i].clone();
+            assert_eq!(decoded_message, hex::decode("deadbeef").unwrap());
+        }
+    }
+
+    #[test]
+    fn test_decode_pubdata_with_single_real_l1_messager_l2_to_l1_log() {
+        let input = "00000001000100000000000000000000000000000000000000008008000000000000000000000000000000000000000000000000000000000000800aa1fd131a17718668a78581197d19972abd907b7b343b9694e02246d18c3801c500000001000000506c0960f962637274317178326c6b30756e756b6d3830716d65706a703439687766397a36786e7a307337336b396a35360000000000000000000000000000000000000000000000000000000005f5e10000000000010001280400032c1818e4770f08c05b28829d7d5f9d401d492c7432c166dfecf4af04238ea323009d7042e8fb0f249338d18505e5ba1d4a546e9d21f47c847ca725ff53ac29f740ca1bbc31cc849a8092a36f9a321e17412dee200b956038af1c2dc83430a0e8b000d3e2c6760d91078e517a2cb882cd3c9551de3ab5f30d554d51b17e3744cf92b0cf368ce957aed709b985423cd3ba11615de01ecafa15eb9a11bc6cdef4f6327900436ef22b96a07224eb06f0eecfecc184033da7db2a5fb58f867f17298b896b55000000420901000000362205f5e1000000003721032b8b14000000382209216c140000003a8901000000000000000000000000000000170000003b8902000000000000000000000000000000170000003e890200000000000000000000000000000017";
+        let encoded_pubdata = hex::decode(input).unwrap();
+        let pubdata_input = Pubdata::decode_pubdata(encoded_pubdata).unwrap();
+
+        let hash = keccak256(&pubdata_input.l2_to_l1_messages[0].clone());
+        assert_eq!(H256::from(hash), pubdata_input.user_logs[0].value);
+    }
+}

--- a/core/lib/via_withdrawal_client/src/types.rs
+++ b/core/lib/via_withdrawal_client/src/types.rs
@@ -1,0 +1,114 @@
+use std::io::Read;
+
+use anyhow::Context;
+use bitcoin::{address::NetworkUnchecked, Address as BitcoinAddress};
+use byteorder::{BigEndian, ReadBytesExt};
+use zksync_types::{Address, H160, H256, U256};
+use zksync_utils::{u256_to_bytes_be, u256_to_h256};
+
+/// The function selector used in L2 to compute the message.
+pub const WITHDRAW_FUNC_SIG: &str = "finalizeEthWithdrawal(uint256,uint256,uint16,bytes,bytes32[])";
+
+/// The L2 system bridge address.
+pub const L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR: &str = "000000000000000000000000000000000000800a";
+
+#[derive(Clone, Debug, Default)]
+pub struct L2BridgeLogMetadata {
+    pub log: L1MessengerL2ToL1Log,
+    pub message: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WithdrawalRequest {
+    /// The receiver l1 address.
+    pub address: BitcoinAddress<NetworkUnchecked>,
+    /// The amount user will receive.
+    pub amount: U256,
+}
+
+/// Corresponds to the following solidity event:
+/// ```solidity
+/// struct L2ToL1Log {
+///     uint8 l2ShardId;
+///     bool isService;
+///     uint16 txNumberInBlock;
+///     address sender;
+///     bytes32 key;
+///     bytes32 value;
+/// }
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct L1MessengerL2ToL1Log {
+    /// l2ShardId The shard identifier, 0 - rollup, 1 - porter
+    /// All other values are not used but are reserved for the future
+    pub l2_shard_id: u8,
+    /// isService A boolean flag that is part of the log along with `key`, `value`, and `sender` address.
+    /// This field is required formally but does not have any special meaning
+    pub is_service: bool,
+    /// txNumberInBatch The L2 transaction number in a Batch, in which the log was sent
+    pub tx_number_in_block: u16,
+    /// sender The L2 address which sent the log
+    pub sender: H160,
+    /// key The 32 bytes of information that was sent in the log
+    pub key: H256,
+    /// value The 32 bytes of information that was sent in the log
+    pub value: H256,
+}
+
+impl L1MessengerL2ToL1Log {
+    pub fn encode_packed(&self) -> Vec<u8> {
+        let mut res: Vec<u8> = vec![];
+        res.push(self.l2_shard_id);
+        res.push(self.is_service as u8);
+        res.extend_from_slice(&self.tx_number_in_block.to_be_bytes());
+        res.extend_from_slice(self.sender.as_bytes());
+        res.extend(u256_to_bytes_be(&U256::from_big_endian(&self.key.0)));
+        res.extend(u256_to_bytes_be(&U256::from_big_endian(&self.value.0)));
+        res
+    }
+
+    pub fn decode_packed<R: Read>(reader: &mut R) -> anyhow::Result<Self> {
+        // Read `l2_shard_id` (1 byte)
+        let l2_shard_id = reader.read_u8().context("Failed to read l2_shard_id")?;
+
+        // Read `is_service` (1 byte, a boolean stored as 0 or 1)
+        let is_service_byte = reader.read_u8().context("Failed to read is_service byte")?;
+        let is_service = is_service_byte != 0; // 0 -> false, non-zero -> true
+
+        // Read `tx_number_in_block` (2 bytes, u16)
+        let tx_number_in_block = reader
+            .read_u16::<BigEndian>()
+            .context("Failed to read tx_number_in_block")?;
+
+        // Read `sender` (address is 20 bytes)
+        let mut sender_bytes = [0u8; 20];
+        reader
+            .read_exact(&mut sender_bytes)
+            .context("Failed to read sender address")?;
+        let sender = Address::from(sender_bytes);
+
+        // Read `key` (U256 is 32 bytes)
+        let key_bytes = _read_bytes(reader, 32).context("Failed to read key bytes")?;
+        let key = u256_to_h256(U256::from_big_endian(&key_bytes));
+
+        // Read `value` (U256 is 32 bytes)
+        let value_bytes = _read_bytes(reader, 32).context("Failed to read value bytes")?;
+        let value = u256_to_h256(U256::from_big_endian(&value_bytes));
+
+        Ok(L1MessengerL2ToL1Log {
+            l2_shard_id,
+            is_service,
+            tx_number_in_block,
+            sender,
+            key,
+            value,
+        })
+    }
+}
+
+/// Helper function to read a specific number of bytes
+fn _read_bytes<R: Read>(reader: &mut R, num_bytes: usize) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = vec![0u8; num_bytes];
+    reader.read_exact(&mut buffer)?;
+    Ok(buffer)
+}

--- a/core/lib/via_withdrawal_client/src/withdraw.rs
+++ b/core/lib/via_withdrawal_client/src/withdraw.rs
@@ -1,0 +1,76 @@
+use std::str::FromStr;
+
+use anyhow::Context;
+use bitcoin::Address as BitcoinAddress;
+use zksync_basic_types::{web3::keccak256, U256};
+
+use crate::types::{WithdrawalRequest, WITHDRAW_FUNC_SIG};
+
+pub fn parse_l2_withdrawal_message(l2_to_l1_message: Vec<u8>) -> anyhow::Result<WithdrawalRequest> {
+    // We check that the message is long enough to read the data.
+    // Please note that there are two versions of the message:
+    // The message that is sent by `withdraw(address _l1Receiver)`
+    // It should be equal to the length of the bytes4 function signature + bytes l1Receiver + uint256 amount = 4 + X + 32.
+    let message_len = l2_to_l1_message.len();
+    let address_size = message_len - 36;
+    if message_len <= 36 {
+        return Err(anyhow::format_err!("Invalid message length."));
+    }
+
+    let func_selector_bytes = &l2_to_l1_message[0..4];
+    if func_selector_bytes != _get_withdraw_function_selector() {
+        return Err(anyhow::format_err!("Invalid message function selector."));
+    }
+
+    // The address bytes represent the l1 receiver
+    let address_bytes = &l2_to_l1_message[4..4 + address_size];
+    let address_str =
+        String::from_utf8(address_bytes.to_vec()).context("Parse address to string")?;
+    let address = BitcoinAddress::from_str(&address_str).context("parse bitcoin address")?;
+
+    // The last 32 bytes represent the amount (uint256)
+    let amount_bytes = &l2_to_l1_message[address_size + 4..];
+    let amount = U256::from_big_endian(amount_bytes);
+
+    return Ok(WithdrawalRequest { address, amount });
+}
+
+/// Get the withdrawal function selector.
+fn _get_withdraw_function_selector() -> Vec<u8> {
+    let hash = keccak256(WITHDRAW_FUNC_SIG.as_bytes());
+    hash[0..4].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_l2_withdrawal_message_when_address_bech32m() {
+        // Example transaction: https://etherscan.io/tx/0x70afe07734e9b0c2d8393ab2a51fda5ac2cfccc80a01cc4a5cf587eaea3c4610
+        let l2_to_l1_message = hex::decode("6c0960f96263317179383267617732687466643573736c706c70676d7a346b74663979336b37706163323232366b30776c6a6c6d7733617466773571776d346176340000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
+        let expected_receiver = BitcoinAddress::from_str(
+            &"bc1qy82gaw2htfd5sslplpgmz4ktf9y3k7pac2226k0wljlmw3atfw5qwm4av4",
+        )
+        .unwrap();
+        let expected_amount = U256::from_dec_str("1000000000000000000").unwrap();
+        let res = parse_l2_withdrawal_message(l2_to_l1_message).unwrap();
+
+        assert_eq!(res.address, expected_receiver);
+        assert_eq!(res.amount, expected_amount);
+    }
+
+    #[test]
+    fn test_parse_l2_withdrawal_message_when_address_p2pkh() {
+        let l2_to_l1_message = hex::decode("6c0960f93141317a5031655035514765666932444d505466544c35534c6d7637446976664e610000000000000000000000000000000000000000000000000de0b6b3a7640000").unwrap();
+        let expected_receiver =
+            BitcoinAddress::from_str(&"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").unwrap();
+        let expected_amount = U256::from_dec_str("1000000000000000000").unwrap();
+        let res = parse_l2_withdrawal_message(l2_to_l1_message).unwrap();
+
+        assert_eq!(res.address, expected_receiver);
+        assert_eq!(res.amount, expected_amount);
+    }
+}

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -113,7 +113,7 @@ services:
     volumes:
       - type: bind
         source: ./volumes/celestia
-        target: /home/celestia:rw
+        target: /home/celestia
     command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip validator-2.celestia-arabica-11.com --p2p.network arabica 
     ports:
       - '26658:26658'

--- a/infrastructure/via/package.json
+++ b/infrastructure/via/package.json
@@ -13,6 +13,8 @@
   "devDependencies": {
     "typescript": "^4.4.4",
     "@types/node": "^16.11.7",
+    "zksync-ethers": "^6.13.1",
+    "ethers": "^6.13.4",
     "eslint": "^7.32.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0"

--- a/infrastructure/via/src/celestia.ts
+++ b/infrastructure/via/src/celestia.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { exec } from 'child_process';
+import { updateEnvVariable } from './helpers';
 
 // Function to execute a shell command and return it as a Promise
 function runCommand(command: string): Promise<string> {
@@ -25,20 +26,6 @@ const get_node_address_command =
 const get_auth_node_command =
     'docker exec $(docker ps -q -f name=celestia-node) celestia light auth admin --p2p.network arabica';
 const restart_celestia_container_command = 'docker restart celestia-node';
-
-async function updateEnvVariable(envFilePath: string, variableName: string, newValue: string) {
-    const envFileContent = await fs.readFile(envFilePath, 'utf-8');
-    const envConfig = dotenv.parse(envFileContent);
-
-    envConfig[variableName] = newValue;
-
-    let newEnvContent = '';
-    for (const key in envConfig) {
-        newEnvContent += `${key}=${envConfig[key]}\n`;
-    }
-
-    await fs.writeFile(envFilePath, newEnvContent, 'utf-8');
-}
 
 async function updateEnvironment(auth_token: string) {
     const envFilePath = path.join(process.env.VIA_HOME!, `etc/env/target/${process.env.VIA_ENV}.env`);

--- a/infrastructure/via/src/index.ts
+++ b/infrastructure/via/src/index.ts
@@ -18,6 +18,7 @@ import { command as bootstrap } from './bootstrap';
 import { command as verifier } from './verifier';
 import { command as celestia } from './celestia';
 import { command as btc_explorer } from './btc_explorer';
+import { command as withdraw } from './withdraw';
 
 const COMMANDS = [
     server,
@@ -35,6 +36,7 @@ const COMMANDS = [
     verifier,
     celestia,
     btc_explorer,
+    withdraw,
     completion(program as Command)
 ];
 

--- a/infrastructure/via/src/withdraw.ts
+++ b/infrastructure/via/src/withdraw.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs';
+import { Command } from 'commander';
+import { Wallet, Provider, Contract } from 'zksync-ethers';
+import { ethers } from 'ethers';
+
+// 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
+const DEFAULT_L2_PRIVATE_KEY = '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110';
+const DEFAULT_L2_RPC_URL = 'http://0.0.0.0:3050';
+const L2_BASE_TOKEN = '0x000000000000000000000000000000000000800a';
+
+async function withdraw(amount: number, receiverL1Address: string, userL2PrivateKey: string, rpcUrl: string) {
+    if (isNaN(amount)) {
+        console.error('Error: Invalid withdraw amount. Please provide a valid number.');
+        return;
+    }
+
+    const abi = [
+        {
+            inputs: [
+                {
+                    internalType: 'uint256',
+                    name: '_account',
+                    type: 'uint256'
+                }
+            ],
+            name: 'balanceOf',
+            outputs: [
+                {
+                    internalType: 'uint256',
+                    name: '',
+                    type: 'uint256'
+                }
+            ],
+            stateMutability: 'view',
+            type: 'function'
+        },
+        {
+            inputs: [
+                {
+                    internalType: 'bytes',
+                    name: '_l1Receiver',
+                    type: 'bytes'
+                }
+            ],
+            name: 'withdraw',
+            outputs: [],
+            stateMutability: 'payable',
+            type: 'function'
+        }
+    ];
+
+    const provider = new Provider(rpcUrl);
+    const wallet = new Wallet(userL2PrivateKey, provider);
+    const btcAddress = ethers.toUtf8Bytes(receiverL1Address);
+    const contract = new Contract(L2_BASE_TOKEN, abi, wallet) as any;
+
+    let balance = await contract.balanceOf(wallet.address);
+    console.log('Balance before withdraw', ethers.formatUnits(balance, 8));
+    const tx = await contract.connect(wallet).withdraw(btcAddress, { value: ethers.parseUnits(String(amount), 8) });
+    await tx.wait();
+    balance = await contract.balanceOf(wallet.address);
+    console.log('Balance after withdraw', ethers.formatUnits(balance, 8));
+}
+
+export const command = new Command('token').description('Bridge BTC L2>L1');
+
+command
+    .command('withdraw')
+    .description('withdraw BTC to l1')
+    .requiredOption('--amount <amount>', 'amount of BTC to withdraw', parseFloat)
+    .requiredOption('--receiver-l1-address <receiverL1Address>', 'receiver l1 address')
+    .option('--user-private-key <userPrivateKey>', 'user private key', DEFAULT_L2_PRIVATE_KEY)
+    .option('--rpc-url <rcpUrl>', 'RPC URL', DEFAULT_L2_RPC_URL)
+    .action((cmd: Command) => withdraw(cmd.amount, cmd.receiverL1Address, cmd.userPrivateKey, cmd.rpcUrl));

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,11 +466,6 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
   integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
-"@eslint-community/regexpp@^4.6.1":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.11.0.tgz#b0ffd0312b4a3fd2d6f77237e7248a5ad3a680ae"
-  integrity sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==
-
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -2559,6 +2554,14 @@
   dependencies:
     ethers "^5.0.2"
 
+"@typechain/ethers-v6@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz#42fe214a19a8b687086c93189b301e2b878797ea"
+  integrity sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
 "@types/abstract-leveldown@*":
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-7.2.5.tgz#db2cf364c159fb1f12be6cd3549f56387eaf8d73"
@@ -2788,6 +2791,13 @@
   version "18.15.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
   integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
+
+"@types/node@22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/node@^10.0.3":
   version "10.17.60"
@@ -5379,6 +5389,19 @@ ethers@^5.0.2, ethers@^5.7.0, ethers@^5.7.2, ethers@~5.7.0:
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
+ethers@^6.13.4:
+  version "6.13.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.4.tgz#bd3e1c3dc1e7dc8ce10f9ffb4ee40967a651b53c"
+  integrity sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "22.7.5"
+    aes-js "4.0.0-beta.5"
+    tslib "2.7.0"
+    ws "8.17.1"
+
 ethers@^6.7.1:
   version "6.12.1"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.12.1.tgz#517ff6d66d4fd5433e38e903051da3e57c87ff37"
@@ -5775,15 +5798,6 @@ form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -7612,13 +7626,6 @@ linkify-it@^4.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
-linkify-it@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
-  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
-  dependencies:
-    uc.micro "^1.0.1"
-
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -8504,23 +8511,6 @@ optionator@^0.9.1:
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
-
-optionator@^0.9.3:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
-  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
-  dependencies:
-    deep-is "^0.1.3"
-    fast-levenshtein "^2.0.6"
-    levn "^0.4.1"
-    prelude-ls "^1.2.1"
-    type-check "^0.4.0"
-    word-wrap "^1.2.5"
-
-ordinal@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/ordinal/-/ordinal-1.0.3.tgz#1a3c7726a61728112f50944ad7c35c06ae3a0d4d"
-  integrity sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -9547,13 +9537,6 @@ serialize-javascript@^6.0.2:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
-
 set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -10476,15 +10459,15 @@ tslib@2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@2.7.0, tslib@^2.6.2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.6.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
-  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tsort@0.0.1:
   version "0.0.1"
@@ -10686,6 +10669,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici@^5.14.0:
   version "5.28.4"
@@ -10972,6 +10960,11 @@ ws@7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
 ws@8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
@@ -11096,6 +11089,11 @@ zksync-ethers@^5.9.0:
   integrity sha512-Y2Mx6ovvxO6UdC2dePLguVzvNToOY8iLWeq5ne+jgGSJxAi/f4He/NF6FNsf6x1aWX0o8dy4Df8RcOQXAkj5qw==
   dependencies:
     ethers "~5.7.0"
+
+zksync-ethers@^6.13.1:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/zksync-ethers/-/zksync-ethers-6.15.2.tgz#bff003ed346aa4ef9a4c714dd21944c3cfed6673"
+  integrity sha512-eqFeKVYXyfHYW1Tw0CkCk255zeuFltDbfZfraxpe/Z/idVR1WxeBlKvLLzIM884KVVeghRkConSRlOibhtm6xw==
 
 zksync-ethers@^6.9.0:
   version "6.9.0"


### PR DESCRIPTION
## What ❔

Implemented the via withdrawal client.
- Fetch the pubdata from the da client.
- Decode the pubdata and select the withdrawal.
- Added a withdraw cmd to via cli.

PRs related #68 #70 
## Why ❔

This PR is required to list the withdrawals that were processed in an L1 batch.

## Test
1. Make via
2. Bridge BTC to L2 
```
via verifier deposit  --amount 100  --receiver-l2-address 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
```
3. Withdraw token from L2 -> L1
```
via token withdraw   --amount 5   --receiver-l1-address bcrt1qx2lk0unukm80qmepjp49hwf9z6xnz0s73k9j56
```
4. List the withdrawals in the block 2
```
cargo run --example withdraw 2
```
You should see your withdrawal
![Screenshot from 2024-12-04 18-20-54](https://github.com/user-attachments/assets/62e7543c-65b8-4b76-80cc-3b5459857127)


5. done
## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
