### PR TITLE
Fix/via l1 l2 message processor

### DIFF
--- a/core/bin/via_server/src/node_builder.rs
+++ b/core/bin/via_server/src/node_builder.rs
@@ -304,8 +304,8 @@ impl ViaNodeBuilder {
                 &rpc_config,
                 &self.contracts_config,
                 &self.genesis_config,
-                via_genesis_config.bridge_address,
-                via_btc_client_config.network(),
+                Some(via_genesis_config.bridge_address),
+                Some(via_btc_client_config.network()),
             ),
             optional_config,
         ));

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -369,7 +369,13 @@ impl MainNodeBuilder {
         };
         self.node.add_layer(Web3ServerLayer::http(
             rpc_config.http_port,
-            InternalApiConfig::new(&rpc_config, &self.contracts_config, &self.genesis_config),
+            InternalApiConfig::new(
+                &rpc_config,
+                &self.contracts_config,
+                &self.genesis_config,
+                None,
+                None,
+            ),
             optional_config,
         ));
 
@@ -410,7 +416,13 @@ impl MainNodeBuilder {
         };
         self.node.add_layer(Web3ServerLayer::ws(
             rpc_config.ws_port,
-            InternalApiConfig::new(&rpc_config, &self.contracts_config, &self.genesis_config),
+            InternalApiConfig::new(
+                &rpc_config,
+                &self.contracts_config,
+                &self.genesis_config,
+                None,
+                None,
+            ),
             optional_config,
         ));
 

--- a/core/lib/types/src/l1/mod.rs
+++ b/core/lib/types/src/l1/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 pub mod error;
+pub mod via_l1;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy)]
 #[repr(u8)]

