### PR TITLE
fix: btc_watch logic index l1 starting block

### DIFF
--- a/core/lib/config/src/configs/via_btc_watch.rs
+++ b/core/lib/config/src/configs/via_btc_watch.rs
@@ -65,7 +65,7 @@ impl ViaBtcWatchConfig {
         &self.actor_role
     }
 
-    /// Returns the number of blocks that we should wait before processing the new blocks.
+    /// Returns the starting L1 block number from which indexing begins.
     pub fn start_l1_block_number(&self) -> u32 {
         self.start_l1_block_number
     }

--- a/core/lib/config/src/configs/via_btc_watch.rs
+++ b/core/lib/config/src/configs/via_btc_watch.rs
@@ -8,6 +8,9 @@ pub enum ActorRole {
     Verifier,
 }
 
+/// Total L1 blocks to process at a time.
+pub const L1_BLOCKS_CHUNK: u32 = 10;
+
 /// Configuration for the Bitcoin watch crate.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ViaBtcWatchConfig {
@@ -36,8 +39,11 @@ pub struct ViaBtcWatchConfig {
     /// Role of the actor. SEQUENCER or VERIFIER.
     pub actor_role: ActorRole,
 
-    /// Number of blocks that we should wait before processing the new blocks.
-    pub btc_blocks_lag: u32,
+    /// The starting L1 block number from which indexing begins
+    pub start_l1_block_number: u32,
+
+    /// When set to true, the btc_watch starts indexing L1 blocks from the "start_l1_block_number".
+    pub restart_indexing: bool,
 
     /// The agreement threshold required for the verifier to finalize an L1 batch.
     pub zk_agreement_threshold: f64,
@@ -60,8 +66,8 @@ impl ViaBtcWatchConfig {
     }
 
     /// Returns the number of blocks that we should wait before processing the new blocks.
-    pub fn btc_blocks_lag(&self) -> u32 {
-        self.btc_blocks_lag
+    pub fn start_l1_block_number(&self) -> u32 {
+        self.start_l1_block_number
     }
 
     /// Returns the RPC URL of the Bitcoin node.
@@ -103,7 +109,8 @@ impl ViaBtcWatchConfig {
             network: "regtest".to_string(),
             bootstrap_txids: vec![],
             actor_role: ActorRole::Sequencer,
-            btc_blocks_lag: 1,
+            start_l1_block_number: 1,
+            restart_indexing: false,
             zk_agreement_threshold: 0.5,
         }
     }

--- a/core/lib/dal/.sqlx/query-12c639fe438fe1346d155e0e4c1f9b30cd2a4db38a78070bf49c688300dc6a57.json
+++ b/core/lib/dal/.sqlx/query-12c639fe438fe1346d155e0e4c1f9b30cd2a4db38a78070bf49c688300dc6a57.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                last_indexer_l1_block\n            FROM\n                via_indexer_metadata\n            WHERE\n                module = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_indexer_l1_block",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "12c639fe438fe1346d155e0e4c1f9b30cd2a4db38a78070bf49c688300dc6a57"
+}

--- a/core/lib/dal/.sqlx/query-89f90028bc6cf29d115c19300f222c2810c93f0a710f9f22e4af9d5772c4cb8c.json
+++ b/core/lib/dal/.sqlx/query-89f90028bc6cf29d115c19300f222c2810c93f0a710f9f22e4af9d5772c4cb8c.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                via_indexer_metadata (last_indexer_l1_block, module, updated_at)\n            VALUES\n                ($1, $2, NOW())\n            ON CONFLICT DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "89f90028bc6cf29d115c19300f222c2810c93f0a710f9f22e4af9d5772c4cb8c"
+}

--- a/core/lib/dal/.sqlx/query-fd1ad398bb74265ad5ce31de56c8f987d9775717f9117030dc2dd369c29a5291.json
+++ b/core/lib/dal/.sqlx/query-fd1ad398bb74265ad5ce31de56c8f987d9775717f9117030dc2dd369c29a5291.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE via_indexer_metadata\n            SET\n                last_indexer_l1_block = $1,\n                updated_at = NOW()\n            WHERE\n                module = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fd1ad398bb74265ad5ce31de56c8f987d9775717f9117030dc2dd369c29a5291"
+}

