### PR TITLE
Feat/Start celestia node from last block

### DIFF
--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -113,8 +113,8 @@ services:
     volumes:
       - type: bind
         source: ./volumes/celestia
-        target: /home/celestia
-    command: celestia light start --core.ip validator-2.celestia-arabica-11.com --p2p.network arabica 
+        target: /home/celestia:rw
+    command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip validator-2.celestia-arabica-11.com --p2p.network arabica 
     ports:
       - '26658:26658'
     environment:

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -113,7 +113,7 @@ services:
     volumes:
       - type: bind
         source: ./volumes/celestia
-        target: /home/celestia:rw
+        target: /home/celestia
     command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip validator-2.celestia-arabica-11.com --p2p.network arabica 
     ports:
       - '26658:26658'

--- a/infrastructure/via/src/celestia.ts
+++ b/infrastructure/via/src/celestia.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
 import { exec } from 'child_process';
+import { updateEnvVariable } from './helpers';
 
 // Function to execute a shell command and return it as a Promise
 function runCommand(command: string): Promise<string> {
@@ -25,20 +26,6 @@ const get_node_address_command =
 const get_auth_node_command =
     'docker exec $(docker ps -q -f name=celestia-node) celestia light auth admin --p2p.network arabica';
 const restart_celestia_container_command = 'docker restart celestia-node';
-
-async function updateEnvVariable(envFilePath: string, variableName: string, newValue: string) {
-    const envFileContent = await fs.readFile(envFilePath, 'utf-8');
-    const envConfig = dotenv.parse(envFileContent);
-
-    envConfig[variableName] = newValue;
-
-    let newEnvContent = '';
-    for (const key in envConfig) {
-        newEnvContent += `${key}=${envConfig[key]}\n`;
-    }
-
-    await fs.writeFile(envFilePath, newEnvContent, 'utf-8');
-}
 
 async function updateEnvironment(auth_token: string) {
     const envFilePath = path.join(process.env.VIA_HOME!, `etc/env/target/${process.env.VIA_ENV}.env`);

--- a/infrastructure/via/src/celestia.ts
+++ b/infrastructure/via/src/celestia.ts
@@ -118,6 +118,19 @@ async function fix_celestia_config() {
         return line;
     });
 
+    // Get the celestia block height where start the node
+    const envFilePath = path.join(process.env.VIA_HOME!, `etc/env/l2-inits/${process.env.VIA_ENV}.init.env`);
+    const envs = (await fs.readFile(envFilePath, 'utf-8')).split('\n');
+    let height = '1';
+    for (let i = 0; i < envs.length; i++) {
+        if (envs[i].startsWith('VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HEIGHT')) {
+            height = envs[i].split('=')[1];
+            break;
+        }
+    }
+
+    await runCommand(`docker exec celestia-node sed -i 's/  SampleFrom = 1/  SampleFrom = ${height}/' config.toml`);
+
     // Join the updated lines back into a single string
     const updatedConfigFileContent = updatedLines.join('\n');
 

--- a/infrastructure/via/src/config.ts
+++ b/infrastructure/via/src/config.ts
@@ -224,4 +224,3 @@ command
         diff = diff ? diff : '0';
         pushConfig(environment, diff);
     });
-// .action(fetchCelestiaTrustedHash);

--- a/infrastructure/via/src/helpers.ts
+++ b/infrastructure/via/src/helpers.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs/promises';
+import * as dotenv from 'dotenv';
+
+export async function updateEnvVariable(envFilePath: string, variableName: string, newValue: string) {
+    const envFileContent = await fs.readFile(envFilePath, 'utf-8');
+    const envConfig = dotenv.parse(envFileContent);
+
+    envConfig[variableName] = newValue;
+
+    let newEnvContent = '';
+    for (const key in envConfig) {
+        newEnvContent += `${key}=${envConfig[key]}\n`;
+    }
+
+    await fs.writeFile(envFilePath, newEnvContent, 'utf-8');
+}

--- a/infrastructure/via/src/init.ts
+++ b/infrastructure/via/src/init.ts
@@ -13,6 +13,7 @@ import * as config from './config';
 import * as run from './run';
 // import * as server from './server';
 import { createVolumes, up } from './up';
+import path from 'path';
 
 // Checks if all required tools are installed with the correct versions
 const checkEnv = async (): Promise<void> => {
@@ -56,7 +57,9 @@ const initSetup = async ({
         await announced('Checking environment', checkEnv());
         await announced('Checking git hooks', env.gitHooks());
         await announced('Create volumes', createVolumes());
-        await announced('Setting up containers', up(docker.VIA_DOCKER_COMPOSE));
+        const envFilePath = path.join(process.env.VIA_HOME!, `etc/env/l2-inits/${process.env.VIA_ENV}.init.env`);
+
+        await announced('Setting up containers', up(docker.VIA_DOCKER_COMPOSE, envFilePath));
     }
 
     await announced('Compiling JS packages', run.yarn());

--- a/infrastructure/via/src/up.ts
+++ b/infrastructure/via/src/up.ts
@@ -23,9 +23,10 @@ export function createVolumes() {
     });
 }
 
-export async function up(composeFile?: string) {
+export async function up(composeFile?: string, envFilePath?: string) {
     if (composeFile) {
-        await utils.spawn(`docker compose -f ${composeFile} up -d`);
+        const envFile = envFilePath ? `--env-file ${envFilePath}` : '';
+        await utils.spawn(`docker compose ${envFile} -f ${composeFile} up -d`);
     } else {
         await utils.spawn('docker compose up -d');
     }


### PR DESCRIPTION
## What ❔

Start Celestia node from the last minted block (current block).

## Why ❔

Before, the Celestia node needed to sync from the first block with the remote node before be able to query data from it.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
