### PR TITLE
Feat/via external node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9621,6 +9621,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "via_external_node"
+version = "24.22.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "async-trait",
+ "clap 4.5.16",
+ "envy",
+ "futures 0.3.30",
+ "rustc_version 0.4.0",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "test-casing",
+ "tokio",
+ "tracing",
+ "url",
+ "vise",
+ "zksync_block_reverter",
+ "zksync_commitment_generator",
+ "zksync_concurrency",
+ "zksync_config",
+ "zksync_consensus_crypto",
+ "zksync_consensus_roles",
+ "zksync_consistency_checker",
+ "zksync_contracts",
+ "zksync_core_leftovers",
+ "zksync_dal",
+ "zksync_db_connection",
+ "zksync_eth_client",
+ "zksync_eth_sender",
+ "zksync_health_check",
+ "zksync_l1_contract_interface",
+ "zksync_metadata_calculator",
+ "zksync_node_api_server",
+ "zksync_node_consensus",
+ "zksync_node_db_pruner",
+ "zksync_node_fee_model",
+ "zksync_node_framework",
+ "zksync_node_genesis",
+ "zksync_node_sync",
+ "zksync_object_store",
+ "zksync_protobuf_config",
+ "zksync_reorg_detector",
+ "zksync_shared_metrics",
+ "zksync_snapshots_applier",
+ "zksync_state",
+ "zksync_state_keeper",
+ "zksync_storage",
+ "zksync_types",
+ "zksync_utils",
+ "zksync_vlog",
+ "zksync_web3_decl",
+]
+
+[[package]]
 name = "via_fee_model"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ members = [
     "core/lib/via_da_clients",
     "core/node/via_block_reverter",
     "core/bin/via_block_reverter",
+    "core/bin/via_external_node",
 
     # VIA Verifier
     "via_verifier/bin/verifier_server",

--- a/core/bin/via_external_node/Cargo.toml
+++ b/core/bin/via_external_node/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+name = "via_external_node"
+description = "Non-validator Via node"
+version = "24.22.0" # x-release-please-version
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
+
+[dependencies]
+zksync_core_leftovers.workspace = true
+zksync_commitment_generator.workspace = true
+zksync_dal.workspace = true
+zksync_db_connection.workspace = true
+zksync_config.workspace = true
+zksync_protobuf_config.workspace = true
+zksync_eth_client.workspace = true
+zksync_storage.workspace = true
+zksync_utils.workspace = true
+zksync_state.workspace = true
+zksync_contracts.workspace = true
+zksync_l1_contract_interface.workspace = true
+zksync_snapshots_applier.workspace = true
+zksync_object_store.workspace = true
+zksync_health_check.workspace = true
+zksync_web3_decl.workspace = true
+zksync_types.workspace = true
+zksync_block_reverter.workspace = true
+zksync_shared_metrics.workspace = true
+zksync_node_genesis.workspace = true
+zksync_node_fee_model.workspace = true
+zksync_node_db_pruner.workspace = true
+zksync_eth_sender.workspace = true
+zksync_state_keeper.workspace = true
+zksync_reorg_detector.workspace = true
+zksync_consistency_checker.workspace = true
+zksync_metadata_calculator.workspace = true
+zksync_node_sync.workspace = true
+zksync_node_api_server.workspace = true
+zksync_node_consensus.workspace = true
+zksync_node_framework.workspace = true
+zksync_vlog.workspace = true
+
+zksync_concurrency.workspace = true
+zksync_consensus_roles.workspace = true
+zksync_consensus_crypto.workspace = true
+vise.workspace = true
+
+async-trait.workspace = true
+anyhow.workspace = true
+tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
+serde = { workspace = true, features = ["derive"] }
+envy.workspace = true
+url.workspace = true
+clap = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+semver.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+assert_matches.workspace = true
+tempfile.workspace = true
+test-casing.workspace = true
+
+[build-dependencies]
+rustc_version.workspace = true

--- a/core/bin/via_external_node/README.md
+++ b/core/bin/via_external_node/README.md
@@ -1,0 +1,45 @@
+# ZKsync External Node
+
+This application is a read replica that can sync from the main node and serve the state locally.
+
+Note: this README is under construction.
+
+## Local development
+
+This section describes how to run the external node locally
+
+### Configuration
+
+Right now, external node requires all the configuration parameters that are required for the main node. It also has one
+unique parameter: `API_WEB3_JSON_RPC_MAIN_NODE_URL` -- the address of the main node to fetch the state from.
+
+The easiest way to see everything that is used is to compile the `ext-node` config and see the contents of the resulting
+`.env` file.
+
+Note: not all the config values from the main node are actually used, so this is temporary, and in the future external
+node would require a much smaller set of config variables.
+
+To change the configuration, edit the `etc/env/chains/ext-node.toml`, add the overrides from the `base` config if you
+need any. Remove `etc/env/chains/ext-node.env`, if it exists. On the next launch of the external node, new config would
+be compiled and will be written to the `etc/env/chains/ext-node.env` file.
+
+### Running
+
+To run the binary:
+
+```sh
+ZKSYNC_ENV=ext-node zk f cargo run --release --bin zksync_external_node
+```
+
+### Clearing the state
+
+This command will reset the Postgres and RocksDB databases used by the external node:
+
+```sh
+ZKSYNC_ENV=ext-node zk db reset && rm -r $ZKSYNC_HOME/en_db
+```
+
+## Building & pushing
+
+Use the `External Node - Build & push docker image` GitHub action. By default, it'll publish the image with `latest2.0`
+tag.

--- a/core/bin/via_external_node/src/config/mod.rs
+++ b/core/bin/via_external_node/src/config/mod.rs
@@ -1,0 +1,1422 @@
+use std::{
+    env,
+    ffi::OsString,
+    num::{NonZeroU32, NonZeroU64, NonZeroUsize},
+    path::PathBuf,
+    time::Duration,
+};
+
+use anyhow::Context;
+use serde::Deserialize;
+use zksync_config::{
+    configs::{
+        api::{MaxResponseSize, MaxResponseSizeOverrides},
+        consensus::{ConsensusConfig, ConsensusSecrets},
+        en_config::ENConfig,
+        GeneralConfig, Secrets,
+    },
+    ObjectStoreConfig,
+};
+use zksync_consensus_crypto::TextFmt;
+use zksync_consensus_roles as roles;
+use zksync_core_leftovers::temp_config_store::{decode_yaml_repr, read_yaml_repr};
+#[cfg(test)]
+use zksync_dal::{ConnectionPool, Core};
+use zksync_metadata_calculator::MetadataCalculatorRecoveryConfig;
+use zksync_node_api_server::{
+    tx_sender::TxSenderConfig,
+    web3::{state::InternalApiConfig, Namespace},
+};
+use zksync_protobuf_config::proto;
+use zksync_snapshots_applier::SnapshotsApplierConfig;
+use zksync_types::{
+    api::BridgeAddresses, commitment::L1BatchCommitmentMode, url::SensitiveUrl, Address,
+    L1BatchNumber, L1ChainId, L2ChainId, SLChainId, ETHEREUM_ADDRESS,
+};
+use zksync_web3_decl::{
+    client::{DynClient, L2},
+    error::ClientRpcContext,
+    jsonrpsee::{core::ClientError, types::error::ErrorCode},
+    namespaces::{EnNamespaceClient, ZksNamespaceClient},
+};
+
+use crate::config::observability::ObservabilityENConfig;
+
+pub(crate) mod observability;
+#[cfg(test)]
+mod tests;
+
+macro_rules! load_optional_config_or_default {
+    ($config:expr, $($name:ident).+, $default:ident) => {
+        $config
+            .as_ref()
+            .map(|a| a.$($name).+.map(|a| a.try_into())).flatten().transpose()?
+            .unwrap_or_else(Self::$default)
+    };
+}
+
+macro_rules! load_config_or_default {
+    ($config:expr, $($name:ident).+, $default:ident) => {
+        $config
+            .as_ref()
+            .map(|a| a.$($name).+.clone().try_into()).transpose()?
+            .unwrap_or_else(Self::$default)
+    };
+}
+
+macro_rules! load_config {
+    ($config:expr, $($name:ident).+) => {
+        $config
+            .as_ref()
+            .map(|a| a.$($name).+.clone().map(|a| a.try_into())).flatten().transpose()?
+    };
+}
+
+const BYTES_IN_MEGABYTE: usize = 1_024 * 1_024;
+
+/// Encapsulation of configuration source with a mock implementation used in tests.
+trait ConfigurationSource: 'static {
+    type Vars<'a>: Iterator<Item = (OsString, OsString)> + 'a;
+
+    fn vars(&self) -> Self::Vars<'_>;
+
+    fn var(&self, name: &str) -> Option<String>;
+}
+
+#[derive(Debug)]
+struct Environment;
+
+impl ConfigurationSource for Environment {
+    type Vars<'a> = env::VarsOs;
+
+    fn vars(&self) -> Self::Vars<'_> {
+        env::vars_os()
+    }
+
+    fn var(&self, name: &str) -> Option<String> {
+        env::var(name).ok()
+    }
+}
+
+/// This part of the external node config is fetched directly from the main node.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RemoteENConfig {
+    pub bridgehub_proxy_addr: Option<Address>,
+    pub state_transition_proxy_addr: Option<Address>,
+    pub transparent_proxy_admin_addr: Option<Address>,
+    /// Should not be accessed directly. Use [`ExternalNodeConfig::diamond_proxy_address`] instead.
+    diamond_proxy_addr: Address,
+    // While on L1 shared bridge and legacy bridge are different contracts with different addresses,
+    // the `l2_erc20_bridge_addr` and `l2_shared_bridge_addr` are basically the same contract, but with
+    // a different name, with names adapted only for consistency.
+    pub l1_shared_bridge_proxy_addr: Option<Address>,
+    pub l2_shared_bridge_addr: Option<Address>,
+    pub l1_erc20_bridge_proxy_addr: Option<Address>,
+    pub l2_erc20_bridge_addr: Option<Address>,
+    pub l1_weth_bridge_addr: Option<Address>,
+    pub l2_weth_bridge_addr: Option<Address>,
+    pub l2_testnet_paymaster_addr: Option<Address>,
+    pub base_token_addr: Address,
+    pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
+    pub dummy_verifier: bool,
+}
+
+impl RemoteENConfig {
+    pub async fn fetch(client: &DynClient<L2>) -> anyhow::Result<Self> {
+        let bridges = client
+            .get_bridge_contracts()
+            .rpc_context("get_bridge_contracts")
+            .await?;
+        let l2_testnet_paymaster_addr = client
+            .get_testnet_paymaster()
+            .rpc_context("get_testnet_paymaster")
+            .await?;
+        let genesis = client.genesis_config().rpc_context("genesis").await.ok();
+        let ecosystem_contracts = client
+            .get_ecosystem_contracts()
+            .rpc_context("ecosystem_contracts")
+            .await
+            .ok();
+        let diamond_proxy_addr = client
+            .get_main_contract()
+            .rpc_context("get_main_contract")
+            .await?;
+        let base_token_addr = match client.get_base_token_l1_address().await {
+            Err(ClientError::Call(err))
+                if [
+                    ErrorCode::MethodNotFound.code(),
+                    // This what `Web3Error::NotImplemented` gets
+                    // `casted` into in the `api` server.
+                    ErrorCode::InternalError.code(),
+                ]
+                .contains(&(err.code())) =>
+            {
+                // This is the fallback case for when the EN tries to interact
+                // with a node that does not implement the `zks_baseTokenL1Address` endpoint.
+                ETHEREUM_ADDRESS
+            }
+            response => response.context("Failed to fetch base token address")?,
+        };
+
+        // These two config variables should always have the same value.
+        // TODO(EVM-578): double check and potentially forbid both of them being `None`.
+        let l2_erc20_default_bridge = bridges
+            .l2_erc20_default_bridge
+            .or(bridges.l2_shared_default_bridge);
+        let l2_erc20_shared_bridge = bridges
+            .l2_shared_default_bridge
+            .or(bridges.l2_erc20_default_bridge);
+
+        if let (Some(legacy_addr), Some(shared_addr)) =
+            (l2_erc20_default_bridge, l2_erc20_shared_bridge)
+        {
+            if legacy_addr != shared_addr {
+                panic!("L2 erc20 bridge address and L2 shared bridge address are different.");
+            }
+        }
+
+        Ok(Self {
+            bridgehub_proxy_addr: ecosystem_contracts.as_ref().map(|a| a.bridgehub_proxy_addr),
+            state_transition_proxy_addr: ecosystem_contracts
+                .as_ref()
+                .map(|a| a.state_transition_proxy_addr),
+            transparent_proxy_admin_addr: ecosystem_contracts
+                .as_ref()
+                .map(|a| a.transparent_proxy_admin_addr),
+            diamond_proxy_addr,
+            l2_testnet_paymaster_addr,
+            l1_erc20_bridge_proxy_addr: bridges.l1_erc20_default_bridge,
+            l2_erc20_bridge_addr: l2_erc20_default_bridge,
+            l1_shared_bridge_proxy_addr: bridges.l1_shared_default_bridge,
+            l2_shared_bridge_addr: l2_erc20_shared_bridge,
+            l1_weth_bridge_addr: bridges.l1_weth_bridge,
+            l2_weth_bridge_addr: bridges.l2_weth_bridge,
+            base_token_addr,
+            l1_batch_commit_data_generator_mode: genesis
+                .as_ref()
+                .map(|a| a.l1_batch_commit_data_generator_mode)
+                .unwrap_or_default(),
+            dummy_verifier: genesis
+                .as_ref()
+                .map(|a| a.dummy_verifier)
+                .unwrap_or_default(),
+        })
+    }
+
+    #[cfg(test)]
+    fn mock() -> Self {
+        Self {
+            bridgehub_proxy_addr: None,
+            state_transition_proxy_addr: None,
+            transparent_proxy_admin_addr: None,
+            diamond_proxy_addr: Address::repeat_byte(1),
+            l1_erc20_bridge_proxy_addr: Some(Address::repeat_byte(2)),
+            l2_erc20_bridge_addr: Some(Address::repeat_byte(3)),
+            l2_weth_bridge_addr: None,
+            l2_testnet_paymaster_addr: None,
+            base_token_addr: Address::repeat_byte(4),
+            l1_shared_bridge_proxy_addr: Some(Address::repeat_byte(5)),
+            l1_weth_bridge_addr: None,
+            l2_shared_bridge_addr: Some(Address::repeat_byte(6)),
+            l1_batch_commit_data_generator_mode: L1BatchCommitmentMode::Rollup,
+            dummy_verifier: true,
+        }
+    }
+}
+
+/// This part of the external node config is completely optional to provide.
+/// It can tweak limits of the API, delay intervals of certain components, etc.
+/// If any of the fields are not provided, the default values will be used.
+#[derive(Debug, Deserialize)]
+pub(crate) struct OptionalENConfig {
+    // User-facing API limits
+    /// Max possible limit of filters to be in the API state at once.
+    #[serde(default = "OptionalENConfig::default_filters_limit")]
+    pub filters_limit: usize,
+    /// Max possible limit of subscriptions to be in the API state at once.
+    #[serde(default = "OptionalENConfig::default_subscriptions_limit")]
+    pub subscriptions_limit: usize,
+    /// Max possible limit of entities to be requested via API at once.
+    #[serde(default = "OptionalENConfig::default_req_entities_limit")]
+    pub req_entities_limit: usize,
+    /// Max possible size of an ABI-encoded transaction supplied to `eth_sendRawTransaction`.
+    #[serde(
+        alias = "max_tx_size",
+        default = "OptionalENConfig::default_max_tx_size_bytes"
+    )]
+    pub max_tx_size_bytes: usize,
+    /// Max number of cache misses during one VM execution. If the number of cache misses exceeds this value, the API server panics.
+    /// This is a temporary solution to mitigate API request resulting in thousands of DB queries.
+    pub vm_execution_cache_misses_limit: Option<usize>,
+    /// Limit for fee history block range.
+    #[serde(default = "OptionalENConfig::default_fee_history_limit")]
+    pub fee_history_limit: u64,
+    /// Maximum number of requests in a single batch JSON RPC request. Default is 500.
+    #[serde(default = "OptionalENConfig::default_max_batch_request_size")]
+    pub max_batch_request_size: usize,
+    /// Maximum response body size in MiBs. Default is 10 MiB.
+    #[serde(default = "OptionalENConfig::default_max_response_body_size_mb")]
+    pub max_response_body_size_mb: usize,
+    /// Method-specific overrides in MiBs for the maximum response body size.
+    #[serde(default = "MaxResponseSizeOverrides::empty")]
+    max_response_body_size_overrides_mb: MaxResponseSizeOverrides,
+
+    // Other API config settings
+    /// Interval between polling DB for Web3 subscriptions.
+    #[serde(
+        alias = "pubsub_polling_interval",
+        default = "OptionalENConfig::default_polling_interval"
+    )]
+    pubsub_polling_interval_ms: u64,
+    /// Tx nonce: how far ahead from the committed nonce can it be.
+    #[serde(default = "OptionalENConfig::default_max_nonce_ahead")]
+    pub max_nonce_ahead: u32,
+    /// Max number of VM instances to be concurrently spawned by the API server.
+    /// This option can be tweaked down if the API server is running out of memory.
+    #[serde(default = "OptionalENConfig::default_vm_concurrency_limit")]
+    pub vm_concurrency_limit: usize,
+    /// Smart contract bytecode cache size for the API server. Default value is 128 MiB.
+    #[serde(default = "OptionalENConfig::default_factory_deps_cache_size_mb")]
+    factory_deps_cache_size_mb: usize,
+    /// Initial writes cache size for the API server. Default value is 32 MiB.
+    #[serde(default = "OptionalENConfig::default_initial_writes_cache_size_mb")]
+    initial_writes_cache_size_mb: usize,
+    /// Latest values cache size in MiBs. The default value is 128 MiB. If set to 0, the latest
+    /// values cache will be disabled.
+    #[serde(default = "OptionalENConfig::default_latest_values_cache_size_mb")]
+    latest_values_cache_size_mb: usize,
+    /// Enabled JSON RPC API namespaces.
+    api_namespaces: Option<Vec<Namespace>>,
+    /// Whether to support HTTP methods that install filters and query filter changes.
+    /// WS methods are unaffected.
+    ///
+    /// When to set this value to `true`:
+    /// Filters are local to the specific node they were created at. Meaning if
+    /// there are multiple nodes behind a load balancer the client cannot reliably
+    /// query the previously created filter as the request might get routed to a
+    /// different node.
+    #[serde(default)]
+    pub filters_disabled: bool,
+    /// Polling period for mempool cache update - how often the mempool cache is updated from the database.
+    /// Default is 50 milliseconds.
+    #[serde(
+        alias = "mempool_cache_update_interval",
+        default = "OptionalENConfig::default_mempool_cache_update_interval_ms"
+    )]
+    pub mempool_cache_update_interval_ms: u64,
+    /// Maximum number of transactions to be stored in the mempool cache.
+    #[serde(default = "OptionalENConfig::default_mempool_cache_size")]
+    pub mempool_cache_size: usize,
+    /// Enables extended tracing of RPC calls. This may negatively impact performance for nodes under high load
+    /// (hundreds or thousands RPS).
+    #[serde(default = "OptionalENConfig::default_extended_api_tracing")]
+    pub extended_rpc_tracing: bool,
+
+    // Health checks
+    /// Time limit in milliseconds to mark a health check as slow and log the corresponding warning.
+    /// If not specified, the default value in the health check crate will be used.
+    healthcheck_slow_time_limit_ms: Option<u64>,
+    /// Time limit in milliseconds to abort a health check and return "not ready" status for the corresponding component.
+    /// If not specified, the default value in the health check crate will be used.
+    healthcheck_hard_time_limit_ms: Option<u64>,
+
+    // Gas estimation config
+    /// The factor by which to scale the gas limit.
+    #[serde(default = "OptionalENConfig::default_estimate_gas_scale_factor")]
+    pub estimate_gas_scale_factor: f64,
+    /// The max possible number of gas that `eth_estimateGas` is allowed to overestimate.
+    #[serde(default = "OptionalENConfig::default_estimate_gas_acceptable_overestimation")]
+    pub estimate_gas_acceptable_overestimation: u32,
+    /// The multiplier to use when suggesting gas price. Should be higher than one,
+    /// otherwise if the L1 prices soar, the suggested gas price won't be sufficient to be included in block.
+    #[serde(default = "OptionalENConfig::default_gas_price_scale_factor")]
+    pub gas_price_scale_factor: f64,
+
+    // Merkle tree config
+    /// Processing delay between processing L1 batches in the Merkle tree.
+    #[serde(
+        alias = "metadata_calculator_delay",
+        default = "OptionalENConfig::default_merkle_tree_processing_delay_ms"
+    )]
+    merkle_tree_processing_delay_ms: u64,
+    /// Maximum number of L1 batches to be processed by the Merkle tree at a time. L1 batches are processed in a bulk
+    /// only if they are readily available (i.e., mostly during node catch-up). Increasing this value reduces the number
+    /// of I/O operations at the cost of requiring more RAM (order of 100 MB / batch).
+    #[serde(
+        alias = "max_blocks_per_tree_batch",
+        alias = "max_l1_batches_per_tree_iter",
+        default = "OptionalENConfig::default_merkle_tree_max_l1_batches_per_iter"
+    )]
+    pub merkle_tree_max_l1_batches_per_iter: usize,
+    /// Maximum number of files concurrently opened by Merkle tree RocksDB. Useful to fit into OS limits; can be used
+    /// as a rudimentary way to control RAM usage of the tree.
+    pub merkle_tree_max_open_files: Option<NonZeroU32>,
+    /// Chunk size for multi-get operations. Can speed up loading data for the Merkle tree on some environments,
+    /// but the effects vary wildly depending on the setup (e.g., the filesystem used).
+    #[serde(default = "OptionalENConfig::default_merkle_tree_multi_get_chunk_size")]
+    pub merkle_tree_multi_get_chunk_size: usize,
+    /// Capacity of the block cache for the Merkle tree RocksDB. Reasonable values range from ~100 MiB to several GiB.
+    /// The default value is 128 MiB.
+    #[serde(default = "OptionalENConfig::default_merkle_tree_block_cache_size_mb")]
+    merkle_tree_block_cache_size_mb: usize,
+    /// If specified, RocksDB indices and Bloom filters will be managed by the block cache, rather than
+    /// being loaded entirely into RAM on the RocksDB initialization. The block cache capacity should be increased
+    /// correspondingly; otherwise, RocksDB performance can significantly degrade.
+    #[serde(default)]
+    pub merkle_tree_include_indices_and_filters_in_block_cache: bool,
+    /// Byte capacity of memtables (recent, non-persisted changes to RocksDB). Setting this to a reasonably
+    /// large value (order of 512 MiB) is helpful for large DBs that experience write stalls.
+    #[serde(default = "OptionalENConfig::default_merkle_tree_memtable_capacity_mb")]
+    merkle_tree_memtable_capacity_mb: usize,
+    /// Timeout to wait for the Merkle tree database to run compaction on stalled writes.
+    #[serde(default = "OptionalENConfig::default_merkle_tree_stalled_writes_timeout_sec")]
+    merkle_tree_stalled_writes_timeout_sec: u64,
+
+    // Postgres config (new parameters)
+    /// Threshold in milliseconds for the DB connection lifetime to denote it as long-living and log its details.
+    /// If not specified, such logging will be disabled.
+    database_long_connection_threshold_ms: Option<u64>,
+    /// Threshold in milliseconds to denote a DB query as "slow" and log its details. If not specified, such logging will be disabled.
+    database_slow_query_threshold_ms: Option<u64>,
+
+    // Other config settings
+    /// Capacity of the queue for asynchronous L2 block sealing. Once this many L2 blocks are queued,
+    /// sealing will block until some of the L2 blocks from the queue are processed.
+    /// 0 means that sealing is synchronous; this is mostly useful for performance comparison, testing etc.
+    #[serde(
+        alias = "miniblock_seal_queue_capacity",
+        default = "OptionalENConfig::default_l2_block_seal_queue_capacity"
+    )]
+    pub l2_block_seal_queue_capacity: usize,
+    /// Configures whether to persist protective reads when persisting L1 batches in the state keeper.
+    /// Protective reads are never required by full nodes so far, not until such a node runs a full Merkle tree
+    /// (presumably, to participate in L1 batch proving).
+    #[serde(default)]
+    pub protective_reads_persistence_enabled: bool,
+    /// Address of the L1 diamond proxy contract used by the consistency checker to match with the origin of logs emitted
+    /// by commit transactions. If not set, it will not be verified.
+    // This is intentionally not a part of `RemoteENConfig` because fetching this info from the main node would defeat
+    // its purpose; the consistency checker assumes that the main node may provide false information.
+    pub contracts_diamond_proxy_addr: Option<Address>,
+    /// Number of requests per second allocated for the main node HTTP client. Default is 100 requests.
+    #[serde(default = "OptionalENConfig::default_main_node_rate_limit_rps")]
+    pub main_node_rate_limit_rps: NonZeroUsize,
+
+    #[serde(default)]
+    pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
+    /// Enables application-level snapshot recovery. Required to start a node that was recovered from a snapshot,
+    /// or to initialize a node from a snapshot. Has no effect if a node that was initialized from a Postgres dump
+    /// or was synced from genesis.
+    ///
+    /// This is an experimental and incomplete feature; do not use unless you know what you're doing.
+    #[serde(default)]
+    pub snapshots_recovery_enabled: bool,
+    /// Maximum concurrency factor for the concurrent parts of snapshot recovery for Postgres. It may be useful to
+    /// reduce this factor to about 5 if snapshot recovery overloads I/O capacity of the node. Conversely,
+    /// if I/O capacity of your infra is high, you may increase concurrency to speed up Postgres recovery.
+    #[serde(default = "OptionalENConfig::default_snapshots_recovery_postgres_max_concurrency")]
+    pub snapshots_recovery_postgres_max_concurrency: NonZeroUsize,
+
+    #[serde(default)]
+    pub snapshots_recovery_object_store: Option<ObjectStoreConfig>,
+
+    /// Enables pruning of the historical node state (Postgres and Merkle tree). The node will retain
+    /// recent state and will continuously remove (prune) old enough parts of the state in the background.
+    #[serde(default)]
+    pub pruning_enabled: bool,
+    /// Number of L1 batches pruned at a time.
+    #[serde(default = "OptionalENConfig::default_pruning_chunk_size")]
+    pub pruning_chunk_size: u32,
+    /// Delta between soft- and hard-removing data from Postgres. Should be reasonably large (order of 60 seconds).
+    /// The default value is 60 seconds.
+    #[serde(default = "OptionalENConfig::default_pruning_removal_delay_sec")]
+    pruning_removal_delay_sec: NonZeroU64,
+    /// If set, L1 batches will be pruned after the batch timestamp is this old (in seconds). Note that an L1 batch
+    /// may be temporarily retained for other reasons; e.g., a batch cannot be pruned until it is executed on L1,
+    /// which happens roughly 24 hours after its generation on the mainnet. Thus, in practice this value can specify
+    /// the retention period greater than that implicitly imposed by other criteria (e.g., 7 or 30 days).
+    /// If set to 0, L1 batches will not be retained based on their timestamp. The default value is 7 days.
+    #[serde(default = "OptionalENConfig::default_pruning_data_retention_sec")]
+    pruning_data_retention_sec: u64,
+    /// Gateway RPC URL, needed for operating during migration.
+    #[allow(dead_code)]
+    pub gateway_url: Option<SensitiveUrl>,
+}
+
+impl OptionalENConfig {
+    fn from_configs(general_config: &GeneralConfig, enconfig: &ENConfig) -> anyhow::Result<Self> {
+        let api_namespaces = load_config!(general_config.api_config, web3_json_rpc.api_namespaces)
+            .map(|a: Vec<String>| a.iter().map(|a| a.parse()).collect::<Result<_, _>>())
+            .transpose()?;
+
+        Ok(OptionalENConfig {
+            filters_limit: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.filters_limit,
+                default_filters_limit
+            ),
+            subscriptions_limit: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.subscriptions_limit,
+                default_subscriptions_limit
+            ),
+            req_entities_limit: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.req_entities_limit,
+                default_req_entities_limit
+            ),
+            max_tx_size_bytes: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.max_tx_size,
+                default_max_tx_size_bytes
+            ),
+            vm_execution_cache_misses_limit: load_config!(
+                general_config.api_config,
+                web3_json_rpc.vm_execution_cache_misses_limit
+            ),
+            fee_history_limit: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.fee_history_limit,
+                default_fee_history_limit
+            ),
+            max_batch_request_size: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.max_batch_request_size,
+                default_max_batch_request_size
+            ),
+            max_response_body_size_mb: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.max_response_body_size_mb,
+                default_max_response_body_size_mb
+            ),
+            max_response_body_size_overrides_mb: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.max_response_body_size_overrides_mb,
+                default_max_response_body_size_overrides_mb
+            ),
+            pubsub_polling_interval_ms: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.pubsub_polling_interval,
+                default_polling_interval
+            ),
+            max_nonce_ahead: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.max_nonce_ahead,
+                default_max_nonce_ahead
+            ),
+            vm_concurrency_limit: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.vm_concurrency_limit,
+                default_vm_concurrency_limit
+            ),
+            factory_deps_cache_size_mb: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.factory_deps_cache_size_mb,
+                default_factory_deps_cache_size_mb
+            ),
+            initial_writes_cache_size_mb: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.initial_writes_cache_size_mb,
+                default_initial_writes_cache_size_mb
+            ),
+            latest_values_cache_size_mb: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.latest_values_cache_size_mb,
+                default_latest_values_cache_size_mb
+            ),
+            filters_disabled: general_config
+                .api_config
+                .as_ref()
+                .map(|a| a.web3_json_rpc.filters_disabled)
+                .unwrap_or_default(),
+            mempool_cache_update_interval_ms: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.mempool_cache_update_interval,
+                default_mempool_cache_update_interval_ms
+            ),
+            mempool_cache_size: load_optional_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.mempool_cache_size,
+                default_mempool_cache_size
+            ),
+
+            healthcheck_slow_time_limit_ms: load_config!(
+                general_config.api_config,
+                healthcheck.slow_time_limit_ms
+            ),
+            healthcheck_hard_time_limit_ms: load_config!(
+                general_config.api_config,
+                healthcheck.hard_time_limit_ms
+            ),
+            estimate_gas_scale_factor: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.estimate_gas_scale_factor,
+                default_estimate_gas_scale_factor
+            ),
+            estimate_gas_acceptable_overestimation: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.estimate_gas_acceptable_overestimation,
+                default_estimate_gas_acceptable_overestimation
+            ),
+            gas_price_scale_factor: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.gas_price_scale_factor,
+                default_gas_price_scale_factor
+            ),
+            merkle_tree_max_l1_batches_per_iter: load_config_or_default!(
+                general_config.db_config,
+                merkle_tree.max_l1_batches_per_iter,
+                default_merkle_tree_max_l1_batches_per_iter
+            ),
+            merkle_tree_max_open_files: load_config!(
+                general_config.db_config,
+                experimental.state_keeper_db_max_open_files
+            ),
+            merkle_tree_multi_get_chunk_size: load_config_or_default!(
+                general_config.db_config,
+                merkle_tree.multi_get_chunk_size,
+                default_merkle_tree_multi_get_chunk_size
+            ),
+            merkle_tree_block_cache_size_mb: load_config_or_default!(
+                general_config.db_config,
+                merkle_tree.block_cache_size_mb,
+                default_merkle_tree_block_cache_size_mb
+            ),
+            merkle_tree_memtable_capacity_mb: load_config_or_default!(
+                general_config.db_config,
+                merkle_tree.memtable_capacity_mb,
+                default_merkle_tree_memtable_capacity_mb
+            ),
+            merkle_tree_stalled_writes_timeout_sec: load_config_or_default!(
+                general_config.db_config,
+                merkle_tree.stalled_writes_timeout_sec,
+                default_merkle_tree_stalled_writes_timeout_sec
+            ),
+            database_long_connection_threshold_ms: load_config!(
+                general_config.postgres_config,
+                long_connection_threshold_ms
+            ),
+            database_slow_query_threshold_ms: load_config!(
+                general_config.postgres_config,
+                slow_query_threshold_ms
+            ),
+            l2_block_seal_queue_capacity: load_config_or_default!(
+                general_config.state_keeper_config,
+                l2_block_seal_queue_capacity,
+                default_l2_block_seal_queue_capacity
+            ),
+            l1_batch_commit_data_generator_mode: enconfig.l1_batch_commit_data_generator_mode,
+            snapshots_recovery_enabled: general_config
+                .snapshot_recovery
+                .as_ref()
+                .map(|a| a.enabled)
+                .unwrap_or_default(),
+            snapshots_recovery_postgres_max_concurrency: load_optional_config_or_default!(
+                general_config.snapshot_recovery,
+                postgres.max_concurrency,
+                default_snapshots_recovery_postgres_max_concurrency
+            ),
+            pruning_enabled: general_config
+                .pruning
+                .as_ref()
+                .map(|a| a.enabled)
+                .unwrap_or_default(),
+            snapshots_recovery_object_store: load_config!(
+                general_config.snapshot_recovery,
+                object_store
+            ),
+            pruning_chunk_size: load_optional_config_or_default!(
+                general_config.pruning,
+                chunk_size,
+                default_pruning_chunk_size
+            ),
+            pruning_removal_delay_sec: load_optional_config_or_default!(
+                general_config.pruning,
+                removal_delay_sec,
+                default_pruning_removal_delay_sec
+            ),
+            pruning_data_retention_sec: load_optional_config_or_default!(
+                general_config.pruning,
+                data_retention_sec,
+                default_pruning_data_retention_sec
+            ),
+            protective_reads_persistence_enabled: general_config
+                .db_config
+                .as_ref()
+                .map(|a| a.experimental.protective_reads_persistence_enabled)
+                .unwrap_or_default(),
+            merkle_tree_processing_delay_ms: load_config_or_default!(
+                general_config.db_config,
+                experimental.processing_delay_ms,
+                default_merkle_tree_processing_delay_ms
+            ),
+            merkle_tree_include_indices_and_filters_in_block_cache: general_config
+                .db_config
+                .as_ref()
+                .map(|a| a.experimental.include_indices_and_filters_in_block_cache)
+                .unwrap_or_default(),
+            extended_rpc_tracing: load_config_or_default!(
+                general_config.api_config,
+                web3_json_rpc.extended_api_tracing,
+                default_extended_api_tracing
+            ),
+            main_node_rate_limit_rps: enconfig
+                .main_node_rate_limit_rps
+                .unwrap_or_else(Self::default_main_node_rate_limit_rps),
+            api_namespaces,
+            contracts_diamond_proxy_addr: None,
+            gateway_url: enconfig.gateway_url.clone(),
+        })
+    }
+
+    const fn default_filters_limit() -> usize {
+        10_000
+    }
+
+    const fn default_subscriptions_limit() -> usize {
+        10_000
+    }
+
+    const fn default_req_entities_limit() -> usize {
+        1_024
+    }
+
+    const fn default_max_tx_size_bytes() -> usize {
+        1_000_000
+    }
+
+    const fn default_polling_interval() -> u64 {
+        200
+    }
+
+    const fn default_estimate_gas_scale_factor() -> f64 {
+        1.2
+    }
+
+    const fn default_estimate_gas_acceptable_overestimation() -> u32 {
+        1_000
+    }
+
+    const fn default_gas_price_scale_factor() -> f64 {
+        1.2
+    }
+
+    const fn default_max_nonce_ahead() -> u32 {
+        50
+    }
+
+    const fn default_merkle_tree_processing_delay_ms() -> u64 {
+        100
+    }
+
+    const fn default_merkle_tree_max_l1_batches_per_iter() -> usize {
+        20
+    }
+
+    const fn default_vm_concurrency_limit() -> usize {
+        // The default limit is large so that it does not create a bottleneck on its own.
+        // VM execution can still be limited by Tokio runtime parallelism and/or the number
+        // of DB connections in a pool.
+        2_048
+    }
+
+    const fn default_factory_deps_cache_size_mb() -> usize {
+        128
+    }
+
+    const fn default_initial_writes_cache_size_mb() -> usize {
+        32
+    }
+
+    const fn default_latest_values_cache_size_mb() -> usize {
+        128
+    }
+
+    const fn default_merkle_tree_multi_get_chunk_size() -> usize {
+        500
+    }
+
+    const fn default_merkle_tree_block_cache_size_mb() -> usize {
+        128
+    }
+
+    const fn default_merkle_tree_memtable_capacity_mb() -> usize {
+        256
+    }
+
+    const fn default_merkle_tree_stalled_writes_timeout_sec() -> u64 {
+        30
+    }
+
+    const fn default_fee_history_limit() -> u64 {
+        1_024
+    }
+
+    const fn default_max_batch_request_size() -> usize {
+        500 // The default limit is chosen to be reasonably permissive.
+    }
+
+    const fn default_max_response_body_size_mb() -> usize {
+        10
+    }
+
+    fn default_max_response_body_size_overrides_mb() -> MaxResponseSizeOverrides {
+        MaxResponseSizeOverrides::empty()
+    }
+
+    const fn default_l2_block_seal_queue_capacity() -> usize {
+        10
+    }
+
+    const fn default_mempool_cache_update_interval_ms() -> u64 {
+        50
+    }
+
+    const fn default_mempool_cache_size() -> usize {
+        10_000
+    }
+
+    const fn default_extended_api_tracing() -> bool {
+        true
+    }
+
+    fn default_main_node_rate_limit_rps() -> NonZeroUsize {
+        NonZeroUsize::new(100).unwrap()
+    }
+
+    fn default_snapshots_recovery_postgres_max_concurrency() -> NonZeroUsize {
+        SnapshotsApplierConfig::default().max_concurrency
+    }
+
+    const fn default_pruning_chunk_size() -> u32 {
+        10
+    }
+
+    fn default_pruning_removal_delay_sec() -> NonZeroU64 {
+        NonZeroU64::new(60).unwrap()
+    }
+
+    fn default_pruning_data_retention_sec() -> u64 {
+        3_600 * 24 * 7 // 7 days
+    }
+
+    fn from_env() -> anyhow::Result<Self> {
+        let mut result: OptionalENConfig = envy::prefixed("EN_")
+            .from_env()
+            .context("could not load external node config")?;
+        result.snapshots_recovery_object_store = snapshot_recovery_object_store_config().ok();
+        Ok(result)
+    }
+
+    pub fn polling_interval(&self) -> Duration {
+        Duration::from_millis(self.pubsub_polling_interval_ms)
+    }
+
+    pub fn merkle_tree_processing_delay(&self) -> Duration {
+        Duration::from_millis(self.merkle_tree_processing_delay_ms)
+    }
+
+    /// Returns the size of factory dependencies cache in bytes.
+    pub fn factory_deps_cache_size(&self) -> usize {
+        self.factory_deps_cache_size_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the size of initial writes cache in bytes.
+    pub fn initial_writes_cache_size(&self) -> usize {
+        self.initial_writes_cache_size_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the size of latest values cache in bytes.
+    pub fn latest_values_cache_size(&self) -> usize {
+        self.latest_values_cache_size_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the size of block cache for Merkle tree in bytes.
+    pub fn merkle_tree_block_cache_size(&self) -> usize {
+        self.merkle_tree_block_cache_size_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the memtable capacity for Merkle tree in bytes.
+    pub fn merkle_tree_memtable_capacity(&self) -> usize {
+        self.merkle_tree_memtable_capacity_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the timeout to wait for the Merkle tree database to run compaction on stalled writes.
+    pub fn merkle_tree_stalled_writes_timeout(&self) -> Duration {
+        Duration::from_secs(self.merkle_tree_stalled_writes_timeout_sec)
+    }
+
+    pub fn long_connection_threshold(&self) -> Option<Duration> {
+        self.database_long_connection_threshold_ms
+            .map(Duration::from_millis)
+    }
+
+    pub fn slow_query_threshold(&self) -> Option<Duration> {
+        self.database_slow_query_threshold_ms
+            .map(Duration::from_millis)
+    }
+
+    pub fn api_namespaces(&self) -> Vec<Namespace> {
+        self.api_namespaces
+            .clone()
+            .unwrap_or_else(|| Namespace::DEFAULT.to_vec())
+    }
+
+    pub fn max_response_body_size(&self) -> MaxResponseSize {
+        let scale = NonZeroUsize::new(BYTES_IN_MEGABYTE).unwrap();
+        MaxResponseSize {
+            global: self.max_response_body_size_mb * BYTES_IN_MEGABYTE,
+            overrides: self.max_response_body_size_overrides_mb.scale(scale),
+        }
+    }
+
+    pub fn healthcheck_slow_time_limit(&self) -> Option<Duration> {
+        self.healthcheck_slow_time_limit_ms
+            .map(Duration::from_millis)
+    }
+
+    pub fn healthcheck_hard_time_limit(&self) -> Option<Duration> {
+        self.healthcheck_hard_time_limit_ms
+            .map(Duration::from_millis)
+    }
+
+    pub fn mempool_cache_update_interval(&self) -> Duration {
+        Duration::from_millis(self.mempool_cache_update_interval_ms)
+    }
+
+    pub fn pruning_removal_delay(&self) -> Duration {
+        Duration::from_secs(self.pruning_removal_delay_sec.get())
+    }
+
+    pub fn pruning_data_retention(&self) -> Duration {
+        Duration::from_secs(self.pruning_data_retention_sec)
+    }
+
+    #[cfg(test)]
+    fn mock() -> Self {
+        // Set all values to their defaults
+        serde_json::from_str("{}").unwrap()
+    }
+}
+
+/// This part of the external node config is required for its operation.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RequiredENConfig {
+    /// The chain ID of the L1 network (e.g., 1 for Ethereum mainnet). In the future, it may be different from the settlement layer.
+    pub l1_chain_id: L1ChainId,
+    /// The chain ID of the settlement layer (e.g., 1 for Ethereum mainnet). This ID will be checked against the `eth_client_url` RPC provider on initialization
+    /// to ensure that there's no mismatch between the expected and actual settlement layer network.
+    pub sl_chain_id: Option<SLChainId>,
+    /// L2 chain ID (e.g., 270 for ZKsync Era mainnet). This ID will be checked against the `main_node_url` RPC provider on initialization
+    /// to ensure that there's no mismatch between the expected and actual L2 network.
+    pub l2_chain_id: L2ChainId,
+
+    /// Port on which the HTTP RPC server is listening.
+    pub http_port: u16,
+    /// Port on which the WebSocket RPC server is listening.
+    pub ws_port: u16,
+    /// Port on which the healthcheck REST server is listening.
+    pub healthcheck_port: u16,
+    /// Address of the Ethereum node API.
+    pub eth_client_url: SensitiveUrl,
+    /// Main node URL - used by external node to proxy transactions to, query state from, etc.
+    pub main_node_url: SensitiveUrl,
+    /// Path to the database data directory that serves state cache.
+    pub state_cache_path: String,
+    /// Fast SSD path. Used as a RocksDB dir for the Merkle tree (*new* implementation).
+    pub merkle_tree_path: String,
+}
+
+impl RequiredENConfig {
+    pub fn settlement_layer_id(&self) -> SLChainId {
+        self.sl_chain_id.unwrap_or(self.l1_chain_id.into())
+    }
+
+    fn from_env() -> anyhow::Result<Self> {
+        envy::prefixed("EN_")
+            .from_env()
+            .context("could not load external node config")
+    }
+
+    fn from_configs(
+        general: &GeneralConfig,
+        en_config: &ENConfig,
+        secrets: &Secrets,
+    ) -> anyhow::Result<Self> {
+        let api_config = general
+            .api_config
+            .as_ref()
+            .context("Api config is required")?;
+        let db_config = general
+            .db_config
+            .as_ref()
+            .context("Database config is required")?;
+        Ok(RequiredENConfig {
+            l1_chain_id: en_config.l1_chain_id,
+            sl_chain_id: None,
+            l2_chain_id: en_config.l2_chain_id,
+            http_port: api_config.web3_json_rpc.http_port,
+            ws_port: api_config.web3_json_rpc.ws_port,
+            healthcheck_port: api_config.healthcheck.port,
+            eth_client_url: secrets
+                .l1
+                .as_ref()
+                .context("L1 secrets are required")?
+                .l1_rpc_url
+                .clone(),
+            main_node_url: en_config.main_node_url.clone(),
+            state_cache_path: db_config.state_keeper_db_path.clone(),
+            merkle_tree_path: db_config.merkle_tree.path.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    fn mock(temp_dir: &tempfile::TempDir) -> Self {
+        Self {
+            l1_chain_id: L1ChainId(9),
+            sl_chain_id: None,
+            l2_chain_id: L2ChainId::default(),
+            http_port: 0,
+            ws_port: 0,
+            healthcheck_port: 0,
+            // L1 and L2 clients must be instantiated before accessing mocks, so these values don't matter
+            eth_client_url: "http://localhost".parse().unwrap(),
+            main_node_url: "http://localhost".parse().unwrap(),
+            state_cache_path: temp_dir
+                .path()
+                .join("state_keeper_cache")
+                .to_str()
+                .unwrap()
+                .to_owned(),
+            merkle_tree_path: temp_dir.path().join("tree").to_str().unwrap().to_owned(),
+        }
+    }
+}
+
+/// Configuration for Postgres database.
+/// While also mandatory, it historically used different naming scheme for corresponding
+/// environment variables.
+/// Thus it is kept separately for backward compatibility and ease of deserialization.
+#[derive(Debug, Deserialize)]
+pub(crate) struct PostgresConfig {
+    database_url: SensitiveUrl,
+    pub max_connections: u32,
+}
+
+impl PostgresConfig {
+    fn from_env() -> anyhow::Result<Self> {
+        Ok(Self {
+            database_url: env::var("DATABASE_URL")
+                .context("DATABASE_URL env variable is not set")?
+                .parse()
+                .context("DATABASE_URL env variable is not a valid Postgres URL")?,
+            max_connections: env::var("DATABASE_POOL_SIZE")
+                .context("DATABASE_POOL_SIZE env variable is not set")?
+                .parse()
+                .context("Unable to parse DATABASE_POOL_SIZE env variable")?,
+        })
+    }
+
+    pub fn database_url(&self) -> SensitiveUrl {
+        self.database_url.clone()
+    }
+
+    #[cfg(test)]
+    fn mock(test_pool: &ConnectionPool<Core>) -> Self {
+        Self {
+            database_url: test_pool.database_url().clone(),
+            max_connections: test_pool.max_size(),
+        }
+    }
+}
+
+/// Experimental part of the external node config. All parameters in this group can change or disappear without notice.
+/// Eventually, parameters from this group generally end up in the optional group.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ExperimentalENConfig {
+    // State keeper cache config
+    /// Block cache capacity of the state keeper RocksDB cache. The default value is 128 MB.
+    #[serde(default = "ExperimentalENConfig::default_state_keeper_db_block_cache_capacity_mb")]
+    state_keeper_db_block_cache_capacity_mb: usize,
+    /// Maximum number of files concurrently opened by state keeper cache RocksDB. Useful to fit into OS limits; can be used
+    /// as a rudimentary way to control RAM usage of the cache.
+    pub state_keeper_db_max_open_files: Option<NonZeroU32>,
+
+    // Snapshot recovery
+    /// L1 batch number of the snapshot to use during recovery. Specifying this parameter is mostly useful for testing.
+    pub snapshots_recovery_l1_batch: Option<L1BatchNumber>,
+    /// Enables dropping storage key preimages when recovering storage logs from a snapshot with version 0.
+    /// This is a temporary flag that will eventually be removed together with version 0 snapshot support.
+    #[serde(default)]
+    pub snapshots_recovery_drop_storage_key_preimages: bool,
+    /// Approximate chunk size (measured in the number of entries) to recover in a single iteration.
+    /// Reasonable values are order of 100,000 (meaning an iteration takes several seconds).
+    ///
+    /// **Important.** This value cannot be changed in the middle of tree recovery (i.e., if a node is stopped in the middle
+    /// of recovery and then restarted with a different config).
+    #[serde(default = "ExperimentalENConfig::default_snapshots_recovery_tree_chunk_size")]
+    pub snapshots_recovery_tree_chunk_size: u64,
+    /// Buffer capacity for parallel persistence operations. Should be reasonably small since larger buffer means more RAM usage;
+    /// buffer elements are persisted tree chunks. OTOH, small buffer can lead to persistence parallelization being inefficient.
+    ///
+    /// If not set, parallel persistence will be disabled.
+    #[serde(default)] // Temporarily use a conservative option (sequential recovery) as default
+    pub snapshots_recovery_tree_parallel_persistence_buffer: Option<NonZeroUsize>,
+
+    // Commitment generator
+    /// Maximum degree of parallelism during commitment generation, i.e., the maximum number of L1 batches being processed in parallel.
+    /// If not specified, commitment generator will use a value roughly equal to the number of CPU cores with some clamping applied.
+    pub commitment_generator_max_parallelism: Option<NonZeroU32>,
+}
+
+impl ExperimentalENConfig {
+    const fn default_state_keeper_db_block_cache_capacity_mb() -> usize {
+        128
+    }
+
+    fn default_snapshots_recovery_tree_chunk_size() -> u64 {
+        MetadataCalculatorRecoveryConfig::default().desired_chunk_size
+    }
+
+    #[cfg(test)]
+    fn mock() -> Self {
+        Self {
+            state_keeper_db_block_cache_capacity_mb:
+                Self::default_state_keeper_db_block_cache_capacity_mb(),
+            state_keeper_db_max_open_files: None,
+            snapshots_recovery_l1_batch: None,
+            snapshots_recovery_drop_storage_key_preimages: false,
+            snapshots_recovery_tree_chunk_size: Self::default_snapshots_recovery_tree_chunk_size(),
+            snapshots_recovery_tree_parallel_persistence_buffer: None,
+            commitment_generator_max_parallelism: None,
+        }
+    }
+
+    /// Returns the size of block cache for the state keeper RocksDB cache in bytes.
+    pub fn state_keeper_db_block_cache_capacity(&self) -> usize {
+        self.state_keeper_db_block_cache_capacity_mb * BYTES_IN_MEGABYTE
+    }
+
+    pub fn from_configs(general_config: &GeneralConfig) -> anyhow::Result<Self> {
+        Ok(Self {
+            state_keeper_db_block_cache_capacity_mb: load_config_or_default!(
+                general_config.db_config,
+                experimental.state_keeper_db_block_cache_capacity_mb,
+                default_state_keeper_db_block_cache_capacity_mb
+            ),
+            state_keeper_db_max_open_files: load_config!(
+                general_config.db_config,
+                experimental.state_keeper_db_max_open_files
+            ),
+            snapshots_recovery_l1_batch: load_config!(general_config.snapshot_recovery, l1_batch),
+            snapshots_recovery_tree_chunk_size: load_optional_config_or_default!(
+                general_config.snapshot_recovery,
+                tree.chunk_size,
+                default_snapshots_recovery_tree_chunk_size
+            ),
+            snapshots_recovery_tree_parallel_persistence_buffer: load_config!(
+                general_config.snapshot_recovery,
+                tree.parallel_persistence_buffer
+            ),
+            snapshots_recovery_drop_storage_key_preimages: general_config
+                .snapshot_recovery
+                .as_ref()
+                .map_or(false, |config| config.drop_storage_key_preimages),
+            commitment_generator_max_parallelism: general_config
+                .commitment_generator
+                .as_ref()
+                .map(|a| a.max_parallelism),
+        })
+    }
+}
+
+/// Generates all possible consensus secrets (from system entropy)
+/// and prints them to stdout.
+/// They should be copied over to the secrets.yaml/consensus_secrets.yaml file.
+pub fn generate_consensus_secrets() {
+    let validator_key = roles::validator::SecretKey::generate();
+    let attester_key = roles::attester::SecretKey::generate();
+    let node_key = roles::node::SecretKey::generate();
+    println!("# {}", validator_key.public().encode());
+    println!("validator_key: {}", validator_key.encode());
+    println!("# {}", attester_key.public().encode());
+    println!("attester_key: {}", attester_key.encode());
+    println!("# {}", node_key.public().encode());
+    println!("node_key: {}", node_key.encode());
+}
+
+pub(crate) fn read_consensus_secrets() -> anyhow::Result<Option<ConsensusSecrets>> {
+    let Ok(path) = env::var("EN_CONSENSUS_SECRETS_PATH") else {
+        return Ok(None);
+    };
+    let cfg = std::fs::read_to_string(&path).context(path)?;
+    Ok(Some(
+        decode_yaml_repr::<proto::secrets::ConsensusSecrets>(&cfg)
+            .context("failed decoding YAML")?,
+    ))
+}
+
+pub(crate) fn read_consensus_config() -> anyhow::Result<Option<ConsensusConfig>> {
+    let Ok(path) = env::var("EN_CONSENSUS_CONFIG_PATH") else {
+        return Ok(None);
+    };
+    let cfg = std::fs::read_to_string(&path).context(path)?;
+    Ok(Some(
+        decode_yaml_repr::<proto::consensus::Config>(&cfg).context("failed decoding YAML")?,
+    ))
+}
+
+/// Configuration for snapshot recovery. Should be loaded optionally, only if snapshot recovery is enabled.
+pub(crate) fn snapshot_recovery_object_store_config() -> anyhow::Result<ObjectStoreConfig> {
+    envy::prefixed("EN_SNAPSHOTS_OBJECT_STORE_")
+        .from_env::<ObjectStoreConfig>()
+        .context("failed loading snapshot object store config from env variables")
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ApiComponentConfig {
+    /// Address of the tree API used by this EN in case it does not have a
+    /// local tree component running and in this case needs to send requests
+    /// to some external tree API.
+    pub tree_api_remote_url: Option<String>,
+}
+
+impl ApiComponentConfig {
+    fn from_configs(general_config: &GeneralConfig) -> Self {
+        ApiComponentConfig {
+            tree_api_remote_url: general_config
+                .api_config
+                .as_ref()
+                .and_then(|a| a.web3_json_rpc.tree_api_url.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TreeComponentConfig {
+    pub api_port: Option<u16>,
+}
+
+impl TreeComponentConfig {
+    fn from_configs(general_config: &GeneralConfig) -> Self {
+        let api_port = general_config
+            .api_config
+            .as_ref()
+            .map(|a| a.merkle_tree.port);
+        TreeComponentConfig { api_port }
+    }
+}
+
+/// External Node Config contains all the configuration required for the EN operation.
+/// It is split into three parts: required, optional and remote for easier navigation.
+#[derive(Debug)]
+pub(crate) struct ExternalNodeConfig<R = RemoteENConfig> {
+    pub required: RequiredENConfig,
+    pub postgres: PostgresConfig,
+    pub optional: OptionalENConfig,
+    pub observability: ObservabilityENConfig,
+    pub experimental: ExperimentalENConfig,
+    pub consensus: Option<ConsensusConfig>,
+    pub api_component: ApiComponentConfig,
+    pub tree_component: TreeComponentConfig,
+    pub remote: R,
+}
+
+impl ExternalNodeConfig<()> {
+    /// Parses the local part of node configuration from the environment.
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            required: RequiredENConfig::from_env()?,
+            postgres: PostgresConfig::from_env()?,
+            optional: OptionalENConfig::from_env()?,
+            observability: ObservabilityENConfig::from_env()?,
+            experimental: envy::prefixed("EN_EXPERIMENTAL_")
+                .from_env::<ExperimentalENConfig>()
+                .context("could not load external node config (experimental params)")?,
+            consensus: read_consensus_config().context("read_consensus_config()")?,
+            api_component: envy::prefixed("EN_API_")
+                .from_env::<ApiComponentConfig>()
+                .context("could not load external node config (API component params)")?,
+            tree_component: envy::prefixed("EN_TREE_")
+                .from_env::<TreeComponentConfig>()
+                .context("could not load external node config (tree component params)")?,
+            remote: (),
+        })
+    }
+
+    pub fn from_files(
+        general_config_path: PathBuf,
+        external_node_config_path: PathBuf,
+        secrets_configs_path: PathBuf,
+        consensus_config_path: Option<PathBuf>,
+    ) -> anyhow::Result<Self> {
+        let general_config = read_yaml_repr::<proto::general::GeneralConfig>(general_config_path)
+            .context("failed decoding general YAML config")?;
+        let external_node_config =
+            read_yaml_repr::<proto::en::ExternalNode>(external_node_config_path)
+                .context("failed decoding external node YAML config")?;
+        let secrets_config = read_yaml_repr::<proto::secrets::Secrets>(secrets_configs_path)
+            .context("failed decoding secrets YAML config")?;
+
+        let consensus = consensus_config_path
+            .map(read_yaml_repr::<proto::consensus::Config>)
+            .transpose()
+            .context("failed decoding consensus YAML config")?;
+
+        let required = RequiredENConfig::from_configs(
+            &general_config,
+            &external_node_config,
+            &secrets_config,
+        )?;
+        let optional = OptionalENConfig::from_configs(&general_config, &external_node_config)?;
+        let postgres = PostgresConfig {
+            database_url: secrets_config
+                .database
+                .as_ref()
+                .context("DB secrets is required")?
+                .server_url
+                .clone()
+                .context("Server url is required")?,
+            max_connections: general_config
+                .postgres_config
+                .as_ref()
+                .context("Postgres config is required")?
+                .max_connections()?,
+        };
+        let observability = ObservabilityENConfig::from_configs(&general_config)?;
+        let experimental = ExperimentalENConfig::from_configs(&general_config)?;
+
+        let api_component = ApiComponentConfig::from_configs(&general_config);
+        let tree_component = TreeComponentConfig::from_configs(&general_config);
+
+        Ok(Self {
+            required,
+            postgres,
+            optional,
+            observability,
+            experimental,
+            consensus,
+            api_component,
+            tree_component,
+            remote: (),
+        })
+    }
+
+    /// Fetches contracts addresses from the main node, completing the configuration.
+    pub async fn fetch_remote(
+        self,
+        main_node_client: &DynClient<L2>,
+    ) -> anyhow::Result<ExternalNodeConfig> {
+        let remote = RemoteENConfig::fetch(main_node_client)
+            .await
+            .context("Unable to fetch required config values from the main node")?;
+        let remote_diamond_proxy_addr = remote.diamond_proxy_addr;
+        if let Some(local_diamond_proxy_addr) = self.optional.contracts_diamond_proxy_addr {
+            anyhow::ensure!(
+                local_diamond_proxy_addr == remote_diamond_proxy_addr,
+                "Diamond proxy address {local_diamond_proxy_addr:?} specified in config doesn't match one returned \
+                by main node ({remote_diamond_proxy_addr:?})"
+            );
+        } else {
+            tracing::info!(
+                "Diamond proxy address is not specified in config; will use address \
+                returned by main node: {remote_diamond_proxy_addr:?}"
+            );
+        }
+        Ok(ExternalNodeConfig {
+            required: self.required,
+            postgres: self.postgres,
+            optional: self.optional,
+            observability: self.observability,
+            experimental: self.experimental,
+            consensus: self.consensus,
+            tree_component: self.tree_component,
+            api_component: self.api_component,
+            remote,
+        })
+    }
+}
+
+impl ExternalNodeConfig {
+    #[cfg(test)]
+    pub(crate) fn mock(temp_dir: &tempfile::TempDir, test_pool: &ConnectionPool<Core>) -> Self {
+        Self {
+            required: RequiredENConfig::mock(temp_dir),
+            postgres: PostgresConfig::mock(test_pool),
+            optional: OptionalENConfig::mock(),
+            remote: RemoteENConfig::mock(),
+            observability: ObservabilityENConfig::default(),
+            experimental: ExperimentalENConfig::mock(),
+            consensus: None,
+            api_component: ApiComponentConfig {
+                tree_api_remote_url: None,
+            },
+            tree_component: TreeComponentConfig { api_port: None },
+        }
+    }
+
+    /// Returns a verified diamond proxy address.
+    /// If local configuration contains the address, it will be checked against the one returned by the main node.
+    /// Otherwise, the remote value will be used. However, using remote value has trust implications for the main
+    /// node so relying on it solely is not recommended.
+    pub fn diamond_proxy_address(&self) -> Address {
+        self.optional
+            .contracts_diamond_proxy_addr
+            .unwrap_or(self.remote.diamond_proxy_addr)
+    }
+}
+
+impl From<&ExternalNodeConfig> for InternalApiConfig {
+    fn from(config: &ExternalNodeConfig) -> Self {
+        Self {
+            l1_chain_id: config.required.l1_chain_id,
+            l2_chain_id: config.required.l2_chain_id,
+            max_tx_size: config.optional.max_tx_size_bytes,
+            estimate_gas_scale_factor: config.optional.estimate_gas_scale_factor,
+            estimate_gas_acceptable_overestimation: config
+                .optional
+                .estimate_gas_acceptable_overestimation,
+            bridge_addresses: BridgeAddresses {
+                l1_erc20_default_bridge: config.remote.l1_erc20_bridge_proxy_addr,
+                l2_erc20_default_bridge: config.remote.l2_erc20_bridge_addr,
+                l1_shared_default_bridge: config.remote.l1_shared_bridge_proxy_addr,
+                l2_shared_default_bridge: config.remote.l2_shared_bridge_addr,
+                l1_weth_bridge: config.remote.l1_weth_bridge_addr,
+                l2_weth_bridge: config.remote.l2_weth_bridge_addr,
+            },
+            bridgehub_proxy_addr: config.remote.bridgehub_proxy_addr,
+            state_transition_proxy_addr: config.remote.state_transition_proxy_addr,
+            transparent_proxy_admin_addr: config.remote.transparent_proxy_admin_addr,
+            diamond_proxy_addr: config.remote.diamond_proxy_addr,
+            l2_testnet_paymaster_addr: config.remote.l2_testnet_paymaster_addr,
+            req_entities_limit: config.optional.req_entities_limit,
+            fee_history_limit: config.optional.fee_history_limit,
+            base_token_address: Some(config.remote.base_token_addr),
+            filters_disabled: config.optional.filters_disabled,
+            dummy_verifier: config.remote.dummy_verifier,
+            l1_batch_commit_data_generator_mode: config.remote.l1_batch_commit_data_generator_mode,
+        }
+    }
+}
+
+impl From<&ExternalNodeConfig> for TxSenderConfig {
+    fn from(config: &ExternalNodeConfig) -> Self {
+        Self {
+            // Fee account address does not matter for the EN operation, since
+            // actual fee distribution is handled my the main node.
+            fee_account_addr: "0xfee0000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+            gas_price_scale_factor: config.optional.gas_price_scale_factor,
+            max_nonce_ahead: config.optional.max_nonce_ahead,
+            vm_execution_cache_misses_limit: config.optional.vm_execution_cache_misses_limit,
+            // We set these values to the maximum since we don't know the actual values
+            // and they will be enforced by the main node anyway.
+            max_allowed_l2_tx_gas_limit: u64::MAX,
+            validation_computational_gas_limit: u32::MAX,
+            chain_id: config.required.l2_chain_id,
+            // Does not matter for EN.
+            whitelisted_tokens_for_aa: Default::default(),
+        }
+    }
+}

--- a/core/bin/via_external_node/src/config/observability.rs
+++ b/core/bin/via_external_node/src/config/observability.rs
@@ -1,0 +1,140 @@
+use std::{collections::HashMap, time::Duration};
+
+use anyhow::Context as _;
+use serde::Deserialize;
+use zksync_config::configs::GeneralConfig;
+use zksync_vlog::{logs::LogFormat, prometheus::PrometheusExporterConfig};
+
+use super::{ConfigurationSource, Environment};
+
+/// Observability part of the node configuration.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct ObservabilityENConfig {
+    /// Port to bind the Prometheus exporter server to. If not specified, the server will not be launched.
+    /// If the push gateway URL is specified, it will prevail.
+    pub prometheus_port: Option<u16>,
+    /// Prometheus push gateway to push metrics to. Overrides `prometheus_port`. A full URL must be specified
+    /// including `job_id` and other path segments; it will be used verbatim as the URL to push data to.
+    pub prometheus_pushgateway_url: Option<String>,
+    /// Interval between pushing metrics to the Prometheus push gateway.
+    #[serde(default = "ObservabilityENConfig::default_prometheus_push_interval_ms")]
+    pub prometheus_push_interval_ms: u64,
+    /// Sentry URL to send panics to.
+    pub sentry_url: Option<String>,
+    /// Environment to use when sending data to Sentry.
+    pub sentry_environment: Option<String>,
+    /// Log format to use: either `plain` (default) or `json`.
+    #[serde(default)]
+    pub log_format: LogFormat,
+    // Log directives in format that is used in `RUST_LOG`
+    pub log_directives: Option<String>,
+}
+
+impl ObservabilityENConfig {
+    const fn default_prometheus_push_interval_ms() -> u64 {
+        10_000
+    }
+
+    pub(super) fn from_env() -> envy::Result<Self> {
+        Self::new(&Environment)
+    }
+
+    pub(super) fn new(source: &impl ConfigurationSource) -> envy::Result<Self> {
+        const OBSOLETE_VAR_NAMES: &[(&str, &str)] = &[
+            ("MISC_SENTRY_URL", "EN_SENTRY_URL"),
+            ("MISC_LOG_FORMAT", "EN_LOG_FORMAT"),
+        ];
+
+        let en_vars = source.vars().filter_map(|(name, value)| {
+            let name = name.into_string().ok()?;
+            if !name.starts_with("EN_") {
+                return None;
+            }
+            Some((name, value.into_string().ok()?))
+        });
+        let mut vars: HashMap<_, _> = en_vars.collect();
+
+        for &(old_name, new_name) in OBSOLETE_VAR_NAMES {
+            if vars.contains_key(new_name) {
+                continue; // new name is set; it should prevail over the obsolete one.
+            }
+            if let Some(value) = source.var(old_name) {
+                vars.insert(new_name.to_owned(), value);
+            }
+        }
+
+        envy::prefixed("EN_").from_iter(vars)
+    }
+
+    pub fn prometheus(&self) -> Option<PrometheusExporterConfig> {
+        match (self.prometheus_port, &self.prometheus_pushgateway_url) {
+            (_, Some(url)) => {
+                if self.prometheus_port.is_some() {
+                    tracing::info!("Both Prometheus port and push gateway URLs are specified; the push gateway URL will be used");
+                }
+                let push_interval = Duration::from_millis(self.prometheus_push_interval_ms);
+                Some(PrometheusExporterConfig::push(url.clone(), push_interval))
+            }
+            (Some(port), None) => Some(PrometheusExporterConfig::pull(port)),
+            (None, None) => None,
+        }
+    }
+
+    pub fn build_observability(&self) -> anyhow::Result<zksync_vlog::ObservabilityGuard> {
+        let logs = zksync_vlog::Logs::from(self.log_format)
+            .with_log_directives(self.log_directives.clone());
+
+        // Some legacy deployments use `unset` as an equivalent of `None`.
+        let sentry_url = self.sentry_url.as_deref().filter(|&url| url != "unset");
+        let sentry = sentry_url
+            .map(|url| {
+                anyhow::Ok(
+                    zksync_vlog::Sentry::new(url)
+                        .context("Invalid Sentry URL")?
+                        .with_environment(self.sentry_environment.clone()),
+                )
+            })
+            .transpose()?;
+        let guard = zksync_vlog::ObservabilityBuilder::new()
+            .with_logs(Some(logs))
+            .with_sentry(sentry)
+            .build();
+        Ok(guard)
+    }
+
+    pub(crate) fn from_configs(general_config: &GeneralConfig) -> anyhow::Result<Self> {
+        let (sentry_url, sentry_environment, log_format, log_directives) =
+            if let Some(observability) = general_config.observability.as_ref() {
+                (
+                    observability.sentry_url.clone(),
+                    observability.sentry_environment.clone(),
+                    observability
+                        .log_format
+                        .parse()
+                        .context("Invalid log format")?,
+                    observability.log_directives.clone(),
+                )
+            } else {
+                (None, None, LogFormat::default(), None)
+            };
+        let (prometheus_port, prometheus_pushgateway_url, prometheus_push_interval_ms) =
+            if let Some(prometheus) = general_config.prometheus_config.as_ref() {
+                (
+                    Some(prometheus.listener_port),
+                    prometheus.pushgateway_url.clone(),
+                    prometheus.push_interval_ms.unwrap_or_default(),
+                )
+            } else {
+                (None, None, 0)
+            };
+        Ok(Self {
+            prometheus_port,
+            prometheus_pushgateway_url,
+            prometheus_push_interval_ms,
+            sentry_url,
+            sentry_environment,
+            log_format,
+            log_directives,
+        })
+    }
+}

--- a/core/bin/via_external_node/src/config/tests.rs
+++ b/core/bin/via_external_node/src/config/tests.rs
@@ -1,0 +1,219 @@
+//! Tests for EN configuration.
+
+use std::collections::HashMap;
+
+use assert_matches::assert_matches;
+
+use super::*;
+
+#[derive(Debug)]
+struct MockEnvironment(HashMap<&'static str, &'static str>);
+
+impl MockEnvironment {
+    pub fn new(vars: &[(&'static str, &'static str)]) -> Self {
+        Self(vars.iter().copied().collect())
+    }
+}
+
+impl ConfigurationSource for MockEnvironment {
+    type Vars<'a> = Box<dyn Iterator<Item = (OsString, OsString)> + 'a>;
+
+    fn vars(&self) -> Self::Vars<'_> {
+        Box::new(
+            self.0
+                .iter()
+                .map(|(&name, &value)| (OsString::from(name), OsString::from(value))),
+        )
+    }
+
+    fn var(&self, name: &str) -> Option<String> {
+        self.0.get(name).copied().map(str::to_owned)
+    }
+}
+
+#[test]
+fn parsing_observability_config() {
+    let mut env_vars = MockEnvironment::new(&[
+        ("EN_PROMETHEUS_PORT", "3322"),
+        ("MISC_SENTRY_URL", "https://example.com/"),
+        ("EN_SENTRY_ENVIRONMENT", "mainnet - mainnet2"),
+    ]);
+    let config = ObservabilityENConfig::new(&env_vars).unwrap();
+    assert_eq!(config.prometheus_port, Some(3322));
+    assert_eq!(config.sentry_url.unwrap(), "https://example.com/");
+    assert_eq!(config.sentry_environment.unwrap(), "mainnet - mainnet2");
+    assert_matches!(config.log_format, zksync_vlog::logs::LogFormat::Plain);
+    assert_eq!(config.prometheus_push_interval_ms, 10_000);
+
+    env_vars.0.insert("MISC_LOG_FORMAT", "json");
+    let config = ObservabilityENConfig::new(&env_vars).unwrap();
+    assert_matches!(config.log_format, zksync_vlog::logs::LogFormat::Json);
+
+    // If both the canonical and obsolete vars are specified, the canonical one should prevail.
+    env_vars.0.insert("EN_LOG_FORMAT", "plain");
+    env_vars
+        .0
+        .insert("EN_SENTRY_URL", "https://example.com/new");
+    let config = ObservabilityENConfig::new(&env_vars).unwrap();
+    assert_matches!(config.log_format, zksync_vlog::logs::LogFormat::Plain);
+    assert_eq!(config.sentry_url.unwrap(), "https://example.com/new");
+}
+
+#[test]
+fn using_unset_sentry_url() {
+    let env_vars = MockEnvironment::new(&[("MISC_SENTRY_URL", "unset")]);
+    let config = ObservabilityENConfig::new(&env_vars).unwrap();
+    config.build_observability().unwrap();
+}
+
+#[test]
+fn parsing_optional_config_from_empty_env() {
+    let config: OptionalENConfig = envy::prefixed("EN_").from_iter([]).unwrap();
+    assert_eq!(config.filters_limit, 10_000);
+    assert_eq!(config.subscriptions_limit, 10_000);
+    assert_eq!(config.fee_history_limit, 1_024);
+    assert_eq!(config.polling_interval(), Duration::from_millis(200));
+    assert_eq!(config.max_tx_size_bytes, 1_000_000);
+    assert_eq!(
+        config.merkle_tree_processing_delay(),
+        Duration::from_millis(100)
+    );
+    assert_eq!(config.max_nonce_ahead, 50);
+    assert_eq!(config.estimate_gas_scale_factor, 1.2);
+    assert_eq!(config.vm_concurrency_limit, 2_048);
+    assert_eq!(config.factory_deps_cache_size(), 128 * BYTES_IN_MEGABYTE);
+    assert_eq!(config.latest_values_cache_size(), 128 * BYTES_IN_MEGABYTE);
+    assert_eq!(config.merkle_tree_multi_get_chunk_size, 500);
+    assert_eq!(
+        config.merkle_tree_block_cache_size(),
+        128 * BYTES_IN_MEGABYTE
+    );
+    assert_eq!(
+        config.max_response_body_size().global,
+        10 * BYTES_IN_MEGABYTE
+    );
+    assert_eq!(
+        config.max_response_body_size().overrides,
+        MaxResponseSizeOverrides::empty()
+    );
+    assert_eq!(
+        config.l1_batch_commit_data_generator_mode,
+        L1BatchCommitmentMode::Rollup
+    );
+}
+
+#[test]
+fn parsing_optional_config_from_env() {
+    let env_vars = [
+        ("EN_FILTERS_DISABLED", "true"),
+        ("EN_FILTERS_LIMIT", "5000"),
+        ("EN_SUBSCRIPTIONS_LIMIT", "20000"),
+        ("EN_FEE_HISTORY_LIMIT", "1000"),
+        ("EN_PUBSUB_POLLING_INTERVAL", "500"),
+        ("EN_MAX_TX_SIZE", "1048576"),
+        ("EN_METADATA_CALCULATOR_DELAY", "50"),
+        ("EN_MAX_NONCE_AHEAD", "100"),
+        ("EN_ESTIMATE_GAS_SCALE_FACTOR", "1.5"),
+        ("EN_VM_CONCURRENCY_LIMIT", "1000"),
+        ("EN_FACTORY_DEPS_CACHE_SIZE_MB", "64"),
+        ("EN_LATEST_VALUES_CACHE_SIZE_MB", "50"),
+        ("EN_MERKLE_TREE_MULTI_GET_CHUNK_SIZE", "1000"),
+        ("EN_MERKLE_TREE_BLOCK_CACHE_SIZE_MB", "32"),
+        ("EN_MAX_RESPONSE_BODY_SIZE_MB", "1"),
+        (
+            "EN_MAX_RESPONSE_BODY_SIZE_OVERRIDES_MB",
+            "zks_getProof=100,eth_call=2",
+        ),
+        ("EN_L1_BATCH_COMMIT_DATA_GENERATOR_MODE", "Validium"),
+    ];
+    let env_vars = env_vars
+        .into_iter()
+        .map(|(name, value)| (name.to_owned(), value.to_owned()));
+
+    let config: OptionalENConfig = envy::prefixed("EN_").from_iter(env_vars).unwrap();
+    assert!(config.filters_disabled);
+    assert_eq!(config.filters_limit, 5_000);
+    assert_eq!(config.subscriptions_limit, 20_000);
+    assert_eq!(config.fee_history_limit, 1_000);
+    assert_eq!(config.polling_interval(), Duration::from_millis(500));
+    assert_eq!(config.max_tx_size_bytes, BYTES_IN_MEGABYTE);
+    assert_eq!(
+        config.merkle_tree_processing_delay(),
+        Duration::from_millis(50)
+    );
+    assert_eq!(config.max_nonce_ahead, 100);
+    assert_eq!(config.estimate_gas_scale_factor, 1.5);
+    assert_eq!(config.vm_concurrency_limit, 1_000);
+    assert_eq!(config.factory_deps_cache_size(), 64 * BYTES_IN_MEGABYTE);
+    assert_eq!(config.latest_values_cache_size(), 50 * BYTES_IN_MEGABYTE);
+    assert_eq!(config.merkle_tree_multi_get_chunk_size, 1_000);
+    assert_eq!(
+        config.merkle_tree_block_cache_size(),
+        32 * BYTES_IN_MEGABYTE
+    );
+    let max_response_size = config.max_response_body_size();
+    assert_eq!(max_response_size.global, BYTES_IN_MEGABYTE);
+    assert_eq!(
+        max_response_size.overrides,
+        MaxResponseSizeOverrides::from_iter([
+            (
+                "zks_getProof",
+                NonZeroUsize::new(100 * BYTES_IN_MEGABYTE).unwrap()
+            ),
+            (
+                "eth_call",
+                NonZeroUsize::new(2 * BYTES_IN_MEGABYTE).unwrap()
+            )
+        ])
+    );
+    assert_eq!(
+        config.l1_batch_commit_data_generator_mode,
+        L1BatchCommitmentMode::Validium
+    );
+}
+
+#[test]
+fn parsing_renamed_optional_parameters() {
+    let env_vars = [
+        ("EN_MAX_TX_SIZE_BYTES", "100000"),
+        ("EN_PUBSUB_POLLING_INTERVAL_MS", "250"),
+        ("EN_MEMPOOL_CACHE_UPDATE_INTERVAL_MS", "100"),
+        ("EN_MERKLE_TREE_MAX_L1_BATCHES_PER_ITER", "15"),
+    ];
+    let env_vars = env_vars
+        .into_iter()
+        .map(|(name, value)| (name.to_owned(), value.to_owned()));
+
+    let config: OptionalENConfig = envy::prefixed("EN_").from_iter(env_vars).unwrap();
+    assert_eq!(config.max_tx_size_bytes, 100_000);
+    assert_eq!(config.pubsub_polling_interval_ms, 250);
+    assert_eq!(config.mempool_cache_update_interval_ms, 100);
+    assert_eq!(config.merkle_tree_max_l1_batches_per_iter, 15);
+}
+
+#[test]
+fn parsing_experimental_config_from_empty_env() {
+    let config: ExperimentalENConfig = envy::prefixed("EN_EXPERIMENTAL_").from_iter([]).unwrap();
+    assert_eq!(config.state_keeper_db_block_cache_capacity(), 128 << 20);
+    assert_eq!(config.state_keeper_db_max_open_files, None);
+}
+
+#[test]
+fn parsing_experimental_config_from_env() {
+    let env_vars = [
+        (
+            "EN_EXPERIMENTAL_STATE_KEEPER_DB_BLOCK_CACHE_CAPACITY_MB",
+            "64",
+        ),
+        ("EN_EXPERIMENTAL_STATE_KEEPER_DB_MAX_OPEN_FILES", "100"),
+    ];
+    let env_vars = env_vars
+        .into_iter()
+        .map(|(name, value)| (name.to_owned(), value.to_owned()));
+
+    let config: ExperimentalENConfig = envy::prefixed("EN_EXPERIMENTAL_")
+        .from_iter(env_vars)
+        .unwrap();
+    assert_eq!(config.state_keeper_db_block_cache_capacity(), 64 << 20);
+    assert_eq!(config.state_keeper_db_max_open_files, NonZeroU32::new(100));
+}

--- a/core/bin/via_external_node/src/main.rs
+++ b/core/bin/via_external_node/src/main.rs
@@ -1,0 +1,178 @@
+use std::{collections::HashSet, str::FromStr};
+
+use anyhow::Context as _;
+use clap::Parser;
+use node_builder::ExternalNodeBuilder;
+use zksync_web3_decl::client::{Client, DynClient, L2};
+
+use crate::config::{generate_consensus_secrets, ExternalNodeConfig};
+
+mod config;
+mod metadata;
+mod metrics;
+mod node_builder;
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Clone, clap::Subcommand)]
+enum Command {
+    /// Generates consensus secret keys to use in the secrets file.
+    /// Prints the keys to the stdout, you need to copy the relevant keys into your secrets file.
+    GenerateSecrets,
+}
+
+/// External node for ZKsync Era.
+#[derive(Debug, Parser)]
+#[command(author = "Matter Labs", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// Enables consensus-based syncing instead of JSON-RPC based one. This is an experimental and incomplete feature;
+    /// do not use unless you know what you're doing.
+    #[arg(long)]
+    enable_consensus: bool,
+
+    /// Comma-separated list of components to launch.
+    #[arg(long, default_value = "all")]
+    components: ComponentsToRun,
+    /// Path to the yaml config. If set, it will be used instead of env vars.
+    #[arg(
+        long,
+        requires = "secrets_path",
+        requires = "external_node_config_path"
+    )]
+    config_path: Option<std::path::PathBuf>,
+    /// Path to the yaml with secrets. If set, it will be used instead of env vars.
+    #[arg(long, requires = "config_path", requires = "external_node_config_path")]
+    secrets_path: Option<std::path::PathBuf>,
+    /// Path to the yaml with external node specific configuration. If set, it will be used instead of env vars.
+    #[arg(long, requires = "config_path", requires = "secrets_path")]
+    external_node_config_path: Option<std::path::PathBuf>,
+    /// Path to the yaml with consensus config. If set, it will be used instead of env vars.
+    #[arg(
+        long,
+        requires = "config_path",
+        requires = "secrets_path",
+        requires = "external_node_config_path",
+        requires = "enable_consensus"
+    )]
+    consensus_path: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+pub enum Component {
+    HttpApi,
+    WsApi,
+    Tree,
+    TreeApi,
+    TreeFetcher,
+    Core,
+}
+
+impl Component {
+    fn components_from_str(s: &str) -> anyhow::Result<&[Component]> {
+        match s {
+            "api" => Ok(&[Component::HttpApi, Component::WsApi]),
+            "http_api" => Ok(&[Component::HttpApi]),
+            "ws_api" => Ok(&[Component::WsApi]),
+            "tree" => Ok(&[Component::Tree]),
+            "tree_api" => Ok(&[Component::TreeApi]),
+            "tree_fetcher" => Ok(&[Component::TreeFetcher]),
+            "core" => Ok(&[Component::Core]),
+            "all" => Ok(&[
+                Component::HttpApi,
+                Component::WsApi,
+                Component::Tree,
+                Component::Core,
+            ]),
+            other => Err(anyhow::anyhow!("{other} is not a valid component name")),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ComponentsToRun(HashSet<Component>);
+
+impl FromStr for ComponentsToRun {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let components = s
+            .split(',')
+            .try_fold(HashSet::new(), |mut acc, component_str| {
+                let components = Component::components_from_str(component_str.trim())?;
+                acc.extend(components);
+                Ok::<_, Self::Err>(acc)
+            })?;
+        Ok(Self(components))
+    }
+}
+
+fn tokio_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
+    Ok(tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?)
+}
+
+fn main() -> anyhow::Result<()> {
+    let runtime = tokio_runtime()?;
+
+    // Initial setup.
+    let opt = Cli::parse();
+
+    if let Some(cmd) = &opt.command {
+        match cmd {
+            Command::GenerateSecrets => generate_consensus_secrets(),
+        }
+        return Ok(());
+    }
+
+    let mut config = if let Some(config_path) = opt.config_path.clone() {
+        let secrets_path = opt.secrets_path.clone().unwrap();
+        let external_node_config_path = opt.external_node_config_path.clone().unwrap();
+        if opt.enable_consensus {
+            anyhow::ensure!(
+                opt.consensus_path.is_some(),
+                "if --config-path and --enable-consensus are specified, then --consensus-path should be used to specify the location of the consensus config"
+            );
+        }
+        ExternalNodeConfig::from_files(
+            config_path,
+            external_node_config_path,
+            secrets_path,
+            opt.consensus_path.clone(),
+        )?
+    } else {
+        ExternalNodeConfig::new().context("Failed to load node configuration")?
+    };
+
+    if !opt.enable_consensus {
+        config.consensus = None;
+    }
+    let guard = {
+        // Observability stack implicitly spawns several tokio tasks, so we need to call this method
+        // from within tokio context.
+        let _rt_guard = runtime.enter();
+        config.observability.build_observability()?
+    };
+
+    // Build L1 and L2 clients.
+    let main_node_url = &config.required.main_node_url;
+    tracing::info!("Main node URL is: {main_node_url:?}");
+    let main_node_client = Client::http(main_node_url.clone())
+        .context("failed creating JSON-RPC client for main node")?
+        .for_network(config.required.l2_chain_id.into())
+        .with_allowed_requests_per_second(config.optional.main_node_rate_limit_rps)
+        .build();
+    let main_node_client = Box::new(main_node_client) as Box<DynClient<L2>>;
+
+    let config = runtime
+        .block_on(config.fetch_remote(main_node_client.as_ref()))
+        .context("failed fetching remote part of node config from main node")?;
+
+    let node = ExternalNodeBuilder::on_runtime(runtime, config)
+        .build(opt.components.0.into_iter().collect())?;
+    node.run(guard)?;
+    anyhow::Ok(())
+}

--- a/core/bin/via_external_node/src/metadata.rs
+++ b/core/bin/via_external_node/src/metadata.rs
@@ -1,0 +1,3 @@
+//! Metadata information about the external node.
+
+pub(crate) const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/core/bin/via_external_node/src/metrics/framework.rs
+++ b/core/bin/via_external_node/src/metrics/framework.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use zksync_dal::{ConnectionPool, Core, CoreDal as _};
+use zksync_node_framework::{
+    implementations::resources::pools::{MasterPool, PoolResource},
+    FromContext, IntoContext, StopReceiver, Task, TaskId, WiringError, WiringLayer,
+};
+use zksync_shared_metrics::rustc::RUST_METRICS;
+use zksync_types::{L1ChainId, L2ChainId, SLChainId};
+
+use super::EN_METRICS;
+
+#[derive(Debug)]
+pub struct ExternalNodeMetricsLayer {
+    pub l1_chain_id: L1ChainId,
+    pub sl_chain_id: SLChainId,
+    pub l2_chain_id: L2ChainId,
+    pub postgres_pool_size: u32,
+}
+
+#[derive(Debug, FromContext)]
+pub struct Input {
+    pub master_pool: PoolResource<MasterPool>,
+}
+
+#[derive(Debug, IntoContext)]
+pub struct Output {
+    #[context(task)]
+    pub task: ProtocolVersionMetricsTask,
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for ExternalNodeMetricsLayer {
+    type Input = Input;
+    type Output = Output;
+
+    fn layer_name(&self) -> &'static str {
+        "external_node_metrics"
+    }
+
+    async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
+        RUST_METRICS.initialize();
+        EN_METRICS.observe_config(
+            self.l1_chain_id,
+            self.sl_chain_id,
+            self.l2_chain_id,
+            self.postgres_pool_size,
+        );
+
+        let pool = input.master_pool.get_singleton().await?;
+        let task = ProtocolVersionMetricsTask { pool };
+        Ok(Output { task })
+    }
+}
+
+#[derive(Debug)]
+pub struct ProtocolVersionMetricsTask {
+    pool: ConnectionPool<Core>,
+}
+
+#[async_trait::async_trait]
+impl Task for ProtocolVersionMetricsTask {
+    fn id(&self) -> TaskId {
+        "en_protocol_version_metrics".into()
+    }
+
+    async fn run(self: Box<Self>, mut stop_receiver: StopReceiver) -> anyhow::Result<()> {
+        const QUERY_INTERVAL: Duration = Duration::from_secs(10);
+
+        while !*stop_receiver.0.borrow_and_update() {
+            let maybe_protocol_version = self
+                .pool
+                .connection()
+                .await?
+                .protocol_versions_dal()
+                .last_used_version_id()
+                .await;
+            if let Some(version) = maybe_protocol_version {
+                EN_METRICS.protocol_version.set(version as u64);
+            }
+
+            tokio::time::timeout(QUERY_INTERVAL, stop_receiver.0.changed())
+                .await
+                .ok();
+        }
+        Ok(())
+    }
+}

