### PR TITLE
feat: Add via command for running unit tests

### DIFF
--- a/infrastructure/via/src/config.ts
+++ b/infrastructure/via/src/config.ts
@@ -157,7 +157,7 @@ export async function pushConfig(environment?: string, diff?: string) {
         env.modify('DATABASE_URL', `postgres://postgres:notsecurepassword@localhost/${environment}`, l2InitFile, false);
         env.modify(
             'TEST_DATABASE_URL',
-            `postgres://postgres:notsecurepassword@localhost/${environment}_test`,
+            `postgres://postgres:notsecurepassword@localhost:5433/${environment}_test`,
             l2InitFile,
             false
         );
@@ -170,7 +170,7 @@ export async function pushConfig(environment?: string, diff?: string) {
         );
         env.modify(
             'TEST_DATABASE_PROVER_URL',
-            `postgres://postgres:notsecurepassword@localhost/prover_${environment}_test`,
+            `postgres://postgres:notsecurepassword@localhost:5433/prover_${environment}_test`,
             l2InitFile,
             false
         );
@@ -183,7 +183,7 @@ export async function pushConfig(environment?: string, diff?: string) {
         );
         env.modify(
             `TEST_DATABASE_VERIFIER_URL`,
-            `postgres://postgres:notsecurepassword@localhost/verifier_${environment}_test`,
+            `postgres://postgres:notsecurepassword@localhost:5433/verifier_${environment}_test`,
             l2InitFile,
             false
         );

--- a/infrastructure/via/src/index.ts
+++ b/infrastructure/via/src/index.ts
@@ -19,6 +19,7 @@ import { verifierCommand as verifier } from './verifier';
 import { command as celestia } from './celestia';
 import { command as btc_explorer } from './btc_explorer';
 import { command as token } from './token';
+import { command as test } from './test/test';
 
 const COMMANDS = [
     server,
@@ -37,6 +38,7 @@ const COMMANDS = [
     celestia,
     btc_explorer,
     token,
+    test,
     completion(program as Command)
 ];
 

--- a/infrastructure/via/src/test/test.ts
+++ b/infrastructure/via/src/test/test.ts
@@ -1,0 +1,44 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import * as utils from 'utils';
+import * as db from '../database';
+
+export async function rust(options: string[]) {
+    await db.resetTest({ core: true, prover: false, verifier: false });
+
+    let result = await utils.exec('cargo install --list');
+    let test_runner = 'cargo nextest run';
+    if (!result.stdout.includes('cargo-nextest')) {
+        console.warn(
+            chalk.bold.red(
+                `cargo-nextest is missing, please run "cargo install cargo-nextest". Falling back to "cargo test".`
+            )
+        );
+        test_runner = 'cargo test';
+    }
+
+    // Quote options containing wildcards to prevent shell expansion
+    options = options.map((opt) => {
+        if (opt.includes('*') || opt.includes('?')) {
+            return `'${opt}'`;
+        }
+        return opt;
+    });
+
+    let cmd = `${test_runner} --release ${options.join(' ')}`;
+    console.log(`running unit tests with '${cmd}'`);
+
+    await utils.spawn(cmd);
+}
+
+export const command = new Command('test').description('run test suites');
+
+command
+    .command('rust [command...]')
+    .allowUnknownOption()
+    .description(
+        "run unit-tests. the default is running all tests in all rust bins and libs. accepts optional arbitrary cargo test flags. use `-p 'via_*'` to run all unit tests for VIA crates."
+    )
+    .action(async (args: string[]) => {
+        await rust(args);
+    });


### PR DESCRIPTION
## What ❔

- `via test rust` command added to via cli for running unit tests with `cargo-nextest`

## Why ❔

- Enables all Via tests (from all crates prefixed with `via_`) to be run with `via test rust -p 'via_*'`, even the ones from Via node components that need access to test db