--- a/core/lib/dal/migrations/20250414100204_via_indexer_metadata.down.sql
+++ b/core/lib/dal/migrations/20250414100204_via_indexer_metadata.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS via_indexer_metadata;

--- a/core/lib/dal/migrations/20250414100204_via_indexer_metadata.up.sql
+++ b/core/lib/dal/migrations/20250414100204_via_indexer_metadata.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS via_indexer_metadata (
+    module VARCHAR UNIQUE NOT NULL,
+    last_indexer_l1_block BIGINT NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);

--- a/core/lib/dal/src/lib.rs
+++ b/core/lib/dal/src/lib.rs
@@ -26,8 +26,8 @@ use crate::{
     tokens_web3_dal::TokensWeb3Dal, transactions_dal::TransactionsDal,
     transactions_web3_dal::TransactionsWeb3Dal, via_blocks_dal::ViaBlocksDal,
     via_btc_sender_dal::ViaBtcSenderDal, via_data_availability_dal::ViaDataAvailabilityDal,
-    via_transactions_dal::ViaTransactionsDal, via_votes_dal::ViaVotesDal,
-    vm_runner_dal::VmRunnerDal,
+    via_indexer_dal::ViaIndexerDal, via_transactions_dal::ViaTransactionsDal,
+    via_votes_dal::ViaVotesDal, vm_runner_dal::VmRunnerDal,
 };
 
 pub mod base_token_dal;
@@ -65,6 +65,7 @@ pub mod transactions_web3_dal;
 pub mod via_blocks_dal;
 pub mod via_btc_sender_dal;
 pub mod via_data_availability_dal;
+pub mod via_indexer_dal;
 pub mod via_transactions_dal;
 pub mod via_votes_dal;
 pub mod vm_runner_dal;
@@ -88,6 +89,8 @@ where
     fn via_transactions_dal(&mut self) -> ViaTransactionsDal<'_, 'a>;
 
     fn via_votes_dal(&mut self) -> ViaVotesDal<'_, 'a>;
+
+    fn via_indexer_dal(&mut self) -> ViaIndexerDal<'_, 'a>;
 
     fn transactions_web3_dal(&mut self) -> TransactionsWeb3Dal<'_, 'a>;
 
@@ -144,6 +147,7 @@ where
     fn pruning_dal(&mut self) -> PruningDal<'_, 'a>;
 
     fn data_availability_dal(&mut self) -> DataAvailabilityDal<'_, 'a>;
+
     fn via_data_availability_dal(&mut self) -> ViaDataAvailabilityDal<'_, 'a>;
 
     fn vm_runner_dal(&mut self) -> VmRunnerDal<'_, 'a>;
