### PR TITLE
Dockerize server for devnet-2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,3 +47,5 @@ contracts/.git
 !etc/env/consensus_secrets.yaml
 !etc/env/consensus_config.yaml
 !rust-toolchain
+
+!via_verifier

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/via
 
 COPY . .
 
-RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y protobuf-compiler git && rm -rf /var/lib/apt/lists/*
 RUN cargo build --release #--features=rocksdb/io-uring <-- investigate what is this
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
Update `server` Dockerfile to work with devnet-2 version.