### PR TITLE
fix: server restart, update via cli, minor logs changes

### DIFF
--- a/core/node/via_btc_sender/src/aggregator.rs
+++ b/core/node/via_btc_sender/src/aggregator.rs
@@ -81,14 +81,15 @@ impl ViaAggregator {
             )
             .await?;
 
-        tracing::debug!(
-            "Found {} l1 batches ready for commit",
-            ready_for_commit_l1_batches.len()
-        );
+        if !ready_for_commit_l1_batches.is_empty() {
+            tracing::debug!(
+                "Found {} l1 batches ready for commit",
+                ready_for_commit_l1_batches.len()
+            );
+        }
 
         validate_l1_batch_sequence(&ready_for_commit_l1_batches);
 
-        tracing::debug!("Extracting ready subrange");
         if let Some(l1_batches) = extract_ready_subrange(
             &mut self.commit_l1_block_criteria,
             ready_for_commit_l1_batches,

--- a/core/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/core/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -45,9 +45,7 @@ impl ViaBtcInscriptionManager {
             let mut storage = pool.connection_tagged("via_btc_sender").await?;
 
             match self.loop_iteration(&mut storage).await {
-                Ok(()) => {
-                    tracing::info!("Inscription manager task finished");
-                }
+                Ok(()) => {}
                 Err(err) => {
                     tracing::error!("Failed to process btc_sender_inscription_manager: {err}");
                 }


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->
This PR fixes problem with `env` during server restart.

Try after stopping server:
```bash
/* via cli re-compile here */
via env via --soft
via server
```
`--soft` will not re-compile configs.
## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