@@ -170,6 +174,10 @@ impl<'a> CoreDal<'a> for Connection<'a, Core> {
 
     fn via_votes_dal(&mut self) -> ViaVotesDal<'_, 'a> {
         ViaVotesDal { storage: self }
+    }
+
+    fn via_indexer_dal(&mut self) -> ViaIndexerDal<'_, 'a> {
+        ViaIndexerDal { storage: self }
     }
 
     fn transactions_web3_dal(&mut self) -> TransactionsWeb3Dal<'_, 'a> {

--- a/core/lib/dal/src/via_indexer_dal.rs
+++ b/core/lib/dal/src/via_indexer_dal.rs
@@ -1,0 +1,75 @@
+use zksync_db_connection::{connection::Connection, error::DalResult, instrument::InstrumentExt};
+
+use crate::Core;
+
+#[derive(Debug)]
+pub struct ViaIndexerDal<'a, 'c> {
+    pub(crate) storage: &'a mut Connection<'c, Core>,
+}
+
+impl ViaIndexerDal<'_, '_> {
+    pub async fn init_indexer_metadata(&mut self, module: &str, l1_block: u32) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO
+                via_indexer_metadata (last_indexer_l1_block, module, updated_at)
+            VALUES
+                ($1, $2, NOW())
+            ON CONFLICT DO NOTHING
+            "#,
+            i64::from(l1_block),
+            module,
+        )
+        .instrument("init_indexer_metadata")
+        .report_latency()
+        .execute(self.storage)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn update_last_processed_l1_block(
+        &mut self,
+        module: &str,
+        l1_block: u32,
+    ) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            UPDATE via_indexer_metadata
+            SET
+                last_indexer_l1_block = $1,
+                updated_at = NOW()
+            WHERE
+                module = $2
+            "#,
+            i64::from(l1_block),
+            module,
+        )
+        .instrument("update_last_processed_l1_block")
+        .report_latency()
+        .execute(self.storage)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_last_processed_l1_block(&mut self, module: &str) -> DalResult<u64> {
+        let record = sqlx::query!(
+            r#"
+            SELECT
+                last_indexer_l1_block
+            FROM
+                via_indexer_metadata
+            WHERE
+                module = $1
+            "#,
+            module,
+        )
+        .instrument("get_last_processed_l1_block")
+        .report_latency()
+        .fetch_optional(self.storage)
+        .await?;
+
+        Ok(record.map(|r| r.last_indexer_l1_block as u64).unwrap_or(0))
+    }
+}

