### PR TITLE
test: connect the musig2 withdrawal test to regtest

### DIFF
--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -105,7 +105,7 @@ services:
       - VERIFIER_1_ADDRESS=bcrt1qw2mvkvm6alfhe86yf328kgvr7mupdx4vln7kpv
       - VERIFIER_2_ADDRESS=bcrt1qk8mkhrmgtq24nylzyzejznfzws6d98g4kmuuh4
       - VERIFIER_3_ADDRESS=bcrt1q23lgaa90s85jvtl6dsrkvn0g949cwjkwuyzwdm
-      - BRIDGE_ADDRESS_TEST=bcrt1pjwy0jgaacfqdnlfrtk9rll0gk5awacen40wwj7yxmyh27g5dtr6s2z74aa
+      - BRIDGE_ADDRESS_TEST=bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg
       - BRIDGE_ADDRESS=bcrt1pu2js99s96f97ecngk8nz7hkaf7fgnjnpv8rxpaft7zd3h9q5affqdz0dch
       - RPC_ARGS=-chain=regtest -rpcconnect=bitcoind -rpcwait -rpcuser=rpcuser -rpcpassword=rpcpassword
       - SLEEP_SECONDS=5
@@ -122,19 +122,19 @@ services:
     environment:
       - POSTGRES_PASSWORD=notsecurepassword
 
-  celestia-node:
-    image: "ghcr.io/celestiaorg/celestia-node:v0.20.4-mocha"
-    container_name: celestia-node
-    volumes:
-      - type: bind
-        source: ./volumes/celestia
-        target: /home/celestia
-    command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip consensus-full-mocha-4.celestia-mocha.com --p2p.network mocha 
-    ports:
-      - '26658:26658'
-    environment:
-      - NODE_TYPE=light
-      - P2P_NETWORK=mocha
+  # celestia-node:
+  #   image: "ghcr.io/celestiaorg/celestia-node:v0.20.4-mocha"
+  #   container_name: celestia-node
+  #   volumes:
+  #     - type: bind
+  #       source: ./volumes/celestia
+  #       target: /home/celestia
+  #   command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip consensus-full-mocha-4.celestia-mocha.com --p2p.network mocha 
+  #   ports:
+  #     - '26658:26658'
+  #   environment:
+  #     - NODE_TYPE=light
+  #     - P2P_NETWORK=mocha
 
 volumes:
   bitcoin_data:

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -50,6 +50,10 @@ services:
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${TEST_ADDRESS} 300
         echo "Sent 300 BTC to TEST_ADDRESS: $${TEST_ADDRESS}"
 
+        echo "TEST_ADDRESS_2: $${TEST_ADDRESS_2}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${TEST_ADDRESS_2} 300
+        echo "Sent 300 BTC to TEST_ADDRESS_2: $${TEST_ADDRESS_2}"
+
         echo "VERIFIER_1_ADDRESS: $${VERIFIER_1_ADDRESS}"
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${VERIFIER_1_ADDRESS} 300
         echo "Sent 300 BTC to VERIFIER_1_ADDRESS: $${VERIFIER_1_ADDRESS}"
@@ -61,6 +65,14 @@ services:
         echo "VERIFIER_3_ADDRESS: $${VERIFIER_3_ADDRESS}"
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${VERIFIER_3_ADDRESS} 300
         echo "Sent 300 BTC to VERIFIER_3_ADDRESS: $${VERIFIER_3_ADDRESS}"
+
+        echo "BRIDGE_ADDRESS: $${BRIDGE_ADDRESS}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${BRIDGE_ADDRESS} 300
+        echo "Sent 300 BTC to BRIDGE_ADDRESS: $${BRIDGE_ADDRESS}"
+
+        echo "BRIDGE_ADDRESS_TEST: $${BRIDGE_ADDRESS_TEST}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${BRIDGE_ADDRESS_TEST} 300
+        echo "Sent 300 BTC to BRIDGE_ADDRESS_TEST: $${BRIDGE_ADDRESS_TEST}"
 
         bitcoin-cli $${RPC_ARGS} generatetoaddress 6 $${ALICE_ADDRESS}
 