--- a/core/bin/via_external_node/src/metrics/mod.rs
+++ b/core/bin/via_external_node/src/metrics/mod.rs
@@ -1,0 +1,55 @@
+use vise::{EncodeLabelSet, Gauge, Info, Metrics};
+use zksync_types::{L1ChainId, L2ChainId, SLChainId};
+
+use crate::metadata::SERVER_VERSION;
+
+pub(crate) mod framework;
+
+/// Immutable EN parameters that affect multiple components.
+#[derive(Debug, Clone, Copy, EncodeLabelSet)]
+struct ExternalNodeInfo {
+    server_version: &'static str,
+    l1_chain_id: u64,
+    sl_chain_id: u64,
+    l2_chain_id: u64,
+    /// Size of the main Postgres connection pool.
+    postgres_pool_size: u32,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "external_node")]
+pub(crate) struct ExternalNodeMetrics {
+    /// General information about the external node.
+    info: Info<ExternalNodeInfo>,
+    /// Current protocol version.
+    protocol_version: Gauge<u64>,
+}
+
+impl ExternalNodeMetrics {
+    pub(crate) fn observe_config(
+        &self,
+        l1_chain_id: L1ChainId,
+        sl_chain_id: SLChainId,
+        l2_chain_id: L2ChainId,
+        postgres_pool_size: u32,
+    ) {
+        let info = ExternalNodeInfo {
+            server_version: SERVER_VERSION,
+            l1_chain_id: l1_chain_id.0,
+            sl_chain_id: sl_chain_id.0,
+            l2_chain_id: l2_chain_id.as_u64(),
+            postgres_pool_size,
+        };
+        tracing::info!("Setting general node information: {info:?}");
+
+        if self.info.set(info).is_err() {
+            tracing::warn!(
+                "General information is already set for the external node: {:?}, was attempting to set {info:?}",
+                self.info.get()
+            );
+        }
+    }
+}
+
+#[vise::register]
+pub(crate) static EN_METRICS: vise::Global<ExternalNodeMetrics> = vise::Global::new();