--- a/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
@@ -67,7 +67,7 @@ impl WiringLayer for BtcWatchLayer {
                     .map_err(|_| WiringError::Configuration("Wrong txid in config".to_string()))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let btc_blocks_lag = self.btc_watch_config.btc_blocks_lag();
+        let start_l1_block_number = self.btc_watch_config.start_l1_block_number();
 
         let indexer = BtcIndexerResource::from(
             BitcoinInscriptionIndexer::new(
@@ -87,9 +87,10 @@ impl WiringLayer for BtcWatchLayer {
             bootstrap_txids,
             main_pool,
             self.btc_watch_config.poll_interval(),
-            btc_blocks_lag,
+            start_l1_block_number,
             self.btc_watch_config.actor_role(),
             self.btc_watch_config.zk_agreement_threshold,
+            self.btc_watch_config.restart_indexing,
         )
         .await?;
 

--- a/core/node/node_framework/src/implementations/layers/via_verifier_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier_btc_watch.rs
@@ -68,7 +68,7 @@ impl WiringLayer for VerifierBtcWatchLayer {
                     .map_err(|_| WiringError::Configuration("Wrong txid in config".to_string()))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let btc_blocks_lag = self.btc_watch_config.btc_blocks_lag();
+        let start_l1_block_number = self.btc_watch_config.start_l1_block_number();
 
         let indexer = BtcIndexerResource::from(
             BitcoinInscriptionIndexer::new(
@@ -88,9 +88,10 @@ impl WiringLayer for VerifierBtcWatchLayer {
             bootstrap_txids,
             main_pool,
             self.btc_watch_config.poll_interval(),
-            btc_blocks_lag,
+            start_l1_block_number,
             self.btc_watch_config.actor_role(),
             self.btc_watch_config.zk_agreement_threshold,
+            self.btc_watch_config.restart_indexing,
         )
         .await?;
 

--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -115,7 +115,7 @@ impl BtcWatch {
                 .via_indexer_dal()
                 .init_indexer_metadata(BtcWatch::module_name(), start_l1_block_number)
                 .await?;
-            last_processed_bitcoin_block = start_l1_block_number;
+            last_processed_bitcoin_block = start_l1_block_number - 1;
         }
 
         let (bridge_address, ..) = indexer.get_state();

--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -3,7 +3,6 @@ mod metrics;
 
 use std::time::Duration;
 
-use anyhow::Context;
 use tokio::sync::watch;
 // re-export via_btc_client types
 pub use via_btc_client::types::BitcoinNetwork;
@@ -11,7 +10,7 @@ use via_btc_client::{
     indexer::BitcoinInscriptionIndexer,
     types::{BitcoinAddress, BitcoinTxid, NodeAuth},
 };
-use zksync_config::ActorRole;
+use zksync_config::{configs::via_btc_watch::L1_BLOCKS_CHUNK, ActorRole};
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 use zksync_types::PriorityOpId;
 
@@ -37,7 +36,7 @@ pub struct BtcWatch {
     last_processed_bitcoin_block: u32,
     pool: ConnectionPool<Core>,
     message_processors: Vec<Box<dyn MessageProcessor>>,
-    btc_blocks_lag: u32,
+    start_l1_block_number: u32,
 }
 
 impl BtcWatch {
@@ -50,14 +49,21 @@ impl BtcWatch {
         bootstrap_txids: Vec<BitcoinTxid>,
         pool: ConnectionPool<Core>,
         poll_interval: Duration,
-        btc_blocks_lag: u32,
+        start_l1_block_number: u32,
         actor_role: &ActorRole,
         zk_agreement_threshold: f64,
+        restart_indexing: bool,
     ) -> anyhow::Result<Self> {
         let indexer =
             BitcoinInscriptionIndexer::new(rpc_url, network, node_auth, bootstrap_txids).await?;
-        let mut storage = pool.connection_tagged("via_btc_watch").await?;
-        let state = Self::initialize_state(&indexer, &mut storage, btc_blocks_lag).await?;
+        let mut storage = pool.connection_tagged(BtcWatch::module_name()).await?;
+        let state = Self::initialize_state(
+            &indexer,
+            &mut storage,
+            start_l1_block_number,
+            restart_indexing,
+        )
+        .await?;
         tracing::info!("initialized state: {state:?}");
         drop(storage);
 
@@ -89,31 +95,28 @@ impl BtcWatch {
             last_processed_bitcoin_block: state.last_processed_bitcoin_block,
             pool,
             message_processors,
-            btc_blocks_lag,
+            start_l1_block_number,
         })
     }
 
     async fn initialize_state(
         indexer: &BitcoinInscriptionIndexer,
         storage: &mut Connection<'_, Core>,
-        btc_blocks_lag: u32,
+        start_l1_block_number: u32,
+        restart_indexing: bool,
     ) -> anyhow::Result<BtcWatchState> {
-        let last_processed_bitcoin_block = match storage
-            .via_transactions_dal()
-            .get_last_processed_l1_block()
-            .await?
-        {
-            Some(block) => block.0.saturating_sub(1),
-            None => {
-                let current_block = indexer
-                    .fetch_block_height()
-                    .await
-                    .with_context(|| "cannot get current Bitcoin block")?
-                    as u32;
+        let mut last_processed_bitcoin_block = storage
+            .via_indexer_dal()
+            .get_last_processed_l1_block(BtcWatch::module_name())
+            .await? as u32;
 
-                current_block.saturating_sub(btc_blocks_lag)
-            }
-        };
+        if last_processed_bitcoin_block == 0 || restart_indexing {
+            storage
+                .via_indexer_dal()
+                .init_indexer_metadata(BtcWatch::module_name(), start_l1_block_number)
+                .await?;
+            last_processed_bitcoin_block = start_l1_block_number;
+        }
 
         let (bridge_address, ..) = indexer.get_state();
 
@@ -142,7 +145,7 @@ impl BtcWatch {
             }
             METRICS.btc_poll.inc();
 
-            let mut storage = pool.connection_tagged("via_btc_watch").await?;
+            let mut storage = pool.connection_tagged(BtcWatch::module_name()).await?;
             match self.loop_iteration(&mut storage).await {
                 Ok(()) => { /* everything went fine */ }
                 Err(MessageProcessorError::Internal(err)) => {
@@ -152,10 +155,14 @@ impl BtcWatch {
                 }
                 Err(err) => {
                     tracing::error!("Failed to process new blocks: {err}");
-                    self.last_processed_bitcoin_block =
-                        Self::initialize_state(&self.indexer, &mut storage, self.btc_blocks_lag)
-                            .await?
-                            .last_processed_bitcoin_block;
+                    self.last_processed_bitcoin_block = Self::initialize_state(
+                        &self.indexer,
+                        &mut storage,
+                        self.start_l1_block_number,
+                        false,
+                    )
+                    .await?
+                    .last_processed_bitcoin_block;
                 }
             }
         }
@@ -168,14 +175,19 @@ impl BtcWatch {
         &mut self,
         storage: &mut Connection<'_, Core>,
     ) -> Result<(), MessageProcessorError> {
-        let to_block = self
-            .indexer
-            .fetch_block_height()
-            .await
-            .map_err(|e| MessageProcessorError::Internal(anyhow::anyhow!(e.to_string())))?
-            .saturating_sub(self.confirmations_for_btc_msg) as u32;
-        if to_block <= self.last_processed_bitcoin_block {
+        let current_l1_block_number =
+            self.indexer
+                .fetch_block_height()
+                .await
+                .map_err(|e| MessageProcessorError::Internal(anyhow::anyhow!(e.to_string())))?
+                .saturating_sub(self.confirmations_for_btc_msg) as u32;
+        if current_l1_block_number <= self.last_processed_bitcoin_block {
             return Ok(());
+        }
+
+        let mut to_block = self.last_processed_bitcoin_block + L1_BLOCKS_CHUNK;
+        if to_block > current_l1_block_number {
+            to_block = current_l1_block_number;
         }
 
         let messages = self
@@ -191,7 +203,17 @@ impl BtcWatch {
                 .map_err(|e| MessageProcessorError::Internal(e.into()))?;
         }
 
+        storage
+            .via_indexer_dal()
+            .update_last_processed_l1_block(BtcWatch::module_name(), to_block)
+            .await
+            .map_err(|e| MessageProcessorError::DatabaseError(e.to_string()))?;
+
         self.last_processed_bitcoin_block = to_block;
         Ok(())
+    }
+
+    fn module_name() -> &'static str {
+        "via_btc_watch"
     }
 }

--- a/etc/env/configs/via_base.toml
+++ b/etc/env/configs/via_base.toml
@@ -10,10 +10,12 @@ rpc_password = "rpcpassword"
 network = "regtest"
 bootstrap_txids = []
 actor_role = "Sequencer"
-# Number of blocks that we should check when restarting the service.
-btc_blocks_lag = 1000
+# The starting L1 block number from which indexing begins.
+start_l1_block_number = 1
 # The agreement threshold required for the verifier to finalize an L1 batch.
 zk_agreement_threshold = 0.5
+# When set to true, the btc_watch starts indexing L1 blocks from the "start_l1_block_number".
+restart_indexing=false
 
 [via_btc_sender]
 poll_interval = 2000

--- a/etc/env/configs/via_coordinator.toml
+++ b/etc/env/configs/via_coordinator.toml
@@ -34,8 +34,6 @@ test_zk_proof_invalid_l1_batch_numbers = [3]
 
 [via_btc_watch]
 actor_role = "Verifier"
-# Number of blocks that we should check when restarting the service.
-btc_blocks_lag = 1000
 
 [via_btc_sender]
 private_key = "cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm"

--- a/etc/env/configs/via_verifier.toml
+++ b/etc/env/configs/via_verifier.toml
@@ -36,8 +36,6 @@ test_zk_proof_invalid_l1_batch_numbers = [3]
 
 [via_btc_watch]
 actor_role = "Verifier"
-# Number of blocks that we should check when restarting the service.
-btc_blocks_lag = 1000
 
 [via_btc_sender]
 private_key = "cQ4UHjdsGWFMcQ8zXcaSr7m4Kxq9x7g9EKqguTaFH7fA34mZAnqW"

--- a/via_verifier/lib/verifier_dal/.sqlx/query-12c639fe438fe1346d155e0e4c1f9b30cd2a4db38a78070bf49c688300dc6a57.json
+++ b/via_verifier/lib/verifier_dal/.sqlx/query-12c639fe438fe1346d155e0e4c1f9b30cd2a4db38a78070bf49c688300dc6a57.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                last_indexer_l1_block\n            FROM\n                via_indexer_metadata\n            WHERE\n                module = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_indexer_l1_block",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "12c639fe438fe1346d155e0e4c1f9b30cd2a4db38a78070bf49c688300dc6a57"
+}

--- a/via_verifier/lib/verifier_dal/.sqlx/query-89f90028bc6cf29d115c19300f222c2810c93f0a710f9f22e4af9d5772c4cb8c.json
+++ b/via_verifier/lib/verifier_dal/.sqlx/query-89f90028bc6cf29d115c19300f222c2810c93f0a710f9f22e4af9d5772c4cb8c.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                via_indexer_metadata (last_indexer_l1_block, module, updated_at)\n            VALUES\n                ($1, $2, NOW())\n            ON CONFLICT DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "89f90028bc6cf29d115c19300f222c2810c93f0a710f9f22e4af9d5772c4cb8c"
+}

--- a/via_verifier/lib/verifier_dal/.sqlx/query-fd1ad398bb74265ad5ce31de56c8f987d9775717f9117030dc2dd369c29a5291.json
+++ b/via_verifier/lib/verifier_dal/.sqlx/query-fd1ad398bb74265ad5ce31de56c8f987d9775717f9117030dc2dd369c29a5291.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE via_indexer_metadata\n            SET\n                last_indexer_l1_block = $1,\n                updated_at = NOW()\n            WHERE\n                module = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fd1ad398bb74265ad5ce31de56c8f987d9775717f9117030dc2dd369c29a5291"
+}

--- a/via_verifier/lib/verifier_dal/migrations/20250414100204_via_indexer_metadata.down.sql
+++ b/via_verifier/lib/verifier_dal/migrations/20250414100204_via_indexer_metadata.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS via_indexer_metadata;

--- a/via_verifier/lib/verifier_dal/migrations/20250414100204_via_indexer_metadata.up.sql
+++ b/via_verifier/lib/verifier_dal/migrations/20250414100204_via_indexer_metadata.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS via_indexer_metadata (
+    module VARCHAR UNIQUE NOT NULL,
+    last_indexer_l1_block BIGINT NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);

--- a/via_verifier/lib/verifier_dal/src/lib.rs
+++ b/via_verifier/lib/verifier_dal/src/lib.rs
@@ -13,12 +13,14 @@ pub use zksync_db_connection::{
 };
 
 use crate::{
-    via_blocks_dal::ViaBlocksDal, via_btc_sender_dal::ViaBtcSenderDal, via_votes_dal::ViaVotesDal,
+    via_blocks_dal::ViaBlocksDal, via_btc_sender_dal::ViaBtcSenderDal,
+    via_indexer_dal::ViaIndexerDal, via_votes_dal::ViaVotesDal,
 };
 
 pub mod models;
 pub mod via_blocks_dal;
 pub mod via_btc_sender_dal;
+pub mod via_indexer_dal;
 pub mod via_transactions_dal;
 pub mod via_votes_dal;
 
@@ -40,6 +42,7 @@ where
     fn via_btc_sender_dal(&mut self) -> ViaBtcSenderDal<'_, 'a>;
     fn via_block_dal(&mut self) -> ViaBlocksDal<'_, 'a>;
     fn via_transactions_dal(&mut self) -> ViaTransactionsDal<'_, 'a>;
+    fn via_indexer_dal(&mut self) -> ViaIndexerDal<'_, 'a>;
 }
 
 #[derive(Clone, Debug)]
@@ -58,10 +61,16 @@ impl<'a> VerifierDal<'a> for Connection<'a, Verifier> {
     fn via_btc_sender_dal(&mut self) -> ViaBtcSenderDal<'_, 'a> {
         ViaBtcSenderDal { storage: self }
     }
+
     fn via_block_dal(&mut self) -> ViaBlocksDal<'_, 'a> {
         ViaBlocksDal { storage: self }
     }
+
     fn via_transactions_dal(&mut self) -> ViaTransactionsDal<'_, 'a> {
         ViaTransactionsDal { storage: self }
+    }
+
+    fn via_indexer_dal(&mut self) -> ViaIndexerDal<'_, 'a> {
+        ViaIndexerDal { storage: self }
     }
 }

--- a/via_verifier/lib/verifier_dal/src/via_indexer_dal.rs
+++ b/via_verifier/lib/verifier_dal/src/via_indexer_dal.rs
@@ -1,0 +1,75 @@
+use zksync_db_connection::{connection::Connection, error::DalResult, instrument::InstrumentExt};
+
+use crate::Verifier;
+
+#[derive(Debug)]
+pub struct ViaIndexerDal<'a, 'c> {
+    pub(crate) storage: &'a mut Connection<'c, Verifier>,
+}
+
+impl ViaIndexerDal<'_, '_> {
+    pub async fn init_indexer_metadata(&mut self, module: &str, l1_block: u32) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO
+                via_indexer_metadata (last_indexer_l1_block, module, updated_at)
+            VALUES
+                ($1, $2, NOW())
+            ON CONFLICT DO NOTHING
+            "#,
+            i64::from(l1_block),
+            module,
+        )
+        .instrument("init_indexer_metadata")
+        .report_latency()
+        .execute(self.storage)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn update_last_processed_l1_block(
+        &mut self,
+        module: &str,
+        l1_block: u32,
+    ) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            UPDATE via_indexer_metadata
+            SET
+                last_indexer_l1_block = $1,
+                updated_at = NOW()
+            WHERE
+                module = $2
+            "#,
+            i64::from(l1_block),
+            module,
+        )
+        .instrument("update_last_processed_l1_block")
+        .report_latency()
+        .execute(self.storage)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_last_processed_l1_block(&mut self, module: &str) -> DalResult<u64> {
+        let record = sqlx::query!(
+            r#"
+            SELECT
+                last_indexer_l1_block
+            FROM
+                via_indexer_metadata
+            WHERE
+                module = $1
+            "#,
+            module,
+        )
+        .instrument("get_last_processed_l1_block")
+        .report_latency()
+        .fetch_optional(self.storage)
+        .await?;
+
+        Ok(record.map(|r| r.last_indexer_l1_block as u64).unwrap_or(0))
+    }
+}

