### PR TITLE
Resolve Dust Limit in inscription tx for mainnet

### DIFF
--- a/core/lib/via_btc_client/src/inscriber/mod.rs
+++ b/core/lib/via_btc_client/src/inscriber/mod.rs
@@ -663,7 +663,7 @@ impl Inscriber {
             .p2wpkh_signature_hash(
                 REVEAL_TX_FEE_INPUT_INDEX as usize,
                 script_pubkey,
-                input.unlock_value,
+                input.prev_outs[REVEAL_TX_FEE_INPUT_INDEX as usize].value,
                 sighash_type,
             )
             .context("Failed to create sighash")?;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-nightly-2024-08-01
+[toolchain]
+channel = "nightly-2024-08-01"


### PR DESCRIPTION
## What ❔

Resolve Dust Limit in inscription transaction for mainnet


`const P2TR_DUST_LIMIT: Amount = Amount::from_sat(330);`

**Reference:** 
https://bitcointalk.org/index.php?topic=5453107.msg62262343#msg62262343
https://bitcoin.stackexchange.com/questions/10986/what-is-meant-by-bitcoin-dust

**commit tx** 
![Screenshot 2025-03-05 at 8 31 12 PM](https://github.com/user-attachments/assets/cd1b6d00-f83b-4993-aa6a-19c921ef4e98)

**reveal tx**
![Screenshot 2025-03-05 at 8 31 18 PM](https://github.com/user-attachments/assets/f22dde6c-761c-4fac-aaf9-f43602d62b03)

