### PR TITLE
Feat/via musig2 transaction builder and utxo context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9844,6 +9844,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitcoin",
+ "dotenv",
  "hex",
  "serde",
  "tokio",

--- a/core/lib/via_btc_client/src/inscriber/test_utils.rs
+++ b/core/lib/via_btc_client/src/inscriber/test_utils.rs
@@ -43,6 +43,10 @@ impl MockBitcoinOpsConfig {
     pub fn set_fee_history(&mut self, fees: Vec<u64>) {
         self.fee_history = fees;
     }
+
+    pub fn set_utxos(&mut self, utxos: Vec<(OutPoint, TxOut)>) {
+        self.utxos = utxos;
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -86,7 +90,7 @@ impl BitcoinOps for MockBitcoinOps {
     }
 
     async fn fetch_utxos(&self, _address: &Address) -> BitcoinClientResult<Vec<(OutPoint, TxOut)>> {
-        BitcoinClientResult::Ok(vec![(
+        let default_utxos = vec![(
             OutPoint {
                 txid: Txid::all_zeros(),
                 vout: 0,
@@ -95,7 +99,11 @@ impl BitcoinOps for MockBitcoinOps {
                 value: Amount::from_btc(1.0).unwrap(),
                 script_pubkey: _address.script_pubkey(),
             },
-        )])
+        )];
+        if self.utxos.is_empty() {
+            return BitcoinClientResult::Ok(default_utxos);
+        }
+        BitcoinClientResult::Ok(self.utxos.clone())
     }
 
     async fn check_tx_confirmation(

--- a/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
@@ -1,9 +1,7 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
-use anyhow::Context;
-use via_btc_client::types::{BitcoinAddress, NodeAuth};
+use via_btc_client::{client::BitcoinClient, traits::BitcoinOps, types::NodeAuth};
 use via_btc_watch::BitcoinNetwork;
-use via_musig2::withdrawal_builder::WithdrawalBuilder;
 use via_verifier_dal::{ConnectionPool, Verifier};
 use via_withdrawal_client::client::WithdrawalClient;
 use zksync_config::{ViaBtcSenderConfig, ViaVerifierConfig};
@@ -56,23 +54,16 @@ impl WiringLayer for ViaCoordinatorApiLayer {
             self.btc_sender_config.rpc_password().to_string(),
         );
         let network = BitcoinNetwork::from_str(self.btc_sender_config.network()).unwrap();
-        let bridge_address = BitcoinAddress::from_str(self.config.bridge_address_str.as_str())
-            .context("Error parse bridge address")?
-            .assume_checked();
 
-        let withdrawal_builder = WithdrawalBuilder::new(
-            self.btc_sender_config.rpc_url(),
-            network,
-            auth,
-            bridge_address,
-        )
-        .await?;
+        let btc_client =
+            Arc::new(BitcoinClient::new(self.btc_sender_config.rpc_url(), network, auth).unwrap());
 
         let withdrawal_client = WithdrawalClient::new(input.client.0, network);
+
         let via_coordinator_api_task = ViaCoordinatorApiTask {
             master_pool,
             config: self.config,
-            withdrawal_builder,
+            btc_client,
             withdrawal_client,
         };
         Ok(Output {
@@ -85,7 +76,7 @@ impl WiringLayer for ViaCoordinatorApiLayer {
 pub struct ViaCoordinatorApiTask {
     master_pool: ConnectionPool<Verifier>,
     config: ViaVerifierConfig,
-    withdrawal_builder: WithdrawalBuilder,
+    btc_client: Arc<dyn BitcoinOps>,
     withdrawal_client: WithdrawalClient,
 }
 
@@ -99,7 +90,7 @@ impl Task for ViaCoordinatorApiTask {
         via_verifier_coordinator::coordinator::api::start_coordinator_server(
             self.config,
             self.master_pool,
-            self.withdrawal_builder,
+            self.btc_client,
             self.withdrawal_client,
             stop_receiver.0,
         )

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -6,7 +6,8 @@ use musig2::{
     SecNonceSpices, SecondRound,
 };
 use secp256k1_musig2::{PublicKey, Secp256k1, SecretKey};
-pub mod withdrawal_builder;
+pub mod transaction_builder;
+pub mod utxo_manager;
 
 #[derive(Debug)]
 pub enum MusigError {

--- a/via_verifier/lib/via_musig2/src/utxo_manager.rs
+++ b/via_verifier/lib/via_musig2/src/utxo_manager.rs
@@ -1,0 +1,426 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use bitcoin::{Address, Amount, OutPoint, Transaction, TxOut};
+use tokio::sync::RwLock;
+use via_btc_client::traits::BitcoinOps;
+
+const CTX_REQUIRED_CONFIRMATIONS: u32 = 1;
+const DEFAULT_CAPACITY: usize = 100;
+
+#[derive(Debug, Clone)]
+pub struct UtxoManager {
+    /// Btc client
+    btc_client: Arc<dyn BitcoinOps>,
+    /// The wallet address
+    address: Address,
+    /// The transactions executed by the wallet
+    context: Arc<RwLock<VecDeque<Transaction>>>,
+    /// The minimum amount to merge utxos
+    minimum_amount: Amount,
+    /// The maximum number of utxos to merge in a single tx
+    merge_limit: usize,
+}
+
+impl UtxoManager {
+    pub fn new(
+        btc_client: Arc<dyn BitcoinOps>,
+        address: Address,
+        minimum_amount: Amount,
+        merge_limit: usize,
+    ) -> Self {
+        UtxoManager {
+            btc_client,
+            address,
+            context: Arc::new(RwLock::new(VecDeque::with_capacity(DEFAULT_CAPACITY))),
+            minimum_amount,
+            merge_limit,
+        }
+    }
+
+    pub async fn get_available_utxos(&self) -> anyhow::Result<Vec<(OutPoint, TxOut)>> {
+        // fetch utxos from client
+        let mut utxos = self.btc_client.fetch_utxos(&self.address).await?;
+        {
+            if self.context.read().await.is_empty() {
+                return Ok(utxos);
+            }
+        }
+
+        // Add the output utxos to the list
+        for tx in self.context.read().await.iter() {
+            for (i, out) in tx.output.iter().enumerate() {
+                if out.script_pubkey != self.address.script_pubkey() {
+                    continue;
+                };
+
+                let outpoit = OutPoint {
+                    txid: tx.compute_txid(),
+                    vout: i as u32,
+                };
+                utxos.push((outpoit, tx.output[i].clone()));
+            }
+        }
+
+        // Remove the inputs used utxos
+        for tx in self.context.read().await.iter() {
+            for input in tx.input.iter() {
+                let outpoint = input.previous_output;
+                let index = utxos.iter().position(|(op, _)| op == &outpoint);
+                if let Some(index) = index {
+                    utxos.remove(index);
+                }
+            }
+        }
+
+        Ok(utxos)
+    }
+
+    pub async fn get_utxos_to_merge(&self) -> anyhow::Result<Vec<(OutPoint, TxOut)>> {
+        let mut utxos_to_merge = Vec::new();
+        let available_utxos = self.get_available_utxos().await?;
+
+        // If the amount is greater than the minimum amount to merge
+        for (outpoint, txout) in available_utxos.iter() {
+            if txout.value >= self.minimum_amount {
+                utxos_to_merge.push((*outpoint, txout.clone()));
+            }
+            if utxos_to_merge.len() == self.merge_limit {
+                break;
+            }
+        }
+        if utxos_to_merge.len() > 1 {
+            return Ok(utxos_to_merge);
+        }
+        Ok(vec![])
+    }
+
+    pub async fn sync_context_with_blockchain(&self) -> anyhow::Result<()> {
+        if self.context.read().await.is_empty() {
+            return Ok(());
+        }
+
+        while let Some(tx) = self.context.write().await.pop_front() {
+            let res = self
+                .btc_client
+                .check_tx_confirmation(&tx.compute_txid(), CTX_REQUIRED_CONFIRMATIONS)
+                .await?;
+
+            if !res {
+                self.context.write().await.push_front(tx);
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn insert_transaction(&self, tx: Transaction) {
+        for ctx_tx in self.context.read().await.iter() {
+            if ctx_tx.compute_txid() == tx.compute_txid() {
+                return;
+            }
+        }
+        self.context.write().await.push_back(tx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use bitcoin::{
+        absolute, hashes::Hash, transaction, Network, ScriptBuf, Sequence, TxIn, Txid, Witness,
+    };
+    use via_btc_client::inscriber::test_utils::{MockBitcoinOps, MockBitcoinOpsConfig};
+
+    use super::*;
+
+    fn bridge_address() -> Address {
+        Address::p2pkh(
+            bitcoin::PublicKey::from_slice(&[0x02; 33]).unwrap(),
+            Network::Bitcoin,
+        )
+    }
+
+    fn random_address() -> Address {
+        Address::p2pkh(
+            bitcoin::PublicKey::from_str(
+                "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+            )
+            .unwrap(),
+            Network::Bitcoin,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_get_available_utxos() {
+        let bridge_address = bridge_address();
+        let mut config = MockBitcoinOpsConfig::default();
+        let utxos = vec![(
+            OutPoint {
+                txid: Txid::all_zeros(),
+                vout: 0,
+            },
+            TxOut {
+                value: Amount::from_sat(700),
+                script_pubkey: bridge_address.script_pubkey(),
+            },
+        )];
+        config.set_utxos(utxos.clone());
+
+        let client = Arc::new(MockBitcoinOps::new(config));
+        let manager = UtxoManager::new(client, bridge_address, Amount::ZERO, 100);
+        let utxos_out = manager.get_available_utxos().await.unwrap();
+
+        assert_eq!(utxos, utxos_out);
+    }
+
+    #[tokio::test]
+    async fn test_get_utxos_to_merge_all_gt_minimum_amount() {
+        let bridge_address = bridge_address();
+        let mut config = MockBitcoinOpsConfig::default();
+        let utxos = vec![
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(600),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(500),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+        ];
+        config.set_utxos(utxos.clone());
+
+        let client = Arc::new(MockBitcoinOps::new(config));
+        let manager = UtxoManager::new(client, bridge_address, Amount::from_sat(500), 100);
+        let utxos_out = manager.get_utxos_to_merge().await.unwrap();
+
+        assert_eq!(utxos, utxos_out);
+    }
+
+    #[tokio::test]
+    async fn test_get_utxos_to_merge_when_merge_limit() {
+        let bridge_address = bridge_address();
+        let mut config = MockBitcoinOpsConfig::default();
+        let utxos = vec![
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(600),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(500),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+        ];
+        config.set_utxos(utxos.clone());
+
+        let client = Arc::new(MockBitcoinOps::new(config));
+        let merge_limit = 2;
+        let manager = UtxoManager::new(client, bridge_address, Amount::from_sat(0), merge_limit);
+        let utxos_out = manager.get_utxos_to_merge().await.unwrap();
+
+        assert_eq!(utxos_out.len(), merge_limit);
+    }
+
+    #[tokio::test]
+    async fn test_get_utxos_to_merge_some_gt_minimum_amount() {
+        let bridge_address = bridge_address();
+        let mut config = MockBitcoinOpsConfig::default();
+        let utxos = vec![
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(100),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(500),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+            (
+                OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                TxOut {
+                    value: Amount::from_sat(600),
+                    script_pubkey: bridge_address.script_pubkey(),
+                },
+            ),
+        ];
+        config.set_utxos(utxos.clone());
+
+        let client = Arc::new(MockBitcoinOps::new(config));
+        let manager = UtxoManager::new(client, bridge_address, Amount::from_sat(500), 100);
+        let utxos_out = manager.get_utxos_to_merge().await.unwrap();
+        let expected_utxos = vec![utxos[1].clone(), utxos[2].clone()];
+        assert_eq!(expected_utxos, utxos_out);
+    }
+
+    #[tokio::test]
+    async fn test_get_utxos_to_merge_when_one_utxo_and_lt_minimum_amount() {
+        let bridge_address = bridge_address();
+        let mut config = MockBitcoinOpsConfig::default();
+        let utxos = vec![(
+            OutPoint {
+                txid: Txid::all_zeros(),
+                vout: 0,
+            },
+            TxOut {
+                value: Amount::from_sat(100),
+                script_pubkey: bridge_address.script_pubkey(),
+            },
+        )];
+        config.set_utxos(utxos.clone());
+
+        let client = Arc::new(MockBitcoinOps::new(config));
+        let manager = UtxoManager::new(client, bridge_address, Amount::from_sat(500), 100);
+        let utxos_out = manager.get_utxos_to_merge().await.unwrap();
+        let expected_utxos: Vec<(OutPoint, TxOut)> = vec![];
+        assert_eq!(expected_utxos, utxos_out);
+    }
+
+    #[tokio::test]
+    async fn test_chainned_utxos_one_after_one() {
+        let bridge_address = bridge_address();
+        let mut config = MockBitcoinOpsConfig::default();
+        let utxos = vec![(
+            OutPoint {
+                txid: Txid::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000001",
+                )
+                .unwrap(),
+                vout: 0,
+            },
+            TxOut {
+                value: Amount::from_sat(500),
+                script_pubkey: bridge_address.script_pubkey(),
+            },
+        )];
+        config.set_utxos(utxos.clone());
+        config.set_tx_confirmation(true);
+
+        let client = Arc::new(MockBitcoinOps::new(config));
+        let manager = UtxoManager::new(client, bridge_address.clone(), Amount::from_sat(500), 100);
+
+        //--------------------------------------------------------------------
+        // Use the first utxo
+        //--------------------------------------------------------------------
+        let mut outputs = vec![TxOut {
+            script_pubkey: bridge_address.script_pubkey(),
+            value: Amount::from_sat(500),
+        }];
+
+        let mut unsigned_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: utxos[0].0,
+                script_sig: ScriptBuf::default(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: outputs.clone(),
+        };
+        let txid1 = unsigned_tx.compute_txid();
+        let mut outpoint = OutPoint {
+            txid: txid1,
+            vout: 0,
+        };
+
+        manager.insert_transaction(unsigned_tx.clone()).await;
+
+        let utxos_out = manager.get_available_utxos().await.unwrap();
+        let expected_utxos: Vec<(OutPoint, TxOut)> = vec![(outpoint, outputs[0].clone())];
+        assert_eq!(expected_utxos, utxos_out);
+
+        //--------------------------------------------------------------------
+        // Use the second utxo
+        //--------------------------------------------------------------------
+
+        outputs = vec![
+            TxOut {
+                script_pubkey: random_address().script_pubkey(),
+                value: Amount::from_sat(100),
+            },
+            TxOut {
+                script_pubkey: random_address().script_pubkey(),
+                value: Amount::from_sat(100),
+            },
+            TxOut {
+                script_pubkey: bridge_address.script_pubkey(),
+                value: Amount::from_sat(300),
+            },
+        ];
+
+        unsigned_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: expected_utxos[0].0,
+                script_sig: ScriptBuf::default(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::default(),
+            }],
+            output: outputs.clone(),
+        };
+        let txid2 = unsigned_tx.compute_txid();
+
+        outpoint = OutPoint {
+            txid: unsigned_tx.compute_txid(),
+            vout: 2,
+        };
+
+        manager.insert_transaction(unsigned_tx.clone()).await;
+
+        let utxos_out = manager.get_available_utxos().await.unwrap();
+        let expected_utxos: Vec<(OutPoint, TxOut)> = vec![(outpoint, outputs[2].clone())];
+        assert_eq!(expected_utxos, utxos_out);
+
+        let txids = [txid1, txid2];
+        assert_eq!(manager.context.read().await.len(), txids.len());
+
+        for (i, tx) in manager.context.read().await.iter().enumerate() {
+            assert_eq!(tx.compute_txid(), txids[i]);
+        }
+
+        // Sync the context manager with network
+        manager.sync_context_with_blockchain().await.unwrap();
+
+        // The context should be empty now
+        assert_eq!(manager.context.read().await.len(), 0);
+    }
+}

--- a/via_verifier/lib/via_withdrawal_client/Cargo.toml
+++ b/via_verifier/lib/via_withdrawal_client/Cargo.toml
@@ -28,6 +28,7 @@ serde.workspace = true
 via_verifier_types.workspace = true
 
 [dev-dependencies]
+dotenv = "0.15"
 zksync_dal.workspace = true
 via_da_clients.workspace = true
 

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use anyhow::Context as _;
 use tokio::sync::watch;
-use via_musig2::withdrawal_builder::WithdrawalBuilder;
+use via_btc_client::traits::BitcoinOps;
 use via_verifier_dal::{ConnectionPool, Verifier};
 use via_withdrawal_client::client::WithdrawalClient;
 use zksync_config::configs::via_verifier::ViaVerifierConfig;
@@ -10,7 +12,7 @@ use crate::coordinator::api_decl::RestApi;
 pub async fn start_coordinator_server(
     config: ViaVerifierConfig,
     master_connection_pool: ConnectionPool<Verifier>,
-    withdrawal_builder: WithdrawalBuilder,
+    btc_client: Arc<dyn BitcoinOps>,
     withdrawal_client: WithdrawalClient,
     mut stop_receiver: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
@@ -18,7 +20,7 @@ pub async fn start_coordinator_server(
     let api = RestApi::new(
         config,
         master_connection_pool,
-        withdrawal_builder,
+        btc_client,
         withdrawal_client,
     )?
     .into_router();

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api_decl.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api_decl.rs
@@ -44,10 +44,8 @@ impl RestApi {
             .context("Error parse bridge address")?
             .assume_checked();
 
-        let transaction_builder = Arc::new(RwLock::new(TransactionBuilder::new(
-            btc_client.clone(),
-            bridge_address,
-        )?));
+        let transaction_builder =
+            Arc::new(TransactionBuilder::new(btc_client.clone(), bridge_address)?);
 
         let withdrawal_session = WithdrawalSession::new(
             master_connection_pool.clone(),

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api_decl.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api_decl.rs
@@ -1,9 +1,12 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 
+use anyhow::Context;
 use axum::middleware;
+use bitcoin::Address;
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
-use via_musig2::withdrawal_builder::WithdrawalBuilder;
+use via_btc_client::traits::BitcoinOps;
+use via_musig2::transaction_builder::TransactionBuilder;
 use via_verifier_dal::{ConnectionPool, Verifier};
 use via_withdrawal_client::client::WithdrawalClient;
 use zksync_config::configs::via_verifier::ViaVerifierConfig;
@@ -24,7 +27,7 @@ impl RestApi {
     pub fn new(
         config: ViaVerifierConfig,
         master_connection_pool: ConnectionPool<Verifier>,
-        withdrawal_builder: WithdrawalBuilder,
+        btc_client: Arc<dyn BitcoinOps>,
         withdrawal_client: WithdrawalClient,
     ) -> anyhow::Result<Self> {
         let state = ViaWithdrawalState {
@@ -36,23 +39,32 @@ impl RestApi {
                 .map(|s| bitcoin::secp256k1::PublicKey::from_str(s).unwrap())
                 .collect(),
         };
+
+        let bridge_address = Address::from_str(config.bridge_address_str.as_str())
+            .context("Error parse bridge address")?
+            .assume_checked();
+
+        let transaction_builder = Arc::new(RwLock::new(TransactionBuilder::new(
+            btc_client.clone(),
+            bridge_address,
+        )?));
+
         let withdrawal_session = WithdrawalSession::new(
             master_connection_pool.clone(),
-            withdrawal_builder.clone(),
+            transaction_builder.clone(),
             withdrawal_client.clone(),
         );
 
         // Add sessions type the verifier network can process
-        let sessions: HashMap<SessionType, Box<dyn ISession>> = [(
+        let sessions: HashMap<SessionType, Arc<dyn ISession>> = [(
             SessionType::Withdrawal,
-            Box::new(withdrawal_session) as Box<dyn ISession>,
+            Arc::new(withdrawal_session) as Arc<dyn ISession>,
         )]
         .into_iter()
         .collect();
 
-        let session_manager = SessionManager::new(sessions);
         Ok(Self {
-            session_manager,
+            session_manager: SessionManager::new(sessions),
             state,
         })
     }

--- a/via_verifier/node/via_verifier_coordinator/src/sessions/session_manager.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/sessions/session_manager.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use bitcoin::Txid;
 
@@ -8,19 +8,18 @@ use crate::{
 };
 
 pub struct SessionManager {
-    pub sessions: HashMap<SessionType, Box<dyn ISession>>,
+    pub sessions: HashMap<SessionType, Arc<dyn ISession>>,
 }
 
 impl SessionManager {
-    pub fn new(sessions: HashMap<SessionType, Box<dyn ISession>>) -> Self {
+    pub fn new(sessions: HashMap<SessionType, Arc<dyn ISession>>) -> Self {
         Self { sessions }
     }
 
     pub async fn get_next_session(&self) -> anyhow::Result<Option<SessionOperation>> {
         for session in self.sessions.values() {
-            let session_op = session.session().await?;
-            if session_op.is_some() {
-                return Ok(session_op);
+            if let Some(op) = session.session().await? {
+                return Ok(Some(op));
             }
         }
         Ok(None)
@@ -30,37 +29,45 @@ impl SessionManager {
         &self,
         session_op: &SessionOperation,
     ) -> anyhow::Result<bool> {
-        Ok(match self.sessions.get(&session_op.get_session_type()) {
-            Some(s) => s.is_session_in_progress(session_op).await?,
-            None => return Ok(false),
-        })
+        let session = self
+            .sessions
+            .get(&session_op.get_session_type())
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        session.verify_message(session_op).await
     }
 
     pub async fn verify_message(&self, session_op: &SessionOperation) -> anyhow::Result<bool> {
-        Ok(match self.sessions.get(&session_op.get_session_type()) {
-            Some(s) => s.verify_message(session_op).await?,
-            None => return Ok(false),
-        })
+        let session = self
+            .sessions
+            .get(&session_op.get_session_type())
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        session.verify_message(session_op).await
     }
 
     pub async fn before_process_session(
         &self,
         session_op: &SessionOperation,
     ) -> anyhow::Result<bool> {
-        Ok(match self.sessions.get(&session_op.get_session_type()) {
-            Some(s) => s.before_process_session(session_op).await?,
-            None => return Ok(false),
-        })
+        let session = self
+            .sessions
+            .get(&session_op.get_session_type())
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        session.before_process_session(session_op).await
     }
 
     pub async fn before_broadcast_final_transaction(
         &self,
         session_op: &SessionOperation,
     ) -> anyhow::Result<bool> {
-        Ok(match self.sessions.get(&session_op.get_session_type()) {
-            Some(s) => s.before_broadcast_final_transaction(session_op).await?,
-            None => return Ok(false),
-        })
+        let session = self
+            .sessions
+            .get(&session_op.get_session_type())
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        session.before_broadcast_final_transaction(session_op).await
     }
 
     pub async fn after_broadcast_final_transaction(
@@ -68,12 +75,13 @@ impl SessionManager {
         txid: Txid,
         session_op: &SessionOperation,
     ) -> anyhow::Result<bool> {
-        Ok(match self.sessions.get(&session_op.get_session_type()) {
-            Some(s) => {
-                s.after_broadcast_final_transaction(txid, session_op)
-                    .await?
-            }
-            None => return Ok(false),
-        })
+        let session = self
+            .sessions
+            .get(&session_op.get_session_type())
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        session
+            .after_broadcast_final_transaction(txid, session_op)
+            .await
     }
 }

--- a/via_verifier/node/via_verifier_coordinator/src/sessions/withdrawal.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/sessions/withdrawal.rs
@@ -7,7 +7,6 @@ use bitcoin::{
     sighash::{Prevouts, SighashCache},
     Address, Amount, TapSighashType, TxOut, Txid,
 };
-use tokio::sync::RwLock;
 use via_musig2::transaction_builder::TransactionBuilder;
 use via_verifier_dal::{ConnectionPool, Verifier, VerifierDal};
 use via_verifier_types::{transaction::UnsignedBridgeTx, withdrawal::WithdrawalRequest};
@@ -21,14 +20,14 @@ const OP_RETURN_WITHDRAW_PREFIX: &[u8] = b"VIA_PROTOCOL:WITHDRAWAL:";
 #[derive(Debug, Clone)]
 pub struct WithdrawalSession {
     master_connection_pool: ConnectionPool<Verifier>,
-    transaction_builder: Arc<RwLock<TransactionBuilder>>,
+    transaction_builder: Arc<TransactionBuilder>,
     withdrawal_client: WithdrawalClient,
 }
 
 impl WithdrawalSession {
     pub fn new(
         master_connection_pool: ConnectionPool<Verifier>,
-        transaction_builder: Arc<RwLock<TransactionBuilder>>,
+        transaction_builder: Arc<TransactionBuilder>,
         withdrawal_client: WithdrawalClient,
     ) -> Self {
         Self {
@@ -188,7 +187,7 @@ impl ISession for WithdrawalSession {
         Ok(false)
     }
 
-    async fn before_process_session(&self, session_op: &SessionOperation) -> anyhow::Result<bool> {
+    async fn before_process_session(&self, _: &SessionOperation) -> anyhow::Result<bool> {
         return Ok(true);
     }
 
@@ -262,8 +261,6 @@ impl WithdrawalSession {
             .collect();
 
         self.transaction_builder
-            .write()
-            .await
             .build_transaction_with_op_return(
                 outputs,
                 OP_RETURN_WITHDRAW_PREFIX,

--- a/via_verifier/node/via_verifier_coordinator/src/sessions/withdrawal.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/sessions/withdrawal.rs
@@ -1,13 +1,14 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{Context, Ok};
 use axum::async_trait;
 use bitcoin::{
     hashes::Hash,
     sighash::{Prevouts, SighashCache},
-    Amount, TapSighashType, Txid,
+    Address, Amount, TapSighashType, TxOut, Txid,
 };
-use via_musig2::withdrawal_builder::WithdrawalBuilder;
+use tokio::sync::RwLock;
+use via_musig2::transaction_builder::TransactionBuilder;
 use via_verifier_dal::{ConnectionPool, Verifier, VerifierDal};
 use via_verifier_types::{transaction::UnsignedBridgeTx, withdrawal::WithdrawalRequest};
 use via_withdrawal_client::client::WithdrawalClient;
@@ -15,23 +16,25 @@ use zksync_types::H256;
 
 use crate::{traits::ISession, types::SessionOperation, utils::h256_to_txid};
 
+const OP_RETURN_WITHDRAW_PREFIX: &[u8] = b"VIA_PROTOCOL:WITHDRAWAL:";
+
 #[derive(Debug, Clone)]
 pub struct WithdrawalSession {
     master_connection_pool: ConnectionPool<Verifier>,
+    transaction_builder: Arc<RwLock<TransactionBuilder>>,
     withdrawal_client: WithdrawalClient,
-    withdrawal_builder: WithdrawalBuilder,
 }
 
 impl WithdrawalSession {
     pub fn new(
         master_connection_pool: ConnectionPool<Verifier>,
-        withdrawal_builder: WithdrawalBuilder,
+        transaction_builder: Arc<RwLock<TransactionBuilder>>,
         withdrawal_client: WithdrawalClient,
     ) -> Self {
         Self {
             master_connection_pool,
             withdrawal_client,
-            withdrawal_builder,
+            transaction_builder,
         }
     }
 }
@@ -105,7 +108,6 @@ impl ISession for WithdrawalSession {
         );
 
         let unsigned_tx = self
-            .withdrawal_builder
             .create_unsigned_withdrawal_tx(withdrawals_to_process, proof_txid)
             .await
             .map_err(|e| {
@@ -202,7 +204,9 @@ impl ISession for WithdrawalSession {
             if let Some(tx) = withdrawal_txid {
                 let tx_id = Txid::from_slice(&tx)?;
                 let is_confirmed = self
-                    .withdrawal_builder
+                    .transaction_builder
+                    .read()
+                    .await
                     .get_btc_client()
                     .check_tx_confirmation(&tx_id, 1)
                     .await?;
@@ -259,6 +263,41 @@ impl ISession for WithdrawalSession {
 }
 
 impl WithdrawalSession {
+    pub async fn create_unsigned_withdrawal_tx(
+        &self,
+        withdrawals: Vec<WithdrawalRequest>,
+        proof_txid: Txid,
+    ) -> anyhow::Result<UnsignedBridgeTx> {
+        // Group withdrawals by address and sum amounts
+        let mut grouped_withdrawals: HashMap<Address, Amount> = HashMap::new();
+        for w in withdrawals {
+            *grouped_withdrawals.entry(w.address).or_insert(Amount::ZERO) = grouped_withdrawals
+                .get(&w.address)
+                .unwrap_or(&Amount::ZERO)
+                .checked_add(w.amount)
+                .ok_or_else(|| anyhow::anyhow!("Withdrawal amount overflow when grouping"))?;
+        }
+
+        // Create outputs for grouped withdrawals
+        let outputs: Vec<TxOut> = grouped_withdrawals
+            .into_iter()
+            .map(|(address, amount)| TxOut {
+                value: amount,
+                script_pubkey: address.script_pubkey(),
+            })
+            .collect();
+
+        self.transaction_builder
+            .write()
+            .await
+            .build_transaction_with_op_return(
+                outputs,
+                OP_RETURN_WITHDRAW_PREFIX,
+                vec![proof_txid.as_raw_hash().to_byte_array()],
+            )
+            .await
+    }
+
     async fn _verify_withdrawals(
         &self,
         l1_batch_number: i64,
@@ -317,7 +356,10 @@ impl WithdrawalSession {
 
         // Verify the OP return
         let tx_id = h256_to_txid(&proof_tx_id)?;
-        let op_return_data = WithdrawalBuilder::create_op_return_script(tx_id)?;
+        let op_return_data = TransactionBuilder::create_op_return_script(
+            OP_RETURN_WITHDRAW_PREFIX,
+            vec![*tx_id.as_raw_hash().as_byte_array()],
+        )?;
         let op_return_tx_out = &unsigned_tx.tx.output[unsigned_tx.tx.output.len() - 2];
 
         if op_return_tx_out.script_pubkey.to_string() != op_return_data.to_string()

--- a/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
@@ -1,12 +1,12 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
-use anyhow::Result;
-use bitcoin::{TapSighashType, Witness};
+use anyhow::{Context, Result};
+use bitcoin::{Address, TapSighashType, Witness};
 use musig2::{CompactSignature, PartialSignature};
 use reqwest::{header, Client, StatusCode};
-use tokio::sync::watch;
+use tokio::sync::{watch, RwLock};
 use via_btc_client::traits::{BitcoinOps, Serializable};
-use via_musig2::{verify_signature, withdrawal_builder::WithdrawalBuilder, Signer};
+use via_musig2::{transaction_builder::TransactionBuilder, verify_signature, Signer};
 use via_verifier_dal::{ConnectionPool, Verifier};
 use via_verifier_types::transaction::UnsignedBridgeTx;
 use via_withdrawal_client::client::WithdrawalClient;
@@ -31,28 +31,36 @@ pub struct ViaWithdrawalVerifier {
 }
 
 impl ViaWithdrawalVerifier {
-    pub async fn new(
+    pub fn new(
+        config: ViaVerifierConfig,
         master_connection_pool: ConnectionPool<Verifier>,
         btc_client: Arc<dyn BitcoinOps>,
-        withdrawal_builder: WithdrawalBuilder,
         withdrawal_client: WithdrawalClient,
-        config: ViaVerifierConfig,
     ) -> anyhow::Result<Self> {
         let signer = get_signer(
             &config.private_key.clone(),
             config.verifiers_pub_keys_str.clone(),
         )?;
 
+        let bridge_address = Address::from_str(config.bridge_address_str.as_str())
+            .context("Error parse bridge address")?
+            .assume_checked();
+
+        let transaction_builder = Arc::new(RwLock::new(TransactionBuilder::new(
+            btc_client.clone(),
+            bridge_address,
+        )?));
+
         let withdrawal_session = WithdrawalSession::new(
             master_connection_pool,
-            withdrawal_builder,
+            transaction_builder.clone(),
             withdrawal_client,
         );
 
         // Add sessions type the verifier network can process
-        let sessions: HashMap<SessionType, Box<dyn ISession>> = [(
+        let sessions: HashMap<SessionType, Arc<dyn ISession>> = [(
             SessionType::Withdrawal,
-            Box::new(withdrawal_session) as Box<dyn ISession>,
+            Arc::new(withdrawal_session) as Arc<dyn ISession>,
         )]
         .into_iter()
         .collect();

--- a/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
@@ -46,10 +46,8 @@ impl ViaWithdrawalVerifier {
             .context("Error parse bridge address")?
             .assume_checked();
 
-        let transaction_builder = Arc::new(RwLock::new(TransactionBuilder::new(
-            btc_client.clone(),
-            bridge_address,
-        )?));
+        let transaction_builder =
+            Arc::new(TransactionBuilder::new(btc_client.clone(), bridge_address)?);
 
         let withdrawal_session = WithdrawalSession::new(
             master_connection_pool,

--- a/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use bitcoin::{Address, TapSighashType, Witness};
 use musig2::{CompactSignature, PartialSignature};
 use reqwest::{header, Client, StatusCode};
-use tokio::sync::{watch, RwLock};
+use tokio::sync::watch;
 use via_btc_client::traits::{BitcoinOps, Serializable};
 use via_musig2::{transaction_builder::TransactionBuilder, verify_signature, Signer};
 use via_verifier_dal::{ConnectionPool, Verifier};


### PR DESCRIPTION
## What ❔

- Add transactions utxo manager that allows to create chained transactions with unit tests. 
- Refactor the withdrawal builder logic to create transaction builder that can be used to create generic transactions.
- Refactor node verifier and coordinator initialization.

## Why ❔

This PR is required for the Rollback session, as we need to be able to create chained transactions and avoid code duplicate when building a transaction.

## Testing
###  Musig2 unit tests
![Screenshot from 2025-02-18 11-37-18](https://github.com/user-attachments/assets/f7ba29b6-787f-4baf-97ee-6be37fdbf8e8)

### Executing a withdrawal
![Screenshot from 2025-02-18 10-22-37](https://github.com/user-attachments/assets/8b868844-64b0-4abb-be3b-1e0bb82ebc8f)


## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
