### PR TITLE
fix: remove db folder when cleaning the setup

### DIFF
--- a/docker-compose-via-btc-explorer.yml
+++ b/docker-compose-via-btc-explorer.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   web:
     container_name: btc-explorer-frontend

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   bitcoind:
     image: 'lightninglabs/bitcoin-core:27'

--- a/infrastructure/via/src/clean.ts
+++ b/infrastructure/via/src/clean.ts
@@ -64,5 +64,6 @@ export const command = new Command('clean')
             clean('volumes');
             clean('contracts/ethereum/.openzeppelin');
             clean('core/lib/via_btc_client/depositor_inscriber_context.json');
+            clean('db');
         }
     });


### PR DESCRIPTION
## What ❔

- Remove the local `db` folder used by state keeper when cleaning the setup in order to avoid invalid L1 batches when running the setup next time.
- Remove version warnings in docker compose files.