--- a/core/bin/via_external_node/src/node_builder.rs
+++ b/core/bin/via_external_node/src/node_builder.rs
@@ -235,7 +235,7 @@ impl ExternalNodeBuilder {
         Ok(self)
     }
 
-    fn add_l1_batch_commitment_mode_validation_layer(mut self) -> anyhow::Result<Self> {
+    fn _add_l1_batch_commitment_mode_validation_layer(mut self) -> anyhow::Result<Self> {
         let layer = L1BatchCommitmentModeValidationLayer::new(
             self.config.diamond_proxy_address(),
             self.config.optional.l1_batch_commit_data_generator_mode,
@@ -244,7 +244,7 @@ impl ExternalNodeBuilder {
         Ok(self)
     }
 
-    fn add_validate_chain_ids_layer(mut self) -> anyhow::Result<Self> {
+    fn _add_validate_chain_ids_layer(mut self) -> anyhow::Result<Self> {
         let layer = ValidateChainIdsLayer::new(
             self.config.required.settlement_layer_id(),
             self.config.required.l2_chain_id,
@@ -253,7 +253,7 @@ impl ExternalNodeBuilder {
         Ok(self)
     }
 
-    fn add_consistency_checker_layer(mut self) -> anyhow::Result<Self> {
+    fn _add_consistency_checker_layer(mut self) -> anyhow::Result<Self> {
         let max_batches_to_recheck = 10; // TODO (BFT-97): Make it a part of a proper EN config
         let layer = ConsistencyCheckerLayer::new(
             self.config.diamond_proxy_address(),
@@ -514,8 +514,8 @@ impl ExternalNodeBuilder {
 
         // Add preconditions for all the components.
         self = self
-            .add_l1_batch_commitment_mode_validation_layer()?
-            .add_validate_chain_ids_layer()?
+            // .add_l1_batch_commitment_mode_validation_layer()?
+            // .add_validate_chain_ids_layer()?
             .add_storage_initialization_layer(LayerKind::Precondition)?;
 
         // Sort the components, so that the components they may depend on each other are added in the correct order.
@@ -572,7 +572,7 @@ impl ExternalNodeBuilder {
                     self = self
                         .add_state_keeper_layer()?
                         .add_pruning_layer()?
-                        .add_consistency_checker_layer()?
+                        // .add_consistency_checker_layer()?
                         .add_commitment_generator_layer()?
                         .add_batch_status_updater_layer()?
                         .add_logs_bloom_backfill_layer()?;

--- a/core/bin/via_external_node/src/node_builder.rs
+++ b/core/bin/via_external_node/src/node_builder.rs
@@ -1,0 +1,627 @@
+//! This module provides a "builder" for the external node,
+//! as well as an interface to run the node with the specified components.
+
+use anyhow::Context as _;
+use zksync_block_reverter::NodeRole;
+use zksync_config::{
+    configs::{
+        api::{HealthCheckConfig, MerkleTreeApiConfig},
+        database::MerkleTreeMode,
+        DatabaseSecrets,
+    },
+    PostgresConfig,
+};
+use zksync_metadata_calculator::{MetadataCalculatorConfig, MetadataCalculatorRecoveryConfig};
+use zksync_node_api_server::{tx_sender::ApiContracts, web3::Namespace};
+use zksync_node_framework::{
+    implementations::layers::{
+        batch_status_updater::BatchStatusUpdaterLayer,
+        block_reverter::BlockReverterLayer,
+        commitment_generator::CommitmentGeneratorLayer,
+        consensus::ExternalNodeConsensusLayer,
+        consistency_checker::ConsistencyCheckerLayer,
+        healtcheck_server::HealthCheckLayer,
+        l1_batch_commitment_mode_validation::L1BatchCommitmentModeValidationLayer,
+        logs_bloom_backfill::LogsBloomBackfillLayer,
+        main_node_client::MainNodeClientLayer,
+        main_node_fee_params_fetcher::MainNodeFeeParamsFetcherLayer,
+        metadata_calculator::MetadataCalculatorLayer,
+        node_storage_init::{
+            external_node_strategy::{ExternalNodeInitStrategyLayer, SnapshotRecoveryConfig},
+            NodeStorageInitializerLayer,
+        },
+        pools_layer::PoolsLayerBuilder,
+        postgres_metrics::PostgresMetricsLayer,
+        prometheus_exporter::PrometheusExporterLayer,
+        pruning::PruningLayer,
+        query_eth_client::QueryEthClientLayer,
+        reorg_detector::ReorgDetectorLayer,
+        sigint::SigintHandlerLayer,
+        state_keeper::{
+            external_io::ExternalIOLayer, main_batch_executor::MainBatchExecutorLayer,
+            output_handler::OutputHandlerLayer, StateKeeperLayer,
+        },
+        sync_state_updater::SyncStateUpdaterLayer,
+        tree_data_fetcher::TreeDataFetcherLayer,
+        validate_chain_ids::ValidateChainIdsLayer,
+        web3_api::{
+            caches::MempoolCacheLayer,
+            server::{Web3ServerLayer, Web3ServerOptionalConfig},
+            tree_api_client::TreeApiClientLayer,
+            tx_sender::{PostgresStorageCachesConfig, TxSenderLayer},
+            tx_sink::ProxySinkLayer,
+        },
+    },
+    service::{ZkStackService, ZkStackServiceBuilder},
+};
+use zksync_state::RocksdbStorageOptions;
+
+use crate::{
+    config::{self, ExternalNodeConfig},
+    metrics::framework::ExternalNodeMetricsLayer,
+    Component,
+};
+
+/// Builder for the external node.
+#[derive(Debug)]
+pub(crate) struct ExternalNodeBuilder {
+    pub(crate) node: ZkStackServiceBuilder,
+    config: ExternalNodeConfig,
+}
+
+impl ExternalNodeBuilder {
+    #[cfg(test)]
+    pub fn new(config: ExternalNodeConfig) -> anyhow::Result<Self> {
+        Ok(Self {
+            node: ZkStackServiceBuilder::new().context("Cannot create ZkStackServiceBuilder")?,
+            config,
+        })
+    }
+
+    pub fn on_runtime(runtime: tokio::runtime::Runtime, config: ExternalNodeConfig) -> Self {
+        Self {
+            node: ZkStackServiceBuilder::on_runtime(runtime),
+            config,
+        }
+    }
+
+    fn add_sigint_handler_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(SigintHandlerLayer);
+        Ok(self)
+    }
+
+    fn add_pools_layer(mut self) -> anyhow::Result<Self> {
+        // Note: the EN config doesn't currently support specifying configuration for replicas,
+        // so we reuse the master configuration for that purpose.
+        // Settings unconditionally set to `None` are either not supported by the EN configuration layer
+        // or are not used in the context of the external node.
+        let config = PostgresConfig {
+            max_connections: Some(self.config.postgres.max_connections),
+            max_connections_master: Some(self.config.postgres.max_connections),
+            acquire_timeout_sec: None,
+            statement_timeout_sec: None,
+            long_connection_threshold_ms: self
+                .config
+                .optional
+                .long_connection_threshold()
+                .map(|d| d.as_millis() as u64),
+            slow_query_threshold_ms: self
+                .config
+                .optional
+                .slow_query_threshold()
+                .map(|d| d.as_millis() as u64),
+            test_server_url: None,
+            test_prover_url: None,
+        };
+        let secrets = DatabaseSecrets {
+            server_url: Some(self.config.postgres.database_url()),
+            server_replica_url: Some(self.config.postgres.database_url()),
+            prover_url: None,
+            verifier_url: None,
+        };
+        let pools_layer = PoolsLayerBuilder::empty(config, secrets)
+            .with_master(true)
+            .with_replica(true)
+            .build();
+        self.node.add_layer(pools_layer);
+        Ok(self)
+    }
+
+    fn add_postgres_metrics_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(PostgresMetricsLayer);
+        Ok(self)
+    }
+
+    fn add_external_node_metrics_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(ExternalNodeMetricsLayer {
+            l1_chain_id: self.config.required.l1_chain_id,
+            sl_chain_id: self.config.required.settlement_layer_id(),
+            l2_chain_id: self.config.required.l2_chain_id,
+            postgres_pool_size: self.config.postgres.max_connections,
+        });
+        Ok(self)
+    }
+
+    fn add_main_node_client_layer(mut self) -> anyhow::Result<Self> {
+        let layer = MainNodeClientLayer::new(
+            self.config.required.main_node_url.clone(),
+            self.config.optional.main_node_rate_limit_rps,
+            self.config.required.l2_chain_id,
+        );
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_healthcheck_layer(mut self) -> anyhow::Result<Self> {
+        let healthcheck_config = HealthCheckConfig {
+            port: self.config.required.healthcheck_port,
+            slow_time_limit_ms: self
+                .config
+                .optional
+                .healthcheck_slow_time_limit()
+                .map(|d| d.as_millis() as u64),
+            hard_time_limit_ms: self
+                .config
+                .optional
+                .healthcheck_hard_time_limit()
+                .map(|d| d.as_millis() as u64),
+        };
+        self.node.add_layer(HealthCheckLayer(healthcheck_config));
+        Ok(self)
+    }
+
+    fn add_prometheus_exporter_layer(mut self) -> anyhow::Result<Self> {
+        if let Some(prom_config) = self.config.observability.prometheus() {
+            self.node.add_layer(PrometheusExporterLayer(prom_config));
+        } else {
+            tracing::info!("No configuration for prometheus exporter, skipping");
+        }
+        Ok(self)
+    }
+
+    fn add_query_eth_client_layer(mut self) -> anyhow::Result<Self> {
+        let query_eth_client_layer = QueryEthClientLayer::new(
+            self.config.required.settlement_layer_id(),
+            self.config.required.eth_client_url.clone(),
+            // TODO(EVM-676): add this config for external node
+            Default::default(),
+        );
+        self.node.add_layer(query_eth_client_layer);
+        Ok(self)
+    }
+
+    fn add_state_keeper_layer(mut self) -> anyhow::Result<Self> {
+        // While optional bytecode compression may be disabled on the main node, there are batches where
+        // optional bytecode compression was enabled. To process these batches (and also for the case where
+        // compression will become optional on the sequencer again), EN has to allow txs without bytecode
+        // compression.
+        const OPTIONAL_BYTECODE_COMPRESSION: bool = true;
+
+        let persistence_layer = OutputHandlerLayer::new(
+            self.config
+                .remote
+                .l2_shared_bridge_addr
+                .expect("L2 shared bridge address is not set"),
+            self.config.optional.l2_block_seal_queue_capacity,
+        )
+        .with_pre_insert_txs(true) // EN requires txs to be pre-inserted.
+        .with_protective_reads_persistence_enabled(
+            self.config.optional.protective_reads_persistence_enabled,
+        );
+
+        let io_layer = ExternalIOLayer::new(self.config.required.l2_chain_id);
+
+        // We only need call traces on the external node if the `debug_` namespace is enabled.
+        let save_call_traces = self
+            .config
+            .optional
+            .api_namespaces()
+            .contains(&Namespace::Debug);
+        let main_node_batch_executor_builder_layer =
+            MainBatchExecutorLayer::new(save_call_traces, OPTIONAL_BYTECODE_COMPRESSION);
+
+        let rocksdb_options = RocksdbStorageOptions {
+            block_cache_capacity: self
+                .config
+                .experimental
+                .state_keeper_db_block_cache_capacity(),
+            max_open_files: self.config.experimental.state_keeper_db_max_open_files,
+        };
+        let state_keeper_layer = StateKeeperLayer::new(
+            self.config.required.state_cache_path.clone(),
+            rocksdb_options,
+        );
+        self.node
+            .add_layer(io_layer)
+            .add_layer(persistence_layer)
+            .add_layer(main_node_batch_executor_builder_layer)
+            .add_layer(state_keeper_layer);
+        Ok(self)
+    }
+
+    fn add_consensus_layer(mut self) -> anyhow::Result<Self> {
+        let config = self.config.consensus.clone();
+        let secrets =
+            config::read_consensus_secrets().context("config::read_consensus_secrets()")?;
+        let layer = ExternalNodeConsensusLayer { config, secrets };
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_pruning_layer(mut self) -> anyhow::Result<Self> {
+        if self.config.optional.pruning_enabled {
+            let layer = PruningLayer::new(
+                self.config.optional.pruning_removal_delay(),
+                self.config.optional.pruning_chunk_size,
+                self.config.optional.pruning_data_retention(),
+            );
+            self.node.add_layer(layer);
+        } else {
+            tracing::info!("Pruning is disabled");
+        }
+        Ok(self)
+    }
+
+    fn add_l1_batch_commitment_mode_validation_layer(mut self) -> anyhow::Result<Self> {
+        let layer = L1BatchCommitmentModeValidationLayer::new(
+            self.config.diamond_proxy_address(),
+            self.config.optional.l1_batch_commit_data_generator_mode,
+        );
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_validate_chain_ids_layer(mut self) -> anyhow::Result<Self> {
+        let layer = ValidateChainIdsLayer::new(
+            self.config.required.settlement_layer_id(),
+            self.config.required.l2_chain_id,
+        );
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_consistency_checker_layer(mut self) -> anyhow::Result<Self> {
+        let max_batches_to_recheck = 10; // TODO (BFT-97): Make it a part of a proper EN config
+        let layer = ConsistencyCheckerLayer::new(
+            self.config.diamond_proxy_address(),
+            max_batches_to_recheck,
+            self.config.optional.l1_batch_commit_data_generator_mode,
+        );
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_commitment_generator_layer(mut self) -> anyhow::Result<Self> {
+        let layer =
+            CommitmentGeneratorLayer::new(self.config.optional.l1_batch_commit_data_generator_mode)
+                .with_max_parallelism(
+                    self.config
+                        .experimental
+                        .commitment_generator_max_parallelism,
+                );
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_batch_status_updater_layer(mut self) -> anyhow::Result<Self> {
+        let layer = BatchStatusUpdaterLayer;
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_tree_data_fetcher_layer(mut self) -> anyhow::Result<Self> {
+        let layer = TreeDataFetcherLayer::new(self.config.diamond_proxy_address());
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_sync_state_updater_layer(mut self) -> anyhow::Result<Self> {
+        // This layer may be used as a fallback for EN API if API server runs without the core component.
+        self.node.add_layer(SyncStateUpdaterLayer);
+        Ok(self)
+    }
+
+    fn add_metadata_calculator_layer(mut self, with_tree_api: bool) -> anyhow::Result<Self> {
+        let metadata_calculator_config = MetadataCalculatorConfig {
+            db_path: self.config.required.merkle_tree_path.clone(),
+            max_open_files: self.config.optional.merkle_tree_max_open_files,
+            mode: MerkleTreeMode::Lightweight,
+            delay_interval: self.config.optional.merkle_tree_processing_delay(),
+            max_l1_batches_per_iter: self.config.optional.merkle_tree_max_l1_batches_per_iter,
+            multi_get_chunk_size: self.config.optional.merkle_tree_multi_get_chunk_size,
+            block_cache_capacity: self.config.optional.merkle_tree_block_cache_size(),
+            include_indices_and_filters_in_block_cache: self
+                .config
+                .optional
+                .merkle_tree_include_indices_and_filters_in_block_cache,
+            memtable_capacity: self.config.optional.merkle_tree_memtable_capacity(),
+            stalled_writes_timeout: self.config.optional.merkle_tree_stalled_writes_timeout(),
+            sealed_batches_have_protective_reads: self
+                .config
+                .optional
+                .protective_reads_persistence_enabled,
+            recovery: MetadataCalculatorRecoveryConfig {
+                desired_chunk_size: self.config.experimental.snapshots_recovery_tree_chunk_size,
+                parallel_persistence_buffer: self
+                    .config
+                    .experimental
+                    .snapshots_recovery_tree_parallel_persistence_buffer,
+            },
+        };
+
+        // Configure basic tree layer.
+        let mut layer = MetadataCalculatorLayer::new(metadata_calculator_config);
+
+        // Add tree API if needed.
+        if with_tree_api {
+            let merkle_tree_api_config = MerkleTreeApiConfig {
+                port: self
+                    .config
+                    .tree_component
+                    .api_port
+                    .context("should contain tree api port")?,
+            };
+            layer = layer.with_tree_api_config(merkle_tree_api_config);
+        }
+
+        // Add tree pruning if needed.
+        if self.config.optional.pruning_enabled {
+            layer = layer.with_pruning_config(self.config.optional.pruning_removal_delay());
+        }
+
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    fn add_tx_sender_layer(mut self) -> anyhow::Result<Self> {
+        let postgres_storage_config = PostgresStorageCachesConfig {
+            factory_deps_cache_size: self.config.optional.factory_deps_cache_size() as u64,
+            initial_writes_cache_size: self.config.optional.initial_writes_cache_size() as u64,
+            latest_values_cache_size: self.config.optional.latest_values_cache_size() as u64,
+        };
+        let max_vm_concurrency = self.config.optional.vm_concurrency_limit;
+        let api_contracts = ApiContracts::load_from_disk_blocking(); // TODO (BFT-138): Allow to dynamically reload API contracts;
+        let tx_sender_layer = TxSenderLayer::new(
+            (&self.config).into(),
+            postgres_storage_config,
+            max_vm_concurrency,
+            api_contracts,
+        )
+        .with_whitelisted_tokens_for_aa_cache(true);
+
+        self.node.add_layer(ProxySinkLayer);
+        self.node.add_layer(tx_sender_layer);
+        Ok(self)
+    }
+
+    fn add_mempool_cache_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(MempoolCacheLayer::new(
+            self.config.optional.mempool_cache_size,
+            self.config.optional.mempool_cache_update_interval(),
+        ));
+        Ok(self)
+    }
+
+    fn add_tree_api_client_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(TreeApiClientLayer::http(
+            self.config.api_component.tree_api_remote_url.clone(),
+        ));
+        Ok(self)
+    }
+
+    fn add_main_node_fee_params_fetcher_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(MainNodeFeeParamsFetcherLayer);
+        Ok(self)
+    }
+
+    fn add_logs_bloom_backfill_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(LogsBloomBackfillLayer);
+        Ok(self)
+    }
+
+    fn web3_api_optional_config(&self) -> Web3ServerOptionalConfig {
+        // The refresh interval should be several times lower than the pruning removal delay, so that
+        // soft-pruning will timely propagate to the API server.
+        let pruning_info_refresh_interval = self.config.optional.pruning_removal_delay() / 5;
+
+        Web3ServerOptionalConfig {
+            namespaces: Some(self.config.optional.api_namespaces()),
+            filters_limit: Some(self.config.optional.filters_limit),
+            subscriptions_limit: Some(self.config.optional.subscriptions_limit),
+            batch_request_size_limit: Some(self.config.optional.max_batch_request_size),
+            response_body_size_limit: Some(self.config.optional.max_response_body_size()),
+            with_extended_tracing: self.config.optional.extended_rpc_tracing,
+            pruning_info_refresh_interval: Some(pruning_info_refresh_interval),
+            polling_interval: Some(self.config.optional.polling_interval()),
+            websocket_requests_per_minute_limit: None, // To be set by WS server layer method if required.
+            replication_lag_limit: None,               // TODO: Support replication lag limit
+        }
+    }
+
+    fn add_http_web3_api_layer(mut self) -> anyhow::Result<Self> {
+        let optional_config = self.web3_api_optional_config();
+        self.node.add_layer(Web3ServerLayer::http(
+            self.config.required.http_port,
+            (&self.config).into(),
+            optional_config,
+        ));
+
+        Ok(self)
+    }
+
+    fn add_ws_web3_api_layer(mut self) -> anyhow::Result<Self> {
+        // TODO: Support websocket requests per minute limit
+        let optional_config = self.web3_api_optional_config();
+        self.node.add_layer(Web3ServerLayer::ws(
+            self.config.required.ws_port,
+            (&self.config).into(),
+            optional_config,
+        ));
+
+        Ok(self)
+    }
+
+    fn add_reorg_detector_layer(mut self) -> anyhow::Result<Self> {
+        self.node.add_layer(ReorgDetectorLayer);
+        Ok(self)
+    }
+
+    fn add_block_reverter_layer(mut self) -> anyhow::Result<Self> {
+        let mut layer = BlockReverterLayer::new(NodeRole::External);
+        // Reverting executed batches is more-or-less safe for external nodes.
+        layer
+            .allow_rolling_back_executed_batches()
+            .enable_rolling_back_postgres()
+            .enable_rolling_back_merkle_tree(self.config.required.merkle_tree_path.clone())
+            .enable_rolling_back_state_keeper_cache(self.config.required.state_cache_path.clone());
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    /// This layer will make sure that the database is initialized correctly,
+    /// e.g.:
+    /// - genesis or snapshot recovery will be performed if it's required.
+    /// - we perform the storage rollback if required (e.g. if reorg is detected).
+    ///
+    /// Depending on the `kind` provided, either a task or a precondition will be added.
+    ///
+    /// *Important*: the task should be added by at most one component, because
+    /// it assumes unique control over the database. Multiple components adding this
+    /// layer in a distributed mode may result in the database corruption.
+    ///
+    /// This task works in pair with precondition, which must be present in every component:
+    /// the precondition will prevent node from starting until the database is initialized.
+    fn add_storage_initialization_layer(mut self, kind: LayerKind) -> anyhow::Result<Self> {
+        let config = &self.config;
+        let snapshot_recovery_config =
+            config
+                .optional
+                .snapshots_recovery_enabled
+                .then_some(SnapshotRecoveryConfig {
+                    snapshot_l1_batch_override: config.experimental.snapshots_recovery_l1_batch,
+                    drop_storage_key_preimages: config
+                        .experimental
+                        .snapshots_recovery_drop_storage_key_preimages,
+                    object_store_config: config.optional.snapshots_recovery_object_store.clone(),
+                });
+        self.node.add_layer(ExternalNodeInitStrategyLayer {
+            l2_chain_id: self.config.required.l2_chain_id,
+            max_postgres_concurrency: self
+                .config
+                .optional
+                .snapshots_recovery_postgres_max_concurrency,
+            snapshot_recovery_config,
+        });
+        let mut layer = NodeStorageInitializerLayer::new();
+        if matches!(kind, LayerKind::Precondition) {
+            layer = layer.as_precondition();
+        }
+        self.node.add_layer(layer);
+        Ok(self)
+    }
+
+    pub fn build(mut self, mut components: Vec<Component>) -> anyhow::Result<ZkStackService> {
+        // Add "base" layers
+        self = self
+            .add_sigint_handler_layer()?
+            .add_healthcheck_layer()?
+            .add_prometheus_exporter_layer()?
+            .add_pools_layer()?
+            .add_main_node_client_layer()?
+            .add_query_eth_client_layer()?
+            .add_reorg_detector_layer()?;
+
+        // Add layers that must run only on a single component.
+        if components.contains(&Component::Core) {
+            // Core is a singleton & mandatory component,
+            // so until we have a dedicated component for "auxiliary" tasks,
+            // it's responsible for things like metrics.
+            self = self
+                .add_postgres_metrics_layer()?
+                .add_external_node_metrics_layer()?;
+            // We assign the storage initialization to the core, as it's considered to be
+            // the "main" component.
+            self = self
+                .add_block_reverter_layer()?
+                .add_storage_initialization_layer(LayerKind::Task)?;
+        }
+
+        // Add preconditions for all the components.
+        self = self
+            .add_l1_batch_commitment_mode_validation_layer()?
+            .add_validate_chain_ids_layer()?
+            .add_storage_initialization_layer(LayerKind::Precondition)?;
+
+        // Sort the components, so that the components they may depend on each other are added in the correct order.
+        components.sort_unstable_by_key(|component| match component {
+            // API consumes the resources provided by other layers (multiple ones), so it has to come the last.
+            Component::HttpApi | Component::WsApi => 1,
+            // Default priority.
+            _ => 0,
+        });
+
+        for component in &components {
+            match component {
+                Component::HttpApi => {
+                    self = self
+                        .add_sync_state_updater_layer()?
+                        .add_mempool_cache_layer()?
+                        .add_tree_api_client_layer()?
+                        .add_main_node_fee_params_fetcher_layer()?
+                        .add_tx_sender_layer()?
+                        .add_http_web3_api_layer()?;
+                }
+                Component::WsApi => {
+                    self = self
+                        .add_sync_state_updater_layer()?
+                        .add_mempool_cache_layer()?
+                        .add_tree_api_client_layer()?
+                        .add_main_node_fee_params_fetcher_layer()?
+                        .add_tx_sender_layer()?
+                        .add_ws_web3_api_layer()?;
+                }
+                Component::Tree => {
+                    // Right now, distributed mode for EN is not fully supported, e.g. there are some
+                    // issues with reorg detection and snapshot recovery.
+                    // So we require the core component to be present, e.g. forcing the EN to run in a monolithic mode.
+                    anyhow::ensure!(
+                        components.contains(&Component::Core),
+                        "Tree must run on the same machine as Core"
+                    );
+                    let with_tree_api = components.contains(&Component::TreeApi);
+                    self = self.add_metadata_calculator_layer(with_tree_api)?;
+                }
+                Component::TreeApi => {
+                    anyhow::ensure!(
+                        components.contains(&Component::Tree),
+                        "Merkle tree API cannot be started without a tree component"
+                    );
+                    // Do nothing, will be handled by the `Tree` component.
+                }
+                Component::TreeFetcher => {
+                    self = self.add_tree_data_fetcher_layer()?;
+                }
+                Component::Core => {
+                    // Main tasks
+                    self = self
+                        .add_state_keeper_layer()?
+                        .add_consensus_layer()?
+                        .add_pruning_layer()?
+                        .add_consistency_checker_layer()?
+                        .add_commitment_generator_layer()?
+                        .add_batch_status_updater_layer()?
+                        .add_logs_bloom_backfill_layer()?;
+                }
+            }
+        }
+
+        Ok(self.node.build())
+    }
+}
+
+/// Marker for layers that can add either a task or a precondition.
+#[derive(Debug)]
+enum LayerKind {
+    Task,
+    Precondition,
+}

--- a/core/bin/via_external_node/src/tests/framework.rs
+++ b/core/bin/via_external_node/src/tests/framework.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+
+use tokio::sync::oneshot;
+use zksync_health_check::AppHealthCheck;
+use zksync_node_framework::{
+    implementations::{
+        layers::{
+            main_node_client::MainNodeClientLayer, query_eth_client::QueryEthClientLayer,
+            sigint::SigintHandlerLayer,
+        },
+        resources::{
+            eth_interface::EthInterfaceResource, healthcheck::AppHealthCheckResource,
+            main_node_client::MainNodeClientResource,
+        },
+    },
+    service::ServiceContext,
+    task::TaskKind,
+    FromContext, IntoContext, StopReceiver, Task, TaskId, WiringError, WiringLayer,
+};
+use zksync_types::{L2ChainId, SLChainId};
+use zksync_web3_decl::client::{MockClient, L1, L2};
+
+use super::ExternalNodeBuilder;
+
+pub(super) fn inject_test_layers(
+    node: &mut ExternalNodeBuilder,
+    sigint_receiver: oneshot::Receiver<()>,
+    app_health_sender: oneshot::Sender<Arc<AppHealthCheck>>,
+    l1_client: MockClient<L1>,
+    l2_client: MockClient<L2>,
+) {
+    node.node
+        .add_layer(TestSigintLayer {
+            receiver: sigint_receiver,
+        })
+        .add_layer(AppHealthHijackLayer {
+            sender: app_health_sender,
+        })
+        .add_layer(MockL1ClientLayer { client: l1_client })
+        .add_layer(MockL2ClientLayer { client: l2_client });
+}
+
+/// A test layer that would stop the node upon request.
+/// Replaces the `SigintHandlerLayer` in tests.
+#[derive(Debug)]
+struct TestSigintLayer {
+    receiver: oneshot::Receiver<()>,
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for TestSigintLayer {
+    type Input = ();
+    type Output = TestSigintTask;
+
+    fn layer_name(&self) -> &'static str {
+        // We want to override layer by inserting it first.
+        SigintHandlerLayer.layer_name()
+    }
+
+    async fn wire(self, _: Self::Input) -> Result<Self::Output, WiringError> {
+        Ok(TestSigintTask(self.receiver))
+    }
+}
+
+struct TestSigintTask(oneshot::Receiver<()>);
+
+#[async_trait::async_trait]
+impl Task for TestSigintTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::UnconstrainedTask
+    }
+
+    fn id(&self) -> TaskId {
+        "test_sigint_task".into()
+    }
+
+    async fn run(self: Box<Self>, _: StopReceiver) -> anyhow::Result<()> {
+        self.0.await?;
+        Ok(())
+    }
+}
+
+impl IntoContext for TestSigintTask {
+    fn into_context(self, context: &mut ServiceContext<'_>) -> Result<(), WiringError> {
+        context.add_task(self);
+        Ok(())
+    }
+}
+
+/// Hijacks the `AppHealthCheck` from the context and passes it to the test.
+/// Note: It's a separate layer to get access to the app health check, not an override.
+#[derive(Debug)]
+struct AppHealthHijackLayer {
+    sender: oneshot::Sender<Arc<AppHealthCheck>>,
+}
+
+#[derive(Debug, FromContext)]
+struct AppHealthHijackInput {
+    #[context(default)]
+    app_health_check: AppHealthCheckResource,
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for AppHealthHijackLayer {
+    type Input = AppHealthHijackInput;
+    type Output = ();
+
+    fn layer_name(&self) -> &'static str {
+        "app_health_hijack"
+    }
+
+    async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
+        self.sender.send(input.app_health_check.0).unwrap();
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct MockL1ClientLayer {
+    client: MockClient<L1>,
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for MockL1ClientLayer {
+    type Input = ();
+    type Output = EthInterfaceResource;
+
+    fn layer_name(&self) -> &'static str {
+        // We don't care about values, we just want to hijack the layer name.
+        // TODO(EVM-676): configure the `settlement_mode` here
+        QueryEthClientLayer::new(
+            SLChainId(1),
+            "https://example.com".parse().unwrap(),
+            Default::default(),
+        )
+        .layer_name()
+    }
+
+    async fn wire(self, _: Self::Input) -> Result<Self::Output, WiringError> {
+        Ok(EthInterfaceResource(Box::new(self.client)))
+    }
+}
+
+#[derive(Debug)]
+struct MockL2ClientLayer {
+    client: MockClient<L2>,
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for MockL2ClientLayer {
+    type Input = ();
+    type Output = MainNodeClientResource;
+
+    fn layer_name(&self) -> &'static str {
+        // We don't care about values, we just want to hijack the layer name.
+        MainNodeClientLayer::new(
+            "https://example.com".parse().unwrap(),
+            100.try_into().unwrap(),
+            L2ChainId::default(),
+        )
+        .layer_name()
+    }
+
+    async fn wire(self, _: Self::Input) -> Result<Self::Output, WiringError> {
+        Ok(MainNodeClientResource(Box::new(self.client)))
+    }
+}

--- a/core/bin/via_external_node/src/tests/mod.rs
+++ b/core/bin/via_external_node/src/tests/mod.rs
@@ -1,0 +1,201 @@
+//! High-level tests for EN.
+
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use framework::inject_test_layers;
+use test_casing::test_casing;
+use zksync_health_check::HealthStatus;
+use zksync_types::{fee_model::FeeParams, L1BatchNumber, U64};
+use zksync_web3_decl::jsonrpsee::core::ClientError;
+
+use super::*;
+
+mod framework;
+mod utils;
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[test_casing(3, ["all", "core", "api"])]
+#[tokio::test]
+#[tracing::instrument] // Add args to the test logs
+async fn external_node_basics(components_str: &'static str) {
+    let _guard = zksync_vlog::ObservabilityBuilder::new().build(); // Enable logging to simplify debugging
+
+    let (env, env_handles) = utils::TestEnvironment::with_genesis_block(components_str).await;
+
+    let expected_health_components = utils::expected_health_components(&env.components);
+    let l2_client = utils::mock_l2_client(&env);
+    let eth_client = utils::mock_eth_client(env.config.diamond_proxy_address());
+
+    let node_handle = tokio::task::spawn_blocking(move || {
+        std::thread::spawn(move || {
+            let mut node = ExternalNodeBuilder::new(env.config)?;
+            inject_test_layers(
+                &mut node,
+                env.sigint_receiver,
+                env.app_health_sender,
+                eth_client,
+                l2_client,
+            );
+
+            let node = node.build(env.components.0.into_iter().collect())?;
+            node.run(None)?;
+            anyhow::Ok(())
+        })
+        .join()
+        .unwrap()
+    });
+
+    // Wait until the node is ready.
+    let app_health = match env_handles.app_health_receiver.await {
+        Ok(app_health) => app_health,
+        Err(_) if node_handle.is_finished() => {
+            node_handle.await.unwrap().unwrap();
+            unreachable!("Node tasks should have panicked or errored");
+        }
+        Err(_) => unreachable!("Node tasks should have panicked or errored"),
+    };
+
+    loop {
+        let health_data = app_health.check_health().await;
+        tracing::info!(?health_data, "received health data");
+        if matches!(health_data.inner().status(), HealthStatus::Ready)
+            && expected_health_components
+                .iter()
+                .all(|name| health_data.components().contains_key(name))
+        {
+            break;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    // Stop the node and check that it timely terminates.
+    env_handles.sigint_sender.send(()).unwrap();
+
+    tokio::time::timeout(SHUTDOWN_TIMEOUT, node_handle)
+        .await
+        .expect("Node hanged up during shutdown")
+        .expect("Node panicked")
+        .expect("Node errored");
+
+    // Check that the node health was appropriately updated.
+    let health_data = app_health.check_health().await;
+    tracing::info!(?health_data, "final health data");
+    assert_matches!(health_data.inner().status(), HealthStatus::ShutDown);
+    for name in expected_health_components {
+        let component_health = &health_data.components()[name];
+        assert_matches!(component_health.status(), HealthStatus::ShutDown);
+    }
+}
+
+#[tokio::test]
+async fn node_reacts_to_stop_signal_during_initial_reorg_detection() {
+    let _guard = zksync_vlog::ObservabilityBuilder::new().build(); // Enable logging to simplify debugging
+    let (env, env_handles) = utils::TestEnvironment::with_genesis_block("core").await;
+
+    let l2_client = utils::mock_l2_client_hanging();
+    let eth_client = utils::mock_eth_client(env.config.diamond_proxy_address());
+
+    let mut node_handle = tokio::task::spawn_blocking(move || {
+        std::thread::spawn(move || {
+            let mut node = ExternalNodeBuilder::new(env.config)?;
+            inject_test_layers(
+                &mut node,
+                env.sigint_receiver,
+                env.app_health_sender,
+                eth_client,
+                l2_client,
+            );
+
+            let node = node.build(env.components.0.into_iter().collect())?;
+            node.run(None)?;
+            anyhow::Ok(())
+        })
+        .join()
+        .unwrap()
+    });
+
+    // Check that the node doesn't stop on its own.
+    let timeout_result = tokio::time::timeout(Duration::from_millis(50), &mut node_handle).await;
+    assert_matches!(timeout_result, Err(tokio::time::error::Elapsed { .. }));
+
+    // Send a stop signal and check that the node reacts to it.
+    env_handles.sigint_sender.send(()).unwrap();
+    node_handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn running_tree_without_core_is_not_allowed() {
+    let _guard = zksync_vlog::ObservabilityBuilder::new().build(); // Enable logging to simplify debugging
+    let (env, _env_handles) = utils::TestEnvironment::with_genesis_block("tree").await;
+
+    let l2_client = utils::mock_l2_client(&env);
+    let eth_client = utils::mock_eth_client(env.config.diamond_proxy_address());
+
+    let node_handle = tokio::task::spawn_blocking(move || {
+        std::thread::spawn(move || {
+            let mut node = ExternalNodeBuilder::new(env.config)?;
+            inject_test_layers(
+                &mut node,
+                env.sigint_receiver,
+                env.app_health_sender,
+                eth_client,
+                l2_client,
+            );
+
+            // We're only interested in the error, so we drop the result.
+            node.build(env.components.0.into_iter().collect()).map(drop)
+        })
+        .join()
+        .unwrap()
+    });
+
+    // Check that we cannot build the node without the core component.
+    let result = node_handle.await.expect("Building the node panicked");
+    let err = result.expect_err("Building the node with tree but without core should fail");
+    assert!(
+        err.to_string()
+            .contains("Tree must run on the same machine as Core"),
+        "Unexpected errror: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn running_tree_api_without_tree_is_not_allowed() {
+    let _guard = zksync_vlog::ObservabilityBuilder::new().build(); // Enable logging to simplify debugging
+    let (env, _env_handles) = utils::TestEnvironment::with_genesis_block("core,tree_api").await;
+
+    let l2_client = utils::mock_l2_client(&env);
+    let eth_client = utils::mock_eth_client(env.config.diamond_proxy_address());
+
+    let node_handle = tokio::task::spawn_blocking(move || {
+        std::thread::spawn(move || {
+            let mut node = ExternalNodeBuilder::new(env.config)?;
+            inject_test_layers(
+                &mut node,
+                env.sigint_receiver,
+                env.app_health_sender,
+                eth_client,
+                l2_client,
+            );
+
+            // We're only interested in the error, so we drop the result.
+            node.build(env.components.0.into_iter().collect()).map(drop)
+        })
+        .join()
+        .unwrap()
+    });
+
+    // Check that we cannot build the node without the core component.
+    let result = node_handle.await.expect("Building the node panicked");
+    let err = result.expect_err("Building the node with tree api but without tree should fail");
+    assert!(
+        err.to_string()
+            .contains("Merkle tree API cannot be started without a tree component"),
+        "Unexpected errror: {}",
+        err
+    );
+}

--- a/core/bin/via_external_node/src/tests/utils.rs
+++ b/core/bin/via_external_node/src/tests/utils.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::sync::oneshot;
+use zksync_dal::{ConnectionPoolBuilder, Core, CoreDal};
+use zksync_db_connection::connection_pool::TestTemplate;
+use zksync_eth_client::clients::MockSettlementLayer;
+use zksync_health_check::AppHealthCheck;
+use zksync_node_genesis::{insert_genesis_batch, GenesisBatchParams, GenesisParams};
+use zksync_types::{
+    api, block::L2BlockHeader, ethabi, Address, L2BlockNumber, ProtocolVersionId, H256,
+};
+use zksync_web3_decl::client::{MockClient, L1};
+
+use super::*;
+
+pub(super) fn block_details_base(hash: H256) -> api::BlockDetailsBase {
+    api::BlockDetailsBase {
+        timestamp: 0,
+        l1_tx_count: 0,
+        l2_tx_count: 0,
+        root_hash: Some(hash),
+        status: api::BlockStatus::Sealed,
+        commit_tx_hash: None,
+        committed_at: None,
+        prove_tx_hash: None,
+        proven_at: None,
+        execute_tx_hash: None,
+        executed_at: None,
+        l1_gas_price: 0,
+        l2_fair_gas_price: 0,
+        fair_pubdata_price: None,
+        base_system_contracts_hashes: Default::default(),
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct TestEnvironment {
+    pub(super) sigint_receiver: oneshot::Receiver<()>,
+    pub(super) app_health_sender: oneshot::Sender<Arc<AppHealthCheck>>,
+    pub(super) components: ComponentsToRun,
+    pub(super) config: ExternalNodeConfig,
+    pub(super) genesis_params: GenesisBatchParams,
+    pub(super) genesis_l2_block: L2BlockHeader,
+    // We have to prevent object from dropping the temp dir, so we store it here.
+    _temp_dir: TempDir,
+}
+
+impl TestEnvironment {
+    pub async fn with_genesis_block(components_str: &str) -> (Self, TestEnvironmentHandles) {
+        // Generate a new environment with a genesis block.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // Simplest case to mock: the EN already has a genesis L1 batch / L2 block, and it's the only L1 batch / L2 block
+        // in the network.
+        let test_db: ConnectionPoolBuilder<Core> =
+            TestTemplate::empty().unwrap().create_db(100).await.unwrap();
+        let connection_pool = test_db.build().await.unwrap();
+        // let singleton_pool_builder = ConnectionPool::singleton(connection_pool.database_url().clone());
+        let mut storage = connection_pool.connection().await.unwrap();
+        let genesis_params = insert_genesis_batch(&mut storage, &GenesisParams::mock())
+            .await
+            .unwrap();
+        let genesis_l2_block = storage
+            .blocks_dal()
+            .get_l2_block_header(L2BlockNumber(0))
+            .await
+            .unwrap()
+            .expect("No genesis L2 block");
+        drop(storage);
+
+        let components: ComponentsToRun = components_str.parse().unwrap();
+        let mut config = ExternalNodeConfig::mock(&temp_dir, &connection_pool);
+        if components.0.contains(&Component::TreeApi) {
+            config.tree_component.api_port = Some(0);
+        }
+        drop(connection_pool);
+
+        // Generate channels to control the node.
+
+        let (sigint_sender, sigint_receiver) = oneshot::channel();
+        let (app_health_sender, app_health_receiver) = oneshot::channel();
+        let this = Self {
+            sigint_receiver,
+            app_health_sender,
+            components,
+            config,
+            genesis_params,
+            genesis_l2_block,
+            _temp_dir: temp_dir,
+        };
+        let handles = TestEnvironmentHandles {
+            sigint_sender,
+            app_health_receiver,
+        };
+
+        (this, handles)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct TestEnvironmentHandles {
+    pub(super) sigint_sender: oneshot::Sender<()>,
+    pub(super) app_health_receiver: oneshot::Receiver<Arc<AppHealthCheck>>,
+}
+
+// The returned components have the fully implemented health check life cycle (i.e., signal their shutdown).
+pub(super) fn expected_health_components(components: &ComponentsToRun) -> Vec<&'static str> {
+    let mut output = vec!["reorg_detector"];
+    if components.0.contains(&Component::Core) {
+        output.extend(["consistency_checker", "commitment_generator"]);
+    }
+    if components.0.contains(&Component::Tree) {
+        output.push("tree");
+    }
+    if components.0.contains(&Component::HttpApi) {
+        output.push("http_api");
+    }
+    if components.0.contains(&Component::WsApi) {
+        output.push("ws_api");
+    }
+    output
+}
+
+pub(super) fn mock_eth_client(diamond_proxy_addr: Address) -> MockClient<L1> {
+    let mock = MockSettlementLayer::builder().with_call_handler(move |call, _| {
+        tracing::info!("L1 call: {call:?}");
+        if call.to == Some(diamond_proxy_addr) {
+            let packed_semver = ProtocolVersionId::latest().into_packed_semver_with_patch(0);
+            let call_signature = &call.data.as_ref().unwrap().0[..4];
+            let contract = zksync_contracts::hyperchain_contract();
+            let pricing_mode_sig = contract
+                .function("getPubdataPricingMode")
+                .unwrap()
+                .short_signature();
+            let protocol_version_sig = contract
+                .function("getProtocolVersion")
+                .unwrap()
+                .short_signature();
+            match call_signature {
+                sig if sig == pricing_mode_sig => {
+                    return ethabi::Token::Uint(0.into()); // "rollup" mode encoding
+                }
+                sig if sig == protocol_version_sig => return ethabi::Token::Uint(packed_semver),
+                _ => { /* unknown call; panic below */ }
+            }
+        }
+        panic!("Unexpected L1 call: {call:?}");
+    });
+    mock.build().into_client()
+}
+
+/// Creates a mock L2 client with the genesis block information.
+pub(super) fn mock_l2_client(env: &TestEnvironment) -> MockClient<L2> {
+    let genesis_root_hash = env.genesis_params.root_hash;
+    let genesis_l2_block_hash = env.genesis_l2_block.hash;
+
+    MockClient::builder(L2::default())
+        .method("eth_chainId", || Ok(U64::from(270)))
+        .method("zks_L1ChainId", || Ok(U64::from(9)))
+        .method("zks_L1BatchNumber", || Ok(U64::from(0)))
+        .method("zks_getL1BatchDetails", move |number: L1BatchNumber| {
+            assert_eq!(number, L1BatchNumber(0));
+            Ok(api::L1BatchDetails {
+                number: L1BatchNumber(0),
+                base: utils::block_details_base(genesis_root_hash),
+            })
+        })
+        .method("eth_blockNumber", || Ok(U64::from(0)))
+        .method(
+            "eth_getBlockByNumber",
+            move |number: api::BlockNumber, _with_txs: bool| {
+                assert_eq!(number, api::BlockNumber::Number(0.into()));
+                Ok(api::Block::<api::TransactionVariant> {
+                    hash: genesis_l2_block_hash,
+                    ..api::Block::default()
+                })
+            },
+        )
+        .method("zks_getFeeParams", || Ok(FeeParams::sensible_v1_default()))
+        .method("en_whitelistedTokensForAA", || Ok([] as [Address; 0]))
+        .build()
+}
+
+/// Creates a mock L2 client that will mimic request timeouts on block info requests.
+pub(super) fn mock_l2_client_hanging() -> MockClient<L2> {
+    MockClient::builder(L2::default())
+        .method("eth_chainId", || Ok(U64::from(270)))
+        .method("zks_L1ChainId", || Ok(U64::from(9)))
+        .method("zks_L1BatchNumber", || {
+            Err::<(), _>(ClientError::RequestTimeout)
+        })
+        .method("eth_blockNumber", || {
+            Err::<(), _>(ClientError::RequestTimeout)
+        })
+        .method("zks_getFeeParams", || Ok(FeeParams::sensible_v1_default()))
+        .method("en_whitelistedTokensForAA", || Ok([] as [Address; 0]))
+        .build()
+}

--- a/etc/env/base/object_store.toml
+++ b/etc/env/base/object_store.toml
@@ -13,3 +13,6 @@ file_backed_base_path="artifacts"
 [snapshots_object_store]
 mode="FileBacked"
 file_backed_base_path="artifacts"
+
+[snapshots_creator]
+object_store={mode="FileBacked", file_backed_base_path="artifacts"}

--- a/etc/env/configs/ext-node.toml
+++ b/etc/env/configs/ext-node.toml
@@ -2,12 +2,15 @@
 # All the variables must be provided explicitly.
 # This is on purpose: if EN will accidentally depend on the main node env, it may cause problems.
 
-database_url = "postgres://postgres:notsecurepassword@localhost/zksync_local_ext_node"
-test_database_url = "postgres://postgres:notsecurepassword@localhost:5433/zksync_local_test_ext_node"
+database_url = "postgres://postgres:notsecurepassword@localhost/via_local_ext_node"
+test_database_url = "postgres://postgres:notsecurepassword@localhost:5433/via_local_test_ext_node"
 database_pool_size = 50
 zksync_action = "dont_ask"
 
 [en]
+main_node_url = "https://sepolia.era.zksync.dev"
+pruning_data_retention_hours = 1
+snapshots_recovery_enabled = true
 http_port = 3060
 ws_port = 3061
 prometheus_port = 3322
@@ -22,7 +25,7 @@ state_cache_path = "./db/ext-node/state_keeper"
 merkle_tree_path = "./db/ext-node/lightweight"
 max_l1_batches_per_tree_iter = 20
 
-eth_client_url = "http://127.0.0.1:8545"
+eth_client_url = "https://ethereum-sepolia-rpc.publicnode.com"
 
 api_namespaces = ["eth", "web3", "net", "pubsub", "zks", "en", "debug"]
 
@@ -43,7 +46,8 @@ long_connection_threshold_ms = 2000
 slow_query_threshold_ms = 100
 
 [en.snapshots.object_store]
-mode = "FileBacked"
+bucket_base_url = "zksync-era-boojnet-external-node-snapshots"
+mode = "GCSAnonymousReadOnly"
 file_backed_base_path = "artifacts"
 # ^ Intentionally set to coincide with main node's in order to read locally produced snapshots
 

--- a/infrastructure/via/src/database.ts
+++ b/infrastructure/via/src/database.ts
@@ -143,7 +143,7 @@ export async function setupForDal(dalPath: DalPath, dbUrl: string, shouldCheck: 
 
     shouldCheck = shouldCheck && dbUrl.startsWith(localDbUrl) && !isLocalSetup;
     if (shouldCheck) {
-        // Dont't do this preparation for local (docker) setup - as it requires full cargo compilation.
+        // Don't do this preparation for local (docker) setup - as it requires full cargo compilation.
         await utils.spawn(
             `cargo sqlx prepare --check --database-url ${dbUrl} -- --tests || cargo sqlx prepare --database-url ${dbUrl} -- --tests`
         );

--- a/infrastructure/via/src/index.ts
+++ b/infrastructure/via/src/index.ts
@@ -2,7 +2,7 @@
 
 import { program, Command } from 'commander';
 import { spawnSync } from 'child_process';
-import { serverCommand as server } from './server';
+import { serverCommand as server, enCommand as en } from './server';
 import { command as up } from './up';
 import { command as down } from './down';
 import { command as completion } from './completion';
@@ -21,6 +21,7 @@ import { command as btc_explorer } from './btc_explorer';
 import { command as token } from './token';
 import { command as contract } from './contract';
 import { command as test } from './test/test';
+import { command as enSetup } from './setup_en';
 
 const COMMANDS = [
     server,
@@ -41,6 +42,8 @@ const COMMANDS = [
     token,
     contract,
     test,
+    enSetup,
+    en,
     completion(program as Command)
 ];
 

--- a/infrastructure/via/src/run.ts
+++ b/infrastructure/via/src/run.ts
@@ -18,7 +18,7 @@ export async function catLogs(exitCode?: number) {
 }
 
 export async function snapshots_creator() {
-    process.chdir(`${process.env.ZKSYNC_HOME}`);
+    process.chdir(`${process.env.VIA_HOME}`);
     let logLevel = 'RUST_LOG=snapshots_creator=debug';
     await utils.spawn(`${logLevel} cargo run --bin snapshots_creator --release`);
 }

--- a/infrastructure/via/src/server.ts
+++ b/infrastructure/via/src/server.ts
@@ -83,7 +83,7 @@ export const serverCommand = new Command('server')
         }
     });
 
-    export const enCommand = new Command('external-node')
+export const enCommand = new Command('external-node')
     .description('start via external node')
     .option('--reinit', 'reset postgres and rocksdb before starting')
     .action(async (cmd: Command) => {

--- a/infrastructure/via/src/setup_en.ts
+++ b/infrastructure/via/src/setup_en.ts
@@ -192,12 +192,6 @@ async function configExternalNode() {
             await changeConfigKey('ext-node', 'l2_chain_id', 270, 'en');
             await changeConfigKey('ext-node', 'main_node_url', 'https://sepolia.era.zksync.dev', 'en');
             await changeConfigKey('ext-node', 'eth_client_url', 'https://ethereum-sepolia-rpc.publicnode.com', 'en');
-            await changeConfigKey(
-                'ext-node',
-                'bucket_base_url',
-                'zksync-era-boojnet-external-node-snapshots',
-                'en.snapshots.object_store'
-            );
             break;
     }
     await compileConfig('ext-node');

--- a/infrastructure/via/src/setup_en.ts
+++ b/infrastructure/via/src/setup_en.ts
@@ -1,0 +1,216 @@
+import { Command } from 'commander';
+import { prompt } from 'enquirer';
+import chalk from 'chalk';
+import { compileConfig } from './config';
+import fs from 'fs';
+import path from 'path';
+import { set as setEnv } from './env';
+import { setup as setupDb } from './database';
+import * as utils from 'utils';
+
+enum Environment {
+    Mainnet = 'mainnet',
+    Testnet = 'testnet',
+    Local = 'local'
+}
+
+enum DataRetentionDuration {
+    Hour = 'hour',
+    Day = 'day',
+    Week = 'week',
+    Month = 'month',
+    Year = 'year',
+    Forever = 'forever'
+}
+
+async function selectDataRetentionDurationHours(): Promise<number | null> {
+    const question = {
+        type: 'select',
+        name: 'retention',
+        message: 'Select how long do you want to keep newest transactions data',
+        choices: [
+            { name: DataRetentionDuration.Hour, message: 'Hour', value: 1 },
+            { name: DataRetentionDuration.Day, message: 'Day', value: 24 },
+            { name: DataRetentionDuration.Week, message: 'Week', value: 24 * 7 },
+            { name: DataRetentionDuration.Month, message: 'Month', value: 24 * 31 },
+            { name: DataRetentionDuration.Year, message: 'Year', value: 24 * 366 },
+            { name: DataRetentionDuration.Forever, message: 'Forever', value: null }
+        ]
+    };
+
+    const answer: { retention: DataRetentionDuration } = await prompt(question);
+    const choice = question.choices.find((choice) => choice.name === answer.retention);
+    return choice ? choice.value : null;
+}
+
+async function selectEnvironment(): Promise<Environment> {
+    const question = {
+        type: 'select',
+        name: 'environment',
+        message: 'Select the environment:',
+        choices: [
+            { name: Environment.Testnet, message: 'Testnet (Sepolia)' },
+            { name: Environment.Mainnet, message: 'Mainnet' },
+            { name: Environment.Local, message: 'Local' }
+        ]
+    };
+
+    const answer: { environment: Environment } = await prompt(question);
+    return answer.environment;
+}
+
+async function removeConfigKey(env: string, key: string) {
+    const filePath = path.join(path.join(process.env.VIA_HOME as string, `etc/env/configs/${env}.toml`));
+    const contents = await fs.promises.readFile(filePath, { encoding: 'utf-8' });
+
+    const modifiedContents = contents
+        .split('\n')
+        .filter((line) => !line.startsWith(`${key} =`) && !line.startsWith(`${key}=`))
+        .join('\n');
+    await fs.promises.writeFile(filePath, modifiedContents);
+}
+
+async function changeConfigKey(env: string, key: string, newValue: string | number | boolean, section: string) {
+    const filePath = path.join(path.join(process.env.VIA_HOME as string, `etc/env/configs/${env}.toml`));
+    let contents = await fs.promises.readFile(filePath, { encoding: 'utf-8' });
+
+    const keyExists =
+        contents.split('\n').find((line) => line.startsWith(`${key} =`) || line.startsWith(`${key}=`)) !== undefined;
+
+    if (!keyExists) {
+        contents = contents.replace(`\n[${section}]\n`, `\n[${section}]\n${key} =\n`);
+    }
+
+    const modifiedContents = contents
+        .split('\n')
+        .map((line) => (line.startsWith(`${key} =`) ? `${key} = ${JSON.stringify(newValue)}` : line))
+        .map((line) => (line.startsWith(`${key}=`) ? `${key}=${JSON.stringify(newValue)}` : line))
+        .join('\n');
+    await fs.promises.writeFile(filePath, modifiedContents);
+}
+
+async function clearIfNeeded() {
+    const filePath = path.join(path.join(process.env.VIA_HOME as string, `etc/env/ext-node.env`));
+    if (!fs.existsSync(filePath)) {
+        return true;
+    }
+
+    const question = {
+        type: 'confirm',
+        name: 'cleanup',
+        message:
+            'The external node files need to be cleared first, this will clear all its databases, do you want to continue?'
+    };
+
+    const answer: { cleanup: boolean } = await prompt(question);
+    if (!answer.cleanup) {
+        return false;
+    }
+    const cmd = chalk.yellow;
+    console.log(`cleaning up database (${cmd('via clean --config ext-node --database')})`);
+    await utils.exec('via clean --config ext-node --database');
+    console.log(`cleaning up db (${cmd('via db drop')})`);
+    await utils.exec('via db drop');
+    return true;
+}
+
+async function runEnIfAskedTo() {
+    const question = {
+        type: 'confirm',
+        name: 'runRequested',
+        message: 'Do you want to run external-node now?'
+    };
+    const answer: { runRequested: boolean } = await prompt(question);
+    if (!answer.runRequested) {
+        return false;
+    }
+    await utils.spawn('via external-node');
+}
+
+async function commentOutConfigKey(env: string, key: string) {
+    const filePath = path.join(path.join(process.env.VIA_HOME as string, `etc/env/configs/${env}.toml`));
+    const contents = await fs.promises.readFile(filePath, { encoding: 'utf-8' });
+    const modifiedContents = contents
+        .split('\n')
+        .map((line) => (line.startsWith(`${key} =`) || line.startsWith(`${key}=`) ? `#${line}` : line))
+        .join('\n');
+    await fs.promises.writeFile(filePath, modifiedContents);
+}
+
+async function configExternalNode() {
+    const cmd = chalk.yellow;
+    const success = chalk.green;
+    const failure = chalk.red;
+
+    console.log(`Changing active env to ext-node (${cmd('via env ext-node')})`);
+    setEnv('ext-node');
+
+    const cleaningSucceeded = await clearIfNeeded();
+    if (!cleaningSucceeded) {
+        console.log(failure('Cleanup not allowed, but needed to proceed, exiting!'));
+        return;
+    }
+    const env = await selectEnvironment();
+
+    const retention = await selectDataRetentionDurationHours();
+    await commentOutConfigKey('ext-node', 'template_database_url');
+    await changeConfigKey('ext-node', 'mode', 'GCSAnonymousReadOnly', 'en.snapshots.object_store');
+    await changeConfigKey('ext-node', 'snapshots_recovery_enabled', true, 'en');
+    if (retention !== null) {
+        await changeConfigKey('ext-node', 'pruning_data_retention_hours', retention, 'en');
+    } else {
+        await removeConfigKey('ext-node', 'pruning_data_retention_hours');
+    }
+
+    switch (env) {
+        case Environment.Mainnet:
+            await changeConfigKey('ext-node', 'l1_chain_id', 1, 'en');
+            await changeConfigKey('ext-node', 'l2_chain_id', 324, 'en');
+            await changeConfigKey('ext-node', 'main_node_url', 'https://mainnet.era.zksync.io', 'en');
+            await changeConfigKey('ext-node', 'eth_client_url', 'https://ethereum-rpc.publicnode.com', 'en');
+            await changeConfigKey(
+                'ext-node',
+                'bucket_base_url',
+                'zksync-era-mainnet-external-node-snapshots',
+                'en.snapshots.object_store'
+            );
+            break;
+        case Environment.Testnet:
+            await changeConfigKey('ext-node', 'l1_chain_id', 11155111, 'en');
+            await changeConfigKey('ext-node', 'l2_chain_id', 300, 'en');
+            await changeConfigKey('ext-node', 'main_node_url', 'https://sepolia.era.zksync.dev', 'en');
+            await changeConfigKey('ext-node', 'eth_client_url', 'https://ethereum-sepolia-rpc.publicnode.com', 'en');
+            await changeConfigKey(
+                'ext-node',
+                'bucket_base_url',
+                'zksync-era-boojnet-external-node-snapshots',
+                'en.snapshots.object_store'
+            );
+            break;
+        case Environment.Local:
+            await changeConfigKey('ext-node', 'l1_chain_id', 9, 'en');
+            await changeConfigKey('ext-node', 'l2_chain_id', 270, 'en');
+            await changeConfigKey('ext-node', 'main_node_url', 'https://sepolia.era.zksync.dev', 'en');
+            await changeConfigKey('ext-node', 'eth_client_url', 'https://ethereum-sepolia-rpc.publicnode.com', 'en');
+            await changeConfigKey(
+                'ext-node',
+                'bucket_base_url',
+                'zksync-era-boojnet-external-node-snapshots',
+                'en.snapshots.object_store'
+            );
+            break;
+    }
+    await compileConfig('ext-node');
+    setEnv('ext-node');
+    console.log(`Setting up postgres (${cmd('via db setup')})`);
+    await setupDb({ prover: false, core: true, verifier: false });
+
+    console.log(`${success('Everything done!')} You can now run your external node using ${cmd('via external-node')}`);
+    await runEnIfAskedTo();
+}
+
+export const command = new Command('setup-external-node')
+    .description('prepare local setup for running external-node on mainnet/testnet')
+    .action(async (_: Command) => {
+        await configExternalNode();
+    });


### PR DESCRIPTION
## What ❔

Via External Node 

## Links

https://matter-labs.github.io/zksync-era/core/latest/guides/external-node/01_intro.html
https://docs.zksync.io/zksync-era/tooling/external-node

## How to run 

### Run Sequencer 
```
make via 
via token deposit --amount  10.4 --receiver-l2-address 0x36615Cf349d7F6344891B1e7CA7C72883F5dc047
```

### Creating Snapshot 
`
via run snapshots-creator 
`
### run external node 
`
via setup-external-node
`

## What is left 
* update `snapshot_applier `
* impl `btc_client` based on EN requirements (for replacing `eth_query_client`)
* impl da integration for EN ( check latest zksync era codebased for this)
* integrate with btc_watch to interprate votes 
* change block_reverter logic based on via revert logic for EN
* using via_state_keeper instead of state_keeper (also apply via fee related logic for EN)