--- a/core/lib/types/src/l1/via_l1.rs
+++ b/core/lib/types/src/l1/via_l1.rs
@@ -1,0 +1,99 @@
+use std::str::FromStr;
+
+use zksync_basic_types::{Address, PriorityOpId, H160, U256};
+use zksync_system_constants::REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE;
+use zksync_utils::address_to_u256;
+
+use super::{L1Tx, L1TxCommonData, OpProcessingType, PriorityQueueType};
+use crate::{
+    abi::L2CanonicalTransaction, helpers::unix_timestamp_ms, Execute, PRIORITY_OPERATION_L2_TX_TYPE,
+};
+
+/// Eth 18 decimals - BTC 8 decimals
+const MANTISSA: u64 = 10_000_000_000;
+
+/// Deposit default L2 gas price.
+const MAX_FEE_PER_GAS: u64 = 120_000_000;
+
+/// Gas limit to required to execute a deposit.
+const GAS_LIMIT: u64 = 300_000;
+
+/// The minimum address that can be used as l2 receiver address.
+const MIN_VALID_L2_RECEIVER_ADDRESS: &str = "0x0000000000000000000000000000000000010001";
+
+#[derive(Debug, Clone)]
+
+pub struct ViaL1Deposit {
+    pub l2_receiver_address: Address,
+    pub amount: u64,
+    pub calldata: Vec<u8>,
+    pub serial_id: PriorityOpId,
+    pub l1_block_number: u64,
+}
+impl ViaL1Deposit {
+    pub fn is_valid_deposit(&self) -> bool {
+        self.l2_receiver_address >= H160::from_str(MIN_VALID_L2_RECEIVER_ADDRESS).unwrap()
+    }
+
+    pub fn l1_tx(&self) -> Option<L1Tx> {
+        if !self.is_valid_deposit() {
+            return None;
+        }
+        Some(L1Tx::from(self.clone()))
+    }
+}
+
+impl From<ViaL1Deposit> for L1Tx {
+    fn from(deposit: ViaL1Deposit) -> Self {
+        let value = U256::from(deposit.amount) * U256::from(MANTISSA);
+
+        let l2_tx = L2CanonicalTransaction {
+            tx_type: PRIORITY_OPERATION_L2_TX_TYPE.into(),
+            from: address_to_u256(&deposit.l2_receiver_address),
+            to: address_to_u256(&deposit.l2_receiver_address),
+            gas_limit: U256::from(GAS_LIMIT),
+            gas_per_pubdata_byte_limit: U256::from(REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE),
+            max_fee_per_gas: U256::from(MAX_FEE_PER_GAS),
+            max_priority_fee_per_gas: U256::zero(),
+            paymaster: U256::zero(),
+            nonce: deposit.serial_id.0.into(),
+            value: U256::zero(),
+            reserved: [
+                value,
+                address_to_u256(&deposit.l2_receiver_address),
+                U256::zero(),
+                U256::zero(),
+            ],
+            data: deposit.calldata.clone(),
+            signature: vec![],
+            factory_deps: vec![],
+            paymaster_input: vec![],
+            reserved_dynamic: vec![],
+        };
+
+        Self {
+            execute: Execute {
+                contract_address: deposit.l2_receiver_address,
+                calldata: deposit.calldata.clone(),
+                value: U256::zero(),
+                factory_deps: vec![],
+            },
+            common_data: L1TxCommonData {
+                sender: deposit.l2_receiver_address,
+                serial_id: deposit.serial_id,
+                layer_2_tip_fee: U256::zero(),
+                full_fee: U256::zero(),
+                max_fee_per_gas: U256::from(MAX_FEE_PER_GAS),
+                gas_limit: U256::from(GAS_LIMIT),
+                gas_per_pubdata_limit: U256::from(REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE),
+                op_processing_type: OpProcessingType::Common,
+                priority_queue_type: PriorityQueueType::Deque,
+                canonical_tx_hash: l2_tx.hash(),
+                to_mint: value,
+                refund_recipient: deposit.l2_receiver_address,
+                eth_block: deposit.l1_block_number,
+            },
+            received_timestamp_ms: unix_timestamp_ms(),
+        }
+    }
+}

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -124,12 +124,12 @@ impl InternalApiConfig {
         web3_config: &Web3JsonRpcConfig,
         contracts_config: &ContractsConfig,
         genesis_config: &GenesisConfig,
-        via_bridge_address: String,
-        via_network: Network,
+        via_bridge_address: Option<String>,
+        via_network: Option<Network>,
     ) -> Self {
         Self {
-            via_bridge_address,
-            via_network,
+            via_bridge_address: via_bridge_address.unwrap_or_default(),
+            via_network: via_network.unwrap_or(Network::Regtest),
             l1_chain_id: genesis_config.l1_chain_id,
             l2_chain_id: genesis_config.l2_chain_id,
             max_tx_size: web3_config.max_tx_size,

--- a/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
@@ -10,7 +10,6 @@ use zksync_config::{
 
 use crate::{
     implementations::resources::{
-        fee_input::ApiFeeInputResource,
         pools::{MasterPool, PoolResource},
         via_btc_indexer::BtcIndexerResource,
     },
@@ -35,7 +34,6 @@ pub struct BtcWatchLayer {
 #[context(crate = crate)]
 pub struct Input {
     pub master_pool: PoolResource<MasterPool>,
-    pub fee_input: ApiFeeInputResource,
 }
 
 #[derive(Debug, IntoContext)]
@@ -95,7 +93,6 @@ impl WiringLayer for BtcWatchLayer {
         let btc_watch = BtcWatch::new(
             self.btc_watch_config,
             indexer,
-            input.fee_input.0,
             main_pool,
             self.via_genesis_config.bridge_address()?,
             self.via_genesis_config.zk_agreement_threshold,

--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -1,8 +1,6 @@
 mod message_processors;
 mod metrics;
 
-use std::sync::Arc;
-
 use message_processors::GovernanceUpgradesEventProcessor;
 use tokio::sync::watch;
 // re-export via_btc_client types
@@ -10,7 +8,6 @@ pub use via_btc_client::types::BitcoinNetwork;
 use via_btc_client::{indexer::BitcoinInscriptionIndexer, types::BitcoinAddress};
 use zksync_config::{configs::via_btc_watch::L1_BLOCKS_CHUNK, ViaBtcWatchConfig};
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
-use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_types::PriorityOpId;
 
 use self::message_processors::{
@@ -37,7 +34,6 @@ impl BtcWatch {
     pub async fn new(
         btc_watch_config: ViaBtcWatchConfig,
         indexer: BitcoinInscriptionIndexer,
-        batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
         pool: ConnectionPool<Core>,
         bridge_address: BitcoinAddress,
         zk_agreement_threshold: f64,
@@ -66,7 +62,6 @@ impl BtcWatch {
                 protocol_semantic_version,
             )),
             Box::new(L1ToL2MessageProcessor::new(
-                batch_fee_input_provider,
                 bridge_address,
                 state.next_expected_priority_id,
             )),

--- a/core/node/via_btc_watch/src/message_processors/l1_to_l2.rs
+++ b/core/node/via_btc_watch/src/message_processors/l1_to_l2.rs
@@ -1,18 +1,11 @@
-use std::sync::Arc;
-
 use via_btc_client::{
     indexer::BitcoinInscriptionIndexer,
     types::{BitcoinAddress, FullInscriptionMessage, L1ToL2Message},
 };
 use zksync_dal::{Connection, Core, CoreDal};
-use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_types::{
-    abi::L2CanonicalTransaction,
-    fee_model::BatchFeeInput,
-    helpers::unix_timestamp_ms,
-    l1::{L1Tx, OpProcessingType, PriorityQueueType},
-    Address, Execute, L1TxCommonData, PriorityOpId, H256, PRIORITY_OPERATION_L2_TX_TYPE,
-    REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256,
+    l1::{via_l1::ViaL1Deposit, L1Tx},
+    PriorityOpId, H256,
 };
 
 use crate::{
@@ -22,19 +15,13 @@ use crate::{
 
 #[derive(Debug)]
 pub struct L1ToL2MessageProcessor {
-    batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     bridge_address: BitcoinAddress,
     next_expected_priority_id: PriorityOpId,
 }
 
 impl L1ToL2MessageProcessor {
-    pub fn new(
-        batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
-        bridge_address: BitcoinAddress,
-        next_expected_priority_id: PriorityOpId,
-    ) -> Self {
+    pub fn new(bridge_address: BitcoinAddress, next_expected_priority_id: PriorityOpId) -> Self {
         Self {
-            batch_fee_input_provider,
             bridge_address,
             next_expected_priority_id,
         }
@@ -74,9 +61,12 @@ impl MessageProcessor for L1ToL2MessageProcessor {
                         continue;
                     }
                     let serial_id = self.next_expected_priority_id;
-                    let batch_fee = self.batch_fee_input_provider.get_batch_fee_input().await?;
-                    let l1_tx =
-                        self.create_l1_tx_from_message(batch_fee, &l1_to_l2_msg, serial_id)?;
+                    let Some(l1_tx) = self.create_l1_tx_from_message(&l1_to_l2_msg, serial_id)
+                    else {
+                        tracing::warn!("Invalid deposit, l1 tx_id {}", &l1_to_l2_msg.common.tx_id);
+                        continue;
+                    };
+
                     priority_ops.push((l1_tx, tx_id));
                     self.next_expected_priority_id = self.next_expected_priority_id.next();
                 }
@@ -104,84 +94,27 @@ impl MessageProcessor for L1ToL2MessageProcessor {
 impl L1ToL2MessageProcessor {
     fn create_l1_tx_from_message(
         &self,
-        batch_fee_input: BatchFeeInput,
         msg: &L1ToL2Message,
         serial_id: PriorityOpId,
-    ) -> Result<L1Tx, MessageProcessorError> {
-        let amount = msg.amount.to_sat();
-        let eth_address_l2 = msg.input.receiver_l2_address;
-        let calldata = msg.input.call_data.clone();
-
-        let mantissa = U256::from(10_000_000_000u64); // Eth 18 decimals - BTC 8 decimals
-        let value = U256::from(amount) * mantissa;
-        let max_fee_per_gas = U256::from(batch_fee_input.fair_l2_gas_price());
-        let gas_limit = U256::from(300_000u64);
-        let gas_per_pubdata_limit = U256::from(REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE);
-
-        let mut l1_tx = L1Tx {
-            execute: Execute {
-                contract_address: eth_address_l2,
-                calldata: calldata.clone(),
-                value: U256::zero(),
-                factory_deps: vec![],
-            },
-            common_data: L1TxCommonData {
-                sender: eth_address_l2,
-                serial_id,
-                layer_2_tip_fee: U256::zero(),
-                full_fee: U256::zero(),
-                max_fee_per_gas,
-                gas_limit,
-                gas_per_pubdata_limit,
-                op_processing_type: OpProcessingType::Common,
-                priority_queue_type: PriorityQueueType::Deque,
-                canonical_tx_hash: H256::zero(),
-                to_mint: value,
-                refund_recipient: eth_address_l2,
-                eth_block: msg.common.block_height as u64,
-            },
-            received_timestamp_ms: unix_timestamp_ms(),
+    ) -> Option<L1Tx> {
+        let deposit = ViaL1Deposit {
+            l2_receiver_address: msg.input.receiver_l2_address,
+            amount: msg.amount.to_sat(),
+            calldata: msg.input.call_data.clone(),
+            serial_id,
+            l1_block_number: msg.common.block_height as u64,
         };
 
-        let l2_transaction = L2CanonicalTransaction {
-            tx_type: PRIORITY_OPERATION_L2_TX_TYPE.into(),
-            from: address_to_u256(&l1_tx.common_data.sender),
-            to: address_to_u256(&l1_tx.execute.contract_address),
-            gas_limit: l1_tx.common_data.gas_limit,
-            gas_per_pubdata_byte_limit: l1_tx.common_data.gas_per_pubdata_limit,
-            max_fee_per_gas: l1_tx.common_data.max_fee_per_gas,
-            max_priority_fee_per_gas: U256::zero(),
-            paymaster: U256::zero(),
-            nonce: l1_tx.common_data.serial_id.0.into(),
-            value: l1_tx.execute.value,
-            reserved: [
-                l1_tx.common_data.to_mint,
-                address_to_u256(&l1_tx.common_data.refund_recipient),
-                U256::zero(),
-                U256::zero(),
-            ],
-            data: l1_tx.execute.calldata.clone(),
-            signature: vec![],
-            factory_deps: vec![],
-            paymaster_input: vec![],
-            reserved_dynamic: vec![],
-        };
-
-        let canonical_tx_hash = l2_transaction.hash();
-
-        l1_tx.common_data.canonical_tx_hash = canonical_tx_hash;
-
-        tracing::info!(
-            "Created L1 transaction with serial id {:?} (block {}) with deposit amount {} and tx hash {}",
-            l1_tx.common_data.serial_id,
-            l1_tx.common_data.eth_block,
-            amount,
-            l1_tx.common_data.canonical_tx_hash,
-        );
-        Ok(l1_tx)
+        if let Some(l1_tx) = deposit.l1_tx() {
+            tracing::info!(
+                "Created L1 transaction with serial id {:?} (block {}) with deposit amount {} and tx hash {}",
+                l1_tx.common_data.serial_id,
+                l1_tx.common_data.eth_block,
+                deposit.amount,
+                l1_tx.common_data.canonical_tx_hash,
+            );
+            return Some(l1_tx);
+        }
+        None
     }
-}
-
-fn address_to_u256(address: &Address) -> U256 {
-    U256::from_big_endian(&address.0)
 }

--- a/infrastructure/via/src/token.ts
+++ b/infrastructure/via/src/token.ts
@@ -143,7 +143,10 @@ async function estimateGasFee(l2RpcUrl: string, amount: number, receiverL2Addres
         })
     );
 
-    const gasPrice = await l2Provider.getGasPrice();
+    // https://github.com/vianetwork/via-core/blob/7c73be01d7160320c615ce0d70bdcdb2c8a9671c/core/lib/types/src/l1/via_l1.rs#L15
+    // Hardcode the gas price to avoid issues during the Priority Id verification.
+    // const gasPrice = await l2Provider.getGasPrice();
+    const gasPrice = BigInt(120_000_000);
     return (gasCost * gasPrice) / BigInt(10_000_000_000);
 }
 


### PR DESCRIPTION
## What ❔

- Refactor the l1 to l2 message processor.
- The `l2 gas price` is now hard-coded for L1 deposits. This modification allows to the `Sequencer` and `verifier network` to calculate the correct `L2 canonical transaction hash`. This is important because it's used during the Priority-id verification.
If the l2 gas price is higher than the hard-coded value, the L1TX is still processed as it has priority in the [SQL query](https://github.com/vianetwork/via-core/blob/718fa13f7296cd5d604d1923d9a834d89bd00611/core/lib/dal/src/transactions_dal.rs#L1757-L1761) 
- Fix the bug related to deposit tokens to the system contracts address. Now, all address less than the [MAX_SYSTEM_CONTRACT_ADDRESS](https://github.com/vianetwork/era-contracts/blob/main/system-contracts/contracts/Constants.sol#L29) +1 are rejected, the L1Tx is ignored and no transaction is created.
- Fix the API config. Use Options for via config instead of DataType to be able to init the ZkSync orchestation layer.

## Why ❔

- When using the l2 gas price from the API for deposits it can leads to wrong `L2 canonical transaction hash`, this can cause the verifier network to reject all the blocks.

## Testing
- Start the Sequencer and coordinator
- Try deposit to address between `0x00000....0000000000` and `0x00000....0000010000`, the `via` cmd will fail during the simulation.
- Update the via cli code and comment this [code](https://github.com/vianetwork/via-core/blob/718fa13f7296cd5d604d1923d9a834d89bd00611/infrastructure/via/src/token.ts#L135-L145) and re^place by `const gasCost = BigInt(300_000)`
- Build the via cli and try again. You should see such `WARN` on terminal
![Screenshot from 2025-04-16 15-42-46](https://github.com/user-attachments/assets/d6f6f0e3-d4fe-4bdf-a86e-4d0e606d8c13)

- Check the database to make sure no transaction was inserted in Sequencer and coordinator db.
- Now, try deposit to any address bigger than  `0x00000....0000010000`, the transaction should pass.
- The verifier should verify and finalize the l1 batch.
- Done :)

## Checklist
- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
