### PR TITLE
fix: use correct bootloader version for eth_call

### DIFF
--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -198,7 +198,7 @@ impl ApiContracts {
                 vm_1_5_0_small_memory: BaseSystemContracts::playground_1_5_0_small_memory(),
                 vm_1_5_0_increased_memory:
                     BaseSystemContracts::playground_post_1_5_0_increased_memory(),
-                vm_bitcoin: BaseSystemContracts::estimate_gas_bitcoin_1_0_0(),
+                vm_bitcoin: BaseSystemContracts::playground_bitcoin_1_0_0(),
             },
         }
     }


### PR DESCRIPTION
## What ❔

- set the correct version of the Bootloader contract (playground) for `eth_call` requests.

## Why ❔

- This Bootloader version should provide better UX with revert messages.