### PR TITLE
refactor: estimate the deposit fee cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9562,6 +9562,7 @@ dependencies = [
  "zksync_config",
  "zksync_contracts",
  "zksync_dal",
+ "zksync_node_fee_model",
  "zksync_shared_metrics",
  "zksync_types",
 ]

--- a/core/bin/via_server/src/node_builder.rs
+++ b/core/bin/via_server/src/node_builder.rs
@@ -461,6 +461,8 @@ impl ViaNodeBuilder {
             .add_prometheus_exporter_layer()?
             .add_storage_initialization_layer(LayerKind::Precondition)?
             // VIA layers
+            .add_gas_adjuster_layer()?
+            .add_l1_gas_layer()?
             .add_btc_watcher_layer()?
             .add_btc_sender_layer()?
             .add_gas_adjuster_layer()?

--- a/core/lib/via_btc_client/examples/deposit.rs
+++ b/core/lib/via_btc_client/examples/deposit.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
         .init();
 
     let args: Vec<String> = env::args().collect();
-    let mut amount = args[1].parse::<f64>()?;
-    let fees: f64 = 0.03;
-    amount += fees;
+    let amount = args[1].parse::<u64>()?;
 
     let receiver_l2_address = EVMAddress::from_str(&args[2])?;
     info!(
@@ -87,7 +85,7 @@ async fn main() -> Result<()> {
             InscriptionMessage::L1ToL2Message(input),
             Some(Recipient {
                 address: bridge_musig2_address,
-                amount: Amount::from_btc(amount)?,
+                amount: Amount::from_sat(amount),
             }),
         )
         .await?;

--- a/core/lib/via_btc_client/examples/deposit_opreturn.rs
+++ b/core/lib/via_btc_client/examples/deposit_opreturn.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     let secp = Secp256k1::new();
 
     let args: Vec<String> = env::args().collect();
-    let amount = Amount::from_btc(args[1].parse::<f64>()?)?;
+    let amount = Amount::from_sat(args[1].parse::<u64>()?);
     let fees = Amount::from_btc(0.0001)?;
     let receiver_l2_address = EVMAddress::from_str(&args[2])?;
     info!(

--- a/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
@@ -4,6 +4,7 @@ use zksync_config::ViaBtcWatchConfig;
 
 use crate::{
     implementations::resources::{
+        fee_input::ApiFeeInputResource,
         pools::{MasterPool, PoolResource},
         via_btc_indexer::BtcIndexerResource,
     },
@@ -25,6 +26,7 @@ pub struct BtcWatchLayer {
 #[context(crate = crate)]
 pub struct Input {
     pub master_pool: PoolResource<MasterPool>,
+    pub fee_input: ApiFeeInputResource,
 }
 
 #[derive(Debug, IntoContext)]
@@ -80,6 +82,7 @@ impl WiringLayer for BtcWatchLayer {
             .map_err(|e| WiringError::Internal(e.into()))?,
         );
         let btc_watch = BtcWatch::new(
+            input.fee_input.0,
             self.btc_watch_config.rpc_url(),
             network,
             node_auth,

--- a/core/node/via_btc_watch/Cargo.toml
+++ b/core/node/via_btc_watch/Cargo.toml
@@ -18,6 +18,7 @@ zksync_dal.workspace = true
 zksync_types.workspace = true
 zksync_config.workspace = true
 zksync_contracts.workspace = true
+zksync_node_fee_model.workspace = true
 
 tokio.workspace = true
 anyhow.workspace = true

--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -1,7 +1,7 @@
 mod message_processors;
 mod metrics;
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
 use message_processors::GovernanceUpgradesEventProcessor;
@@ -14,6 +14,7 @@ use via_btc_client::{
 };
 use zksync_config::ActorRole;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
+use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_types::PriorityOpId;
 
 use self::{
@@ -44,6 +45,7 @@ pub struct BtcWatch {
 impl BtcWatch {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
+        batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
         rpc_url: &str,
         network: BitcoinNetwork,
         node_auth: NodeAuth,
@@ -78,6 +80,7 @@ impl BtcWatch {
                 protocol_semantic_version,
             )),
             Box::new(L1ToL2MessageProcessor::new(
+                batch_fee_input_provider,
                 state.bridge_address.clone(),
                 state.next_expected_priority_id,
             )),


### PR DESCRIPTION
## What ❔

- Add fee estimation to `deposit` and `deposit-with-op-return`.
- Reduce the `gas_limit` when create an L1Tx in the btc_watcher
- Use the BaseBatchFee model in `btc_watch` and use the l2_faire_gas_price to  the gas price

## Why ❔

The PR was opened to improve gas efficiency and accuracy by replacing hardcoded gas fees and prices with dynamic estimates from the ZKS API, and to lower the excessively high `gas_limit` to reduce unnecessary refunds.
![Screenshot from 2025-03-26 10-20-52](https://github.com/user-attachments/assets/c7b34515-e0a9-4981-8c66-5b816620bad1)
- The first transaction is `deposit`.
 
## Testing
1. Use via CLI to `deposit` and `deposit-with-op-return`
2. The transaction should be processed by the sequencer.
3. Check the transaction
```sql
select 
	full_fee,
	layer_2_tip_fee,
	gas_limit,
	gas_per_storage_limit,
	gas_per_pubdata_limit,
	max_fee_per_gas,
	max_priority_fee_per_gas,
	effective_gas_price,
	refunded_gas
from transactions
```
3. The outcomes are:
- Small refunds.
- Uses the l2 faire gas price.
![Screenshot from 2025-03-26 15-13-41](https://github.com/user-attachments/assets/5f1419d7-3451-4354-ad54-c0805da987db)

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