--- a/via_verifier/node/via_btc_watch/src/lib.rs
+++ b/via_verifier/node/via_btc_watch/src/lib.rs
@@ -106,7 +106,7 @@ impl VerifierBtcWatch {
                 .via_indexer_dal()
                 .init_indexer_metadata(VerifierBtcWatch::module_name(), start_l1_block_number)
                 .await?;
-            last_processed_bitcoin_block = start_l1_block_number;
+            last_processed_bitcoin_block = start_l1_block_number - 1;
         }
 
         Ok(BtcWatchState {


### PR DESCRIPTION
## What ❔

- Fix the logic where the indexer start indexing the L1 blocks (Sequencer and verifier).
- Adding pagination logic to the L1 blocks selection to avoid memory issues due to selecting many blocks at a time.
- Added a new table `via_indexer_metadata` to track the last indexed L1 block number.
- Added logic to allow restart indexing the L1 chain from a specific L1 block number. This logic can in create duplicates transactions as it's handled by the message processor.

## Why ❔

- At some point we will need to restart the indexer at a specific L1 block number.
- Avoid loading a lots of L1 blocks in memory during the message processing checks.

## Testing
1. Start the sequencer.
2. Deposit BTC.
3. You should see this in DB
![Screenshot from 2025-04-14 13-29-47](https://github.com/user-attachments/assets/48c0c7bd-1775-45fc-83a3-4f38b27e933c)

4. Stop the sequencer and update the `via.env` and update the `VIA_BTC_WATCH_RESTART_INDEXING=true`  
5. Check the DB you should see that the indexer restarted indexing from 1 with a offset of 10 blocks.
6. The already indexed deposit is not re-inserted.
7. Do same for the coordinator.
8. Done

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