@@ -89,9 +101,12 @@ services:
     environment:
       - BITCOIN_DATA=/home/bitcoin/.bitcoin
       - TEST_ADDRESS=bcrt1qx2lk0unukm80qmepjp49hwf9z6xnz0s73k9j56
+      - TEST_ADDRESS_2=bcrt1quw8xktufw6v4vjl32ledaenfzghs9ckyujcc5z
       - VERIFIER_1_ADDRESS=bcrt1qw2mvkvm6alfhe86yf328kgvr7mupdx4vln7kpv
       - VERIFIER_2_ADDRESS=bcrt1qk8mkhrmgtq24nylzyzejznfzws6d98g4kmuuh4
       - VERIFIER_3_ADDRESS=bcrt1q23lgaa90s85jvtl6dsrkvn0g949cwjkwuyzwdm
+      - BRIDGE_ADDRESS_TEST=bcrt1pdsrfe4xu50j9yl8k3t2x3zsl3u6nzg4eleg3udw406ev2kn2hmpqwvr44v
+      - BRIDGE_ADDRESS=bcrt1pu2js99s96f97ecngk8nz7hkaf7fgnjnpv8rxpaft7zd3h9q5affqdz0dch
       - RPC_ARGS=-chain=regtest -rpcconnect=bitcoind -rpcwait -rpcuser=rpcuser -rpcpassword=rpcpassword
       - SLEEP_SECONDS=5
 
@@ -108,18 +123,18 @@ services:
       - POSTGRES_PASSWORD=notsecurepassword
 
   celestia-node:
-    image: "ghcr.io/celestiaorg/celestia-node:v0.20.2-arabica"
+    image: "ghcr.io/celestiaorg/celestia-node:v0.20.4-mocha"
     container_name: celestia-node
     volumes:
       - type: bind
         source: ./volumes/celestia
         target: /home/celestia
-    command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip validator-2.celestia-arabica-11.com --p2p.network arabica 
+    command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip consensus-full-mocha-4.celestia-mocha.com --p2p.network mocha 
     ports:
       - '26658:26658'
     environment:
       - NODE_TYPE=light
-      - P2P_NETWORK=arabica
+      - P2P_NETWORK=mocha
 
 volumes:
   bitcoin_data:

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -105,7 +105,7 @@ services:
       - VERIFIER_1_ADDRESS=bcrt1qw2mvkvm6alfhe86yf328kgvr7mupdx4vln7kpv
       - VERIFIER_2_ADDRESS=bcrt1qk8mkhrmgtq24nylzyzejznfzws6d98g4kmuuh4
       - VERIFIER_3_ADDRESS=bcrt1q23lgaa90s85jvtl6dsrkvn0g949cwjkwuyzwdm
-      - BRIDGE_ADDRESS_TEST=bcrt1pdsrfe4xu50j9yl8k3t2x3zsl3u6nzg4eleg3udw406ev2kn2hmpqwvr44v
+      - BRIDGE_ADDRESS_TEST=bcrt1pjwy0jgaacfqdnlfrtk9rll0gk5awacen40wwj7yxmyh27g5dtr6s2z74aa
       - BRIDGE_ADDRESS=bcrt1pu2js99s96f97ecngk8nz7hkaf7fgnjnpv8rxpaft7zd3h9q5affqdz0dch
       - RPC_ARGS=-chain=regtest -rpcconnect=bitcoind -rpcwait -rpcuser=rpcuser -rpcpassword=rpcpassword
       - SLEEP_SECONDS=5

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -55,3 +55,8 @@ path = "examples/coordinator.rs"
 [[example]]
 name = "withdrawal2"
 path = "examples/withdrawal2.rs"
+
+
+[[example]]
+name = "withdrawal3"
+path = "examples/withdrawal3.rs"

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -51,6 +51,7 @@ path = "examples/withdrawal.rs"
 name = "coordinator"
 path = "examples/coordinator.rs"
 
+
 [[example]]
-name = "generate_btc_pk"
-path = "examples/generate_btc_pk.rs"
+name = "withdrawal2"
+path = "examples/withdrawal2.rs"

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -23,13 +23,18 @@ reqwest.workspace = true
 bitcoincore-rpc = "0.19.0"
 bitcoin = { version = "0.32.2", features = ["serde"] }
 musig2 = "0.2.0"
