### PR TITLE
Refactor/via improve error messages

### DIFF
--- a/core/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/core/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -98,8 +98,7 @@ impl ViaBtcInscriptionManager {
                         .get_client()
                         .await
                         .fetch_block_height()
-                        .await
-                        .context("context")?;
+                        .await?;
 
                     if last_inscription_history.sent_at_block + BLOCK_RESEND as i64
                         > current_block as i64
@@ -165,22 +164,18 @@ impl ViaBtcInscriptionManager {
             .get_client()
             .await
             .fetch_block_height()
-            .await
-            .context("Error to fetch current block number")? as i64;
+            .await? as i64;
 
         let input =
             InscriptionMessage::from_bytes(&tx.inscription_message.clone().unwrap_or_default());
 
-        let inscribe_info = self
-            .inscriber
-            .inscribe(input)
-            .await
-            .context("Sent inscription tx")?;
+        let inscribe_info = self.inscriber.inscribe(input).await?;
 
-        let signed_commit_tx =
-            serialize(&inscribe_info.final_commit_tx.tx).context("Serilize the commit tx")?;
-        let signed_reveal_tx =
-            serialize(&inscribe_info.final_reveal_tx.tx).context("Serilize the reveal tx")?;
+        let signed_commit_tx = serialize(&inscribe_info.final_commit_tx.tx)
+            .with_context(|| format!("Error serializing the commit tx"))?;
+
+        let signed_reveal_tx = serialize(&inscribe_info.final_reveal_tx.tx)
+            .with_context(|| format!("Error serializing the reveal tx"))?;
 
         let actual_fees = inscribe_info.reveal_tx_output_info._reveal_fee
             + inscribe_info.commit_tx_output_info.commit_tx_fee;

--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -3,7 +3,6 @@ mod metrics;
 
 use std::time::Duration;
 
-use anyhow::Context as _;
 use tokio::sync::watch;
 // re-export via_btc_client types
 pub use via_btc_client::types::BitcoinNetwork;
@@ -106,8 +105,7 @@ impl BtcWatch {
             Some(block) => block.0.saturating_sub(1),
             None => indexer
                 .fetch_block_height()
-                .await
-                .context("cannot get current Bitcoin block")?
+                .await?
                 .saturating_sub(btc_blocks_lag as u128) as u32, // TODO: remove cast
         };
 

--- a/via_verifier/lib/verifier_dal/src/via_btc_sender_dal.rs
+++ b/via_verifier/lib/verifier_dal/src/via_btc_sender_dal.rs
@@ -179,7 +179,7 @@ impl ViaBtcSenderDal<'_, '_> {
             .storage
             .start_transaction()
             .await
-            .context("start_transaction")?;
+            .with_context(|| "start_transaction")?;
 
         sqlx::query!(
             r#"
@@ -210,6 +210,9 @@ impl ViaBtcSenderDal<'_, '_> {
         .execute(transaction.conn())
         .await?;
 
-        transaction.commit().await.context("commit()")
+        transaction
+            .commit()
+            .await
+            .with_context(|| "Error commit and confirm transaction")
     }
 }

--- a/via_verifier/lib/via_da_client/src/pubdata.rs
+++ b/via_verifier/lib/via_da_client/src/pubdata.rs
@@ -41,7 +41,8 @@ impl Pubdata {
         // Decode user L2->L1 logs
         let num_user_logs = cursor
             .read_u32::<BigEndian>()
-            .context("Failed to decode num user logs")? as usize;
+            .with_context(|| "Failed to decode num user logs")?
+            as usize;
         for _ in 0..num_user_logs {
             let log = L1MessengerL2ToL1Log::decode_packed(&mut cursor)?;
             user_logs.push(log);
@@ -54,7 +55,7 @@ impl Pubdata {
             let mut message = vec![0u8; message_len];
             cursor
                 .read_exact(&mut message)
-                .context("Read l2 to l1 message")?;
+                .with_context(|| "Error read l2 to l1 message")?;
             l2_to_l1_messages.push(message);
         }
 

--- a/via_verifier/lib/via_da_client/src/types.rs
+++ b/via_verifier/lib/via_da_client/src/types.rs
@@ -64,30 +64,34 @@ impl L1MessengerL2ToL1Log {
 
     pub fn decode_packed<R: Read>(reader: &mut R) -> anyhow::Result<Self> {
         // Read `l2_shard_id` (1 byte)
-        let l2_shard_id = reader.read_u8().context("Failed to read l2_shard_id")?;
+        let l2_shard_id = reader
+            .read_u8()
+            .with_context(|| "Failed to read l2_shard_id")?;
 
         // Read `is_service` (1 byte, a boolean stored as 0 or 1)
-        let is_service_byte = reader.read_u8().context("Failed to read is_service byte")?;
+        let is_service_byte = reader
+            .read_u8()
+            .with_context(|| "Failed to read is_service byte")?;
         let is_service = is_service_byte != 0; // 0 -> false, non-zero -> true
 
         // Read `tx_number_in_block` (2 bytes, u16)
         let tx_number_in_block = reader
             .read_u16::<BigEndian>()
-            .context("Failed to read tx_number_in_block")?;
+            .with_context(|| "Failed to read tx_number_in_block")?;
 
         // Read `sender` (address is 20 bytes)
         let mut sender_bytes = [0u8; 20];
         reader
             .read_exact(&mut sender_bytes)
-            .context("Failed to read sender address")?;
+            .with_context(|| "Failed to read sender address")?;
         let sender = Address::from(sender_bytes);
 
         // Read `key` (U256 is 32 bytes)
-        let key_bytes = _read_bytes(reader, 32).context("Failed to read key bytes")?;
+        let key_bytes = _read_bytes(reader, 32).with_context(|| "Failed to read key bytes")?;
         let key = u256_to_h256(U256::from_big_endian(&key_bytes));
 
         // Read `value` (U256 is 32 bytes)
-        let value_bytes = _read_bytes(reader, 32).context("Failed to read value bytes")?;
+        let value_bytes = _read_bytes(reader, 32).with_context(|| "Failed to read value bytes")?;
         let value = u256_to_h256(U256::from_big_endian(&value_bytes));
 
         Ok(L1MessengerL2ToL1Log {

--- a/via_verifier/lib/via_musig2/src/transaction_builder.rs
+++ b/via_verifier/lib/via_musig2/src/transaction_builder.rs
@@ -179,7 +179,7 @@ impl TransactionBuilder {
         }
         let sighash = sighash_cache
             .taproot_key_spend_signature_hash(0, &Prevouts::All(&txout_list), sighash_type)
-            .context("Error taproot_key_spend_signature_hash")?;
+            .with_context(|| "Error taproot_key_spend_signature_hash")?;
 
         Ok(sighash)
     }

--- a/via_verifier/lib/via_withdrawal_client/src/withdraw.rs
+++ b/via_verifier/lib/via_withdrawal_client/src/withdraw.rs
@@ -28,9 +28,9 @@ pub fn parse_l2_withdrawal_message(
     // The address bytes represent the l1 receiver
     let address_bytes = &l2_to_l1_message[4..4 + address_size];
     let address_str =
-        String::from_utf8(address_bytes.to_vec()).context("Parse address to string")?;
+        String::from_utf8(address_bytes.to_vec()).with_context(|| "Parse address to string")?;
     let address = BitcoinAddress::from_str(&address_str)
-        .context("parse bitcoin address")?
+        .with_context(|| "parse bitcoin address")?
         .require_network(network)?;
 
     // The last 32 bytes represent the amount (uint256)

--- a/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -101,8 +101,7 @@ impl ViaBtcInscriptionManager {
                         .get_client()
                         .await
                         .fetch_block_height()
-                        .await
-                        .context("context")?;
+                        .await?;
 
                     if last_inscription_history.sent_at_block + BLOCK_RESEND as i64
                         > current_block as i64
@@ -169,22 +168,18 @@ impl ViaBtcInscriptionManager {
             .get_client()
             .await
             .fetch_block_height()
-            .await
-            .context("Error to fetch current block number")? as i64;
+            .await? as i64;
 
         let input =
             InscriptionMessage::from_bytes(&tx.inscription_message.clone().unwrap_or_default());
 
-        let inscribe_info = self
-            .inscriber
-            .inscribe(input)
-            .await
-            .context("Sent inscription tx")?;
+        let inscribe_info = self.inscriber.inscribe(input).await?;
 
-        let signed_commit_tx =
-            serialize(&inscribe_info.final_commit_tx.tx).context("Serilize the commit tx")?;
-        let signed_reveal_tx =
-            serialize(&inscribe_info.final_reveal_tx.tx).context("Serilize the reveal tx")?;
+        let signed_commit_tx = serialize(&inscribe_info.final_commit_tx.tx)
+            .with_context(|| format!("Error serializing the commit tx"))?;
+
+        let signed_reveal_tx = serialize(&inscribe_info.final_reveal_tx.tx)
+            .with_context(|| format!("Error serializing the reveal tx"))?;
 
         let actual_fees = inscribe_info.reveal_tx_output_info._reveal_fee
             + inscribe_info.commit_tx_output_info.commit_tx_fee;

--- a/via_verifier/node/via_btc_sender/src/btc_vote_inscription.rs
+++ b/via_verifier/node/via_btc_sender/src/btc_vote_inscription.rs
@@ -67,8 +67,7 @@ impl ViaVoteInscription {
                     InscriptionMessage::to_bytes(&inscription_message),
                     0,
                 )
-                .await
-                .context("Via save btc inscriptions request")?;
+                .await?;
 
             transaction
                 .via_block_dal()
@@ -77,8 +76,7 @@ impl ViaVoteInscription {
                     inscription_request.id,
                     ViaVerifierBtcInscriptionRequestType::VoteOnchain,
                 )
-                .await
-                .context("Via set inscription request id")?;
+                .await?;
             transaction.commit().await?;
         }
         Ok(())
@@ -137,6 +135,6 @@ impl ViaVoteInscription {
         }
         let mut reversed_bytes = h256_bytes.to_vec();
         reversed_bytes.reverse();
-        Txid::from_slice(&reversed_bytes).context("Failed to convert H256 to Txid")
+        Txid::from_slice(&reversed_bytes).with_context(|| "Failed to convert H256 to Txid")
     }
 }

--- a/via_verifier/node/via_btc_watch/src/lib.rs
+++ b/via_verifier/node/via_btc_watch/src/lib.rs
@@ -3,7 +3,7 @@ mod metrics;
 
 use std::time::Duration;
 
-use anyhow::Context as _;
+use anyhow::Context;
 use tokio::sync::watch;
 // re-export via_btc_client types
 pub use via_btc_client::types::BitcoinNetwork;
@@ -102,7 +102,7 @@ impl VerifierBtcWatch {
             None => indexer
                 .fetch_block_height()
                 .await
-                .context("cannot get current Bitcoin block")?
+                .with_context(|| "Error to get current Bitcoin block")?
                 .saturating_sub(btc_blocks_lag as u128) as u32, // TODO: remove cast
         };
 

--- a/via_verifier/node/via_verifier_coordinator/src/auth.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/auth.rs
@@ -9,9 +9,11 @@ pub fn sign_request<T: Serialize>(payload: &T, secret_key: &SecretKey) -> anyhow
     let secp = Secp256k1::new();
 
     // Serialize and hash the payload.
-    let payload_bytes = serde_json::to_vec(payload).context("Failed to serialize payload")?;
+    let payload_bytes =
+        serde_json::to_vec(payload).with_context(|| "Failed to serialize payload")?;
     let hash = Sha256::digest(&payload_bytes);
-    let message = Message::from_digest_slice(hash.as_ref()).context("Hash is not 32 bytes")?;
+    let message =
+        Message::from_digest_slice(hash.as_ref()).with_context(|| "Hash is not 32 bytes")?;
 
     // Sign the message.
     let sig = secp.sign_ecdsa(&message, secret_key);
@@ -31,14 +33,16 @@ pub fn verify_signature<T: Serialize>(
     // Decode the base64 signature.
     let sig_bytes = base64::engine::general_purpose::STANDARD
         .decode(signature_b64)
-        .context("Failed to decode base64 signature")?;
+        .with_context(|| "Failed to decode base64 signature")?;
     let sig = bitcoin::secp256k1::ecdsa::Signature::from_compact(&sig_bytes)
-        .context("Failed to parse signature from compact form")?;
+        .with_context(|| "Failed to parse signature from compact form")?;
 
     // Serialize and hash the payload.
-    let payload_bytes = serde_json::to_vec(payload).context("Failed to serialize payload")?;
+    let payload_bytes =
+        serde_json::to_vec(payload).with_context(|| "Failed to serialize payload")?;
     let hash = Sha256::digest(&payload_bytes);
-    let message = Message::from_digest_slice(hash.as_ref()).context("Hash is not 32 bytes")?;
+    let message =
+        Message::from_digest_slice(hash.as_ref()).with_context(|| "Hash is not 32 bytes")?;
 
     // Verify the signature.
     Ok(secp.verify_ecdsa(&message, &sig, public_key).is_ok())

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api.rs
@@ -27,7 +27,7 @@ pub async fn start_coordinator_server(
 
     let listener = tokio::net::TcpListener::bind(bind_address)
         .await
-        .context("Cannot bind to the specified address")?;
+        .with_context(|| "Cannot bind to the specified address")?;
     axum::serve(listener, api)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
@@ -36,7 +36,7 @@ pub async fn start_coordinator_server(
             tracing::info!("Stop signal received, coordinator server is shutting down");
         })
         .await
-        .context("coordinator handler server failed")?;
+        .with_context(|| "coordinator handler server failed")?;
     tracing::info!("coordinator handler server shut down");
     Ok(())
 }

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api_decl.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api_decl.rs
@@ -41,7 +41,7 @@ impl RestApi {
         };
 
         let bridge_address = Address::from_str(config.bridge_address_str.as_str())
-            .context("Error parse bridge address")?
+            .with_context(|| "Error parse bridge address")?
             .assume_checked();
 
         let transaction_builder =

--- a/via_verifier/node/via_verifier_coordinator/src/sessions/withdrawal.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/sessions/withdrawal.rs
@@ -68,7 +68,7 @@ impl ISession for WithdrawalSession {
                 .withdrawal_client
                 .get_withdrawals(blob_id)
                 .await
-                .context("Error to get withdrawals from DA")?;
+                .with_context(|| "Error to get withdrawals from DA")?;
             raw_proof_tx_id = proof_tx_id.clone();
 
             if !withdrawals.is_empty() {
@@ -91,8 +91,7 @@ impl ISession for WithdrawalSession {
                         &raw_proof_tx_id,
                         *batch_number,
                     )
-                    .await
-                    .context("Error to mark a vote transaction as processed")?;
+                    .await?;
                 tracing::info!(
                     "There is no withdrawal to process in l1 batch {}",
                     batch_number.clone()
@@ -110,7 +109,7 @@ impl ISession for WithdrawalSession {
             withdrawals_to_process.len()
         );
 
-        let proof_txid = h256_to_txid(&raw_proof_tx_id).context("Invalid proof tx id")?;
+        let proof_txid = h256_to_txid(&raw_proof_tx_id).with_context(|| "Invalid proof tx id")?;
         let unsigned_tx = self
             .create_unsigned_tx(withdrawals_to_process, proof_txid)
             .await
@@ -127,7 +126,7 @@ impl ISession for WithdrawalSession {
         }
         let sighash = sighash_cache
             .taproot_key_spend_signature_hash(0, &Prevouts::All(&txout_list), sighash_type)
-            .context("Error taproot_key_spend_signature_hash")?;
+            .with_context(|| "Error taproot_key_spend_signature_hash")?;
 
         tracing::info!("New withdrawal session found for l1 batch {l1_batch_number}");
 

--- a/via_verifier/node/via_verifier_coordinator/src/utils.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/utils.rs
@@ -15,7 +15,7 @@ pub fn get_signer(
 ) -> anyhow::Result<Signer> {
     let private_key = PrivateKey::from_wif(private_key_wif)?;
     let secret_key = SecretKey::from_byte_array(&private_key.inner.secret_bytes())
-        .context("Error to compute the coordinator sk")?;
+        .with_context(|| "Error to compute the coordinator sk")?;
     let secp = Secp256k1::new();
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 
@@ -38,7 +38,7 @@ pub fn get_signer(
 pub fn decode_signature(signature: String) -> anyhow::Result<PartialSignature> {
     let decoded_sig = base64::engine::general_purpose::STANDARD
         .decode(&signature)
-        .context("error to decode signature")?;
+        .with_context(|| "Error to decode signature")?;
     Ok(PartialSignature::from_slice(&decoded_sig)?)
 }
 
@@ -65,7 +65,7 @@ pub fn encode_nonce(signer_index: usize, nonce: PubNonce) -> anyhow::Result<Nonc
 pub fn decode_nonce(nonce_pair: NoncePair) -> anyhow::Result<PubNonce> {
     let decoded_nonce = base64::engine::general_purpose::STANDARD
         .decode(&nonce_pair.nonce)
-        .context("error to encode nonde")?;
+        .with_context(|| "Error to encode nonce")?;
     let pub_nonce = PubNonce::from_bytes(&decoded_nonce)?;
     Ok(pub_nonce)
 }
@@ -77,5 +77,5 @@ pub(crate) fn h256_to_txid(h256_bytes: &[u8]) -> anyhow::Result<Txid> {
     }
     let mut reversed_bytes = h256_bytes.to_vec();
     reversed_bytes.reverse();
-    Txid::from_slice(&reversed_bytes).context("Failed to convert H256 to Txid")
+    Txid::from_slice(&reversed_bytes).with_context(|| "Failed to convert H256 to Txid")
 }

--- a/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
@@ -43,7 +43,7 @@ impl ViaWithdrawalVerifier {
         )?;
 
         let bridge_address = Address::from_str(config.bridge_address_str.as_str())
-            .context("Error parse bridge address")?
+            .with_context(|| "Error parse bridge address")?
             .assume_checked();
 
         let transaction_builder =

--- a/via_verifier/node/via_zk_verifier/src/lib.rs
+++ b/via_verifier/node/via_zk_verifier/src/lib.rs
@@ -107,7 +107,7 @@ impl ViaVerifier {
             tracing::info!("New non executed block ready to be processed");
 
             raw_tx_id.reverse();
-            let proof_txid = bytes_to_txid(&raw_tx_id).context("Failed to parse tx_id")?;
+            let proof_txid = bytes_to_txid(&raw_tx_id).with_context(|| "Failed to parse tx_id")?;
             tracing::info!("trying to get proof_txid: {}", proof_txid);
             let proof_msgs = self.indexer.parse_transaction(&proof_txid).await?;
             let proof_msg = self.expect_single_msg(&proof_msgs, "ProofDAReference")?;
@@ -254,7 +254,7 @@ impl ViaVerifier {
             .da_client
             .get_inclusion_data(&proof_msg.input.blob_id)
             .await
-            .context("Failed to get blob")?
+            .with_context(|| "Failed to fetch the blob")?
             .ok_or_else(|| anyhow::anyhow!("Blob not found"))?;
         let batch_tx_id = proof_msg.input.l1_batch_reveal_txid;
 
@@ -270,7 +270,7 @@ impl ViaVerifier {
             .da_client
             .get_inclusion_data(&batch_msg.input.blob_id)
             .await
-            .context("Failed to get blob")?
+            .with_context(|| "Failed to fetch the blob")?
             .ok_or_else(|| anyhow::anyhow!("Blob not found"))?;
         let hash = batch_msg.input.l1_batch_hash;
 


### PR DESCRIPTION
## What ❔
- Improve the error handling by using `with_context` instead of `context` to avoid override the original error. 
- Remove not required `.context(...)`

## Why ❔
When use `context` the original error is override and it becomes hard to debug