-secp256k1_musig2 = { package = "secp256k1", version = "0.30.0", features = ["rand"]}
+secp256k1_musig2 = { package = "secp256k1", version = "0.30.0", features = [
+    "rand",
+    "hashes",
+] }
 tokio = { version = "1.0", features = ["full"] }
 axum = "0.6"
 uuid = { version = "1.3", features = ["v4"] }
 hyper = { version = "0.14", features = ["full"] }
 base64 = "0.21"
 
+[dev-dependencies]
+bitcoincore-rpc = "0.19.0"
 
 
 [[example]]
@@ -45,3 +50,7 @@ path = "examples/withdrawal.rs"
 [[example]]
 name = "coordinator"
 path = "examples/coordinator.rs"
+
+[[example]]
+name = "generate_btc_pk"
+path = "examples/generate_btc_pk.rs"

--- a/via_verifier/lib/via_musig2/examples/withdrawal2.rs
+++ b/via_verifier/lib/via_musig2/examples/withdrawal2.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Demonstrate creating a transaction that spends to and from p2tr outputs.
+
+use std::str::FromStr;
+
+use bitcoin::{
+    hashes::Hash,
+    key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey},
+    locktime::absolute,
+    secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification},
+    sighash::{Prevouts, SighashCache, TapSighashType},
+    transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+    Txid, Witness,
+};
+
+const DUMMY_UTXO_AMOUNT: Amount = Amount::from_sat(20_000_000);
+const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
+const CHANGE_AMOUNT: Amount = Amount::from_sat(14_999_000); // 1000 sat fee.
+
+fn main() {
+    let secp = Secp256k1::new();
+
+    // Get a keypair we control. In a real application these would come from a stored secret.
+    let keypair = senders_keys(&secp);
+    let (internal_key, _parity) = keypair.x_only_public_key();
+
+    // Get an unspent output that is locked to the key above that we control.
+    // In a real application these would come from the chain.
+    let (dummy_out_point, dummy_utxo) = dummy_unspent_transaction_output(&secp, internal_key);
+
+    // Get an address to send to.
+    let address = receivers_address();
+
+    // The input for the transaction we are constructing.
+    let input = TxIn {
+        previous_output: dummy_out_point, // The dummy output we are spending.
+        script_sig: ScriptBuf::default(), // For a p2tr script_sig is empty.
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::default(), // Filled in after signing.
+    };
+
+    // The spend output is locked to a key controlled by the receiver.
+    let spend = TxOut {
+        value: SPEND_AMOUNT,
+        script_pubkey: address.script_pubkey(),
+    };
+
+    // The change output is locked to a key controlled by us.
+    let change = TxOut {
+        value: CHANGE_AMOUNT,
+        script_pubkey: ScriptBuf::new_p2tr(&secp, internal_key, None), // Change comes back to us.
+    };
+
+    // The transaction we want to sign and broadcast.
+    let mut unsigned_tx = Transaction {
+        version: transaction::Version::TWO,  // Post BIP-68.
+        lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
+        input: vec![input],                  // Input goes into index 0.
+        output: vec![spend, change],         // Outputs, order does not matter.
+    };
+    let input_index = 0;
+
+    // Get the sighash to sign.
+
+    let sighash_type = TapSighashType::Default;
+    let prevouts = vec![dummy_utxo];
+    let prevouts = Prevouts::All(&prevouts);
+
+    let mut sighasher = SighashCache::new(&mut unsigned_tx);
+    let sighash = sighasher
+        .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
+        .expect("failed to construct sighash");
+
+    // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
+    let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, None);
+    let msg = Message::from_digest_slice(&sighash.to_byte_array()).expect("32 bytes");
+    let signature = secp.sign_schnorr(&msg, &tweaked.to_inner());
+
+    // Update the witness stack.
+    let signature = bitcoin::taproot::Signature {
+        signature,
+        sighash_type,
+    };
+    *sighasher.witness_mut(input_index).unwrap() = Witness::p2tr_key_spend(&signature);
+
+    // Get the signed transaction.
+    let tx = sighasher.into_transaction();
+
+    // BOOM! Transaction signed and ready to broadcast.
+    println!("{:#?}", tx);
+}
+
+/// An example of keys controlled by the transaction sender.
+///
+/// In a real application these would be actual secrets.
+fn senders_keys<C: Signing>(secp: &Secp256k1<C>) -> Keypair {
+    let sk = SecretKey::new(&mut rand::thread_rng());
+    Keypair::from_secret_key(secp, &sk)
+}
+
+/// A dummy address for the receiver.
+///
+/// We lock the spend output to the key associated with this address.
+///
+/// (FWIW this is an arbitrary mainnet address from block 805222.)
+fn receivers_address() -> Address {
+    Address::from_str("bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va")
+        .expect("a valid address")
+        .require_network(Network::Bitcoin)
+        .expect("valid address for mainnet")
+}
+
+/// Creates a p2wpkh output locked to the key associated with `wpkh`.
+///
+/// An utxo is described by the `OutPoint` (txid and index within the transaction that it was
+/// created). Using the out point one can get the transaction by `txid` and using the `vout` get the
+/// transaction value and script pubkey (`TxOut`) of the utxo.
+///
+/// This output is locked to keys that we control, in a real application this would be a valid
+/// output taken from a transaction that appears in the chain.
+fn dummy_unspent_transaction_output<C: Verification>(
+    secp: &Secp256k1<C>,
+    internal_key: UntweakedPublicKey,
+) -> (OutPoint, TxOut) {
+    let script_pubkey = ScriptBuf::new_p2tr(secp, internal_key, None);
+
+    let out_point = OutPoint {
+        txid: Txid::all_zeros(), // Obviously invalid.
+        vout: 0,
+    };
+
+    let utxo = TxOut {
+        value: DUMMY_UTXO_AMOUNT,
+        script_pubkey,
+    };
+
+    (out_point, utxo)
+}

--- a/via_verifier/lib/via_musig2/examples/withdrawal3.rs
+++ b/via_verifier/lib/via_musig2/examples/withdrawal3.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Demonstrate creating a transaction that spends to and from p2tr outputs with musig2.
+
+use std::str::FromStr;
+
+use bitcoin::{
+    hashes::Hash,
+    key::{Keypair, TapTweak, TweakedKeypair},
+    locktime::absolute,
+    secp256k1::{Message, Secp256k1, SecretKey},
+    sighash::{Prevouts, SighashCache, TapSighashType},
+    transaction, Address, Amount, Network, PrivateKey, PublicKey, ScriptBuf, Sequence, Transaction,
+    TxIn, TxOut, Witness, XOnlyPublicKey,
+};
+use musig2::{secp::Scalar, KeyAggContext};
+use rand::Rng;
+use secp256k1_musig2::schnorr::Signature;
+use via_btc_client::{inscriber::Inscriber, types::NodeAuth};
+
+const RPC_URL: &str = "http://0.0.0.0:18443";
+const RPC_USERNAME: &str = "rpcuser";
+const RPC_PASSWORD: &str = "rpcpassword";
+const NETWORK: Network = Network::Regtest;
+const PK: &str = "cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm";
+const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let secp = Secp256k1::new();
+
+    // Get a keypair we control. In a real application these would come from a stored secret.
+    let private_key_1 =
+        PrivateKey::from_wif("cVZduZu265sWeAqFYygoDEE1FZ7wV9rpW5qdqjRkUehjaUMWLT1R").unwrap();
+
+    let private_key_2 =
+        PrivateKey::from_wif("cUWA5dZXc6NwLovW3Kr9DykfY5ysFigKZM5Annzty7J8a43Fe2YF").unwrap();
+
+    let private_key_3 =
+        PrivateKey::from_wif("cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm").unwrap();
+
+    let secret_key_1 = SecretKey::from_slice(&private_key_1.inner.secret_bytes()).unwrap();
+    let secret_key_2 = SecretKey::from_slice(&private_key_2.inner.secret_bytes()).unwrap();
+    let secret_key_3 = SecretKey::from_slice(&private_key_3.inner.secret_bytes()).unwrap();
+
+    let keypair_1 = Keypair::from_secret_key(&secp, &secret_key_1);
+    let keypair_2 = Keypair::from_secret_key(&secp, &secret_key_2);
+    let keypair_3 = Keypair::from_secret_key(&secp, &secret_key_3);
+
+    let (internal_key_1, parity_1) = keypair_1.x_only_public_key();
+    let (internal_key_2, parity_2) = keypair_2.x_only_public_key();
+    let (internal_key_3, parity_3) = keypair_3.x_only_public_key();
+
+    // -------------------------------------------
+    // Key aggregation (MuSig2)
+    // -------------------------------------------
+    let pubkeys = vec![
+        musig2::secp256k1::PublicKey::from_slice(&internal_key_1.public_key(parity_1).serialize())
+            .unwrap(),
+        musig2::secp256k1::PublicKey::from_slice(&internal_key_2.public_key(parity_2).serialize())
+            .unwrap(),
+        musig2::secp256k1::PublicKey::from_slice(&internal_key_3.public_key(parity_3).serialize())
+            .unwrap(),
+    ];
+
+    let mut musig_key_agg_cache = KeyAggContext::new(pubkeys)?;
+
+    let agg_pubkey: secp256k1_musig2::PublicKey = musig_key_agg_cache.aggregated_pubkey();
+
+    let final_internal_key = agg_pubkey.x_only_public_key();
+
+    let final_internal_key = XOnlyPublicKey::from_slice(&final_internal_key.0.serialize())?;
+    let address = Address::p2tr(&secp, final_internal_key, None, NETWORK);
+
+    println!("address: {}", address);
+
+    // -------------------------------------------
+    // Connect to Bitcoin node (adjust RPC credentials and URL)
+    // -------------------------------------------
+    let inscriber = Inscriber::new(
+        RPC_URL,
+        NETWORK,
+        NodeAuth::UserPass(RPC_USERNAME.to_string(), RPC_PASSWORD.to_string()),
+        PK,
+        None,
+    )
+    .await?;
+    let client = inscriber.get_client().await;
+
+    // -------------------------------------------
+    // Fetching UTXOs from node
+    // -------------------------------------------
+    let utxos = client.fetch_utxos(&address).await?;
+
+    // Get an unspent output that is locked to the key above that we control.
+    // In a real application these would come from the chain.
+    let (dummy_out_point, dummy_utxo) = utxos[0].clone();
+
+    let change_amount = dummy_utxo.value - SPEND_AMOUNT;
+
+    // Get an address to send to.
+    let address = receivers_address();
+
+    // The input for the transaction we are constructing.
+    let input = TxIn {
+        previous_output: dummy_out_point, // The dummy output we are spending.
+        script_sig: ScriptBuf::default(), // For a p2tr script_sig is empty.
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::default(), // Filled in after signing.
+    };
+
+    // The spend output is locked to a key controlled by the receiver.
+    let spend = TxOut {
+        value: SPEND_AMOUNT,
+        script_pubkey: address.script_pubkey(),
+    };
+
+    // The change output is locked to a key controlled by us.
+    let change = TxOut {
+        value: change_amount,
+        script_pubkey: ScriptBuf::new_p2tr(&secp, final_internal_key, None), // Change comes back to us.
+    };
+
+    // The transaction we want to sign and broadcast.
+    let mut unsigned_tx = Transaction {
+        version: transaction::Version::TWO,  // Post BIP-68.
+        lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
+        input: vec![input],                  // Input goes into index 0.
+        output: vec![spend, change],         // Outputs, order does not matter.
+    };
+    let input_index = 0;
+
+    // Get the sighash to sign.
+    let sighash_type = TapSighashType::Default;
+    let prevouts = vec![dummy_utxo];
+    let prevouts = Prevouts::All(&prevouts);
+
+    let mut sighasher = SighashCache::new(&mut unsigned_tx);
+    let sighash = sighasher
+        .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
+        .expect("failed to construct sighash");
+
+    // -------------------------------------------
+    // MuSig2 Signing Process
+    // -------------------------------------------
+    use musig2::{FirstRound, SecNonceSpices};
+    use rand::thread_rng;
+
+    // Convert bitcoin::SecretKey to musig2::SecretKey for each participant
+    let secret_key_1 = musig2::secp256k1::SecretKey::from_slice(&secret_key_1[..]).unwrap();
+    let secret_key_2 = musig2::secp256k1::SecretKey::from_slice(&secret_key_2[..]).unwrap();
+    let secret_key_3 = musig2::secp256k1::SecretKey::from_slice(&secret_key_3[..]).unwrap();
+
+    // Apply taproot tweak to the aggregation context
+    let merkle_root = [0u8; 32]; // No script path in this example
+    let musig_key_agg_cache = musig_key_agg_cache
+        .with_taproot_tweak(&merkle_root)
+        .unwrap();
+
+    // First round: Generate nonces
+    let mut first_round_1 = FirstRound::new(
+        musig_key_agg_cache.clone(),
+        thread_rng().gen::<[u8; 32]>(),
+        0,
+        SecNonceSpices::new()
+            .with_seckey(secret_key_1)
+            .with_message(&sighash.to_byte_array()),
+    )?;
+
+    let mut first_round_2 = FirstRound::new(
+        musig_key_agg_cache.clone(),
+        thread_rng().gen::<[u8; 32]>(),
+        1,
+        SecNonceSpices::new()
+            .with_seckey(secret_key_2)
+            .with_message(&sighash.to_byte_array()),
+    )?;
+
+    let mut first_round_3 = FirstRound::new(
+        musig_key_agg_cache.clone(),
+        thread_rng().gen::<[u8; 32]>(),
+        2,
+        SecNonceSpices::new()
+            .with_seckey(secret_key_3)
+            .with_message(&sighash.to_byte_array()),
+    )?;
+
+    // Exchange nonces
+    let nonce_1 = first_round_1.our_public_nonce();
+    let nonce_2 = first_round_2.our_public_nonce();
+    let nonce_3 = first_round_3.our_public_nonce();
+
+    first_round_1.receive_nonce(1, nonce_2.clone())?;
+    first_round_1.receive_nonce(2, nonce_3.clone())?;
+    first_round_2.receive_nonce(0, nonce_1.clone())?;
+    first_round_2.receive_nonce(2, nonce_3.clone())?;
+    first_round_3.receive_nonce(0, nonce_1.clone())?;
+    first_round_3.receive_nonce(1, nonce_2.clone())?;
+
+    // Second round: Create partial signatures
+    let binding = sighash.to_byte_array();
+    let mut second_round_1 = first_round_1.finalize(secret_key_1, &binding)?;
+    let binding = sighash.to_byte_array();
+    let second_round_2 = first_round_2.finalize(secret_key_2, &binding)?;
+    let binding = sighash.to_byte_array();
+    let second_round_3 = first_round_3.finalize(secret_key_3, &binding)?;
+    // Combine partial signatures
+    let partial_sig_2: [u8; 32] = second_round_2.our_signature();
+    let partial_sig_3: [u8; 32] = second_round_3.our_signature();
+
+    second_round_1.receive_signature(1, Scalar::from_slice(&partial_sig_2).unwrap())?;
+    second_round_1.receive_signature(2, Scalar::from_slice(&partial_sig_3).unwrap())?;
+
+    let final_signature: Signature = second_round_1.finalize()?;
+
+    // Update the witness stack with the aggregated signature
+    let signature = bitcoin::taproot::Signature {
+        signature: bitcoin::secp256k1::schnorr::Signature::from_slice(
+            &final_signature.serialize(),
+        )?,
+        sighash_type,
+    };
+    *sighasher.witness_mut(input_index).unwrap() = Witness::p2tr_key_spend(&signature);
+
+    // Get the signed transaction
+    let tx = sighasher.into_transaction();
+
+    // BOOM! Transaction signed and ready to broadcast.
+    println!("{:#?}", tx);
+
+    let tx_hex = bitcoin::consensus::encode::serialize_hex(&tx);
+    let res = client.broadcast_signed_transaction(&tx_hex).await?;
+    println!("res: {:?}", res);
+
+    Ok(())
+}
+
+/// A dummy address for the receiver.
+///
+/// We lock the spend output to the key associated with this address.
+///
+/// (FWIW this is an arbitrary mainnet address from block 805222.)
+fn receivers_address() -> Address {
+    Address::from_str("bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va")
+        .expect("a valid address")
+        .require_network(Network::Bitcoin)
+        .expect("valid address for mainnet")
+}


### PR DESCRIPTION
## What ❔
Connect the musig2 example to regtest.

## Why ❔

Test the brodcast signed transaction.

## Test
1. `make env`
2. `make config`
3. `make init`
4. `cargo run  --example withdrawal`

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
