### PR TITLE
Fix: add wallet endpoint to the btc rpc url

### DIFF
--- a/core/lib/config/src/configs/via_btc_client.rs
+++ b/core/lib/config/src/configs/via_btc_client.rs
@@ -20,7 +20,7 @@ impl ViaBtcClientConfig {
             return base_rpc_url;
         }
         // Include the wallet endpoint to fetch the utxos.
-        let base_rpc_url = format!("{}/wallet/{}", base_rpc_url, wallet);
+        let base_rpc_url = format!("{}wallet/{}", base_rpc_url, wallet);
         println!(
             "------------------------------------------- {}",
             base_rpc_url.clone()

--- a/core/lib/config/src/configs/via_btc_client.rs
+++ b/core/lib/config/src/configs/via_btc_client.rs
@@ -20,7 +20,12 @@ impl ViaBtcClientConfig {
             return base_rpc_url;
         }
         // Include the wallet endpoint to fetch the utxos.
-        format!("{}/wallet/{}", base_rpc_url, wallet)
+        let base_rpc_url = format!("{}/wallet/{}", base_rpc_url, wallet);
+        println!(
+            "------------------------------------------- {}",
+            base_rpc_url.clone()
+        );
+        base_rpc_url
     }
 }
 

--- a/core/lib/config/src/configs/via_btc_client.rs
+++ b/core/lib/config/src/configs/via_btc_client.rs
@@ -14,6 +14,14 @@ impl ViaBtcClientConfig {
     pub fn network(&self) -> Network {
         Network::from_str(&self.network).unwrap_or(Network::Regtest)
     }
+
+    pub fn rpc_url(&self, base_rpc_url: String, wallet: String) -> String {
+        if self.network() == Network::Regtest {
+            return base_rpc_url;
+        }
+        // Include the wallet endpoint to fetch the utxos.
+        format!("{}/wallet/{}", base_rpc_url, wallet)
+    }
 }
 
 impl ViaBtcClientConfig {

--- a/core/lib/config/src/configs/via_btc_sender.rs
+++ b/core/lib/config/src/configs/via_btc_sender.rs
@@ -23,6 +23,9 @@ pub struct ViaBtcSenderConfig {
 
     /// The identifier of the DA layer.
     pub da_identifier: Option<String>,
+
+    /// The btc sender wallet address.
+    pub wallet_address: String,
 }
 
 impl ViaBtcSenderConfig {
@@ -48,6 +51,7 @@ impl ViaBtcSenderConfig {
             max_txs_in_flight: 1,
             block_confirmations: 0,
             da_identifier: None,
+            wallet_address: "".into(),
         }
     }
 }

--- a/core/lib/config/src/configs/via_verifier.rs
+++ b/core/lib/config/src/configs/via_verifier.rs
@@ -25,6 +25,9 @@ pub struct ViaVerifierConfig {
 
     /// (TEST ONLY) returns the proof verification result.
     pub test_zk_proof_invalid_l1_batch_numbers: Vec<i64>,
+
+    /// The verifier btc wallet address.
+    pub wallet_address: String,
 }
 
 impl ViaVerifierConfig {
@@ -46,6 +49,7 @@ impl ViaVerifierConfig {
             coordinator_port: 3000,
             verifier_request_timeout: 10,
             test_zk_proof_invalid_l1_batch_numbers: vec![],
+            wallet_address: "".into(),
         }
     }
 }

--- a/core/lib/config/src/configs/via_wallets.rs
+++ b/core/lib/config/src/configs/via_wallets.rs
@@ -6,6 +6,7 @@ use super::wallets::{AddressWallet, StateKeeper, TokenMultiplierSetter, Wallet};
 
 #[derive(Default, Clone, PartialEq)]
 pub struct ViaWallet {
+    pub address: String,
     pub private_key: String,
 }
 
@@ -13,14 +14,17 @@ impl fmt::Debug for ViaWallet {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Secret")
-            .field("private_key", &"******")
+            .field("address", &self.address)
             .finish()
     }
 }
 
 impl ViaWallet {
-    pub fn new(private_key: String) -> Self {
-        Self { private_key }
+    pub fn new(address: String, private_key: String) -> Self {
+        Self {
+            address,
+            private_key,
+        }
     }
 }
 
@@ -43,8 +47,8 @@ impl ViaWallets {
             token_multiplier_setter: Some(TokenMultiplierSetter {
                 wallet: Wallet::from_private_key_bytes(H256::repeat_byte(0x4), None).unwrap(),
             }),
-            btc_sender: Some(ViaWallet::new(String::from("pk"))),
-            vote_operator: Some(ViaWallet::new(String::from("pk"))),
+            btc_sender: Some(ViaWallet::new("".into(), String::from("pk"))),
+            vote_operator: Some(ViaWallet::new("".into(), String::from("pk"))),
         }
     }
 }

--- a/core/lib/env_config/src/via_wallets.rs
+++ b/core/lib/env_config/src/via_wallets.rs
@@ -17,18 +17,26 @@ impl FromEnv for ViaWallets {
     fn from_env() -> anyhow::Result<Self> {
         let wallets = Wallets::from_env()?;
 
+        let btc_sender_address = pk_from_env(
+            "VIA_BTC_SENDER_WALLET_ADDRESS",
+            "Malformed operator address",
+        )?;
         let btc_sender_pk = pk_from_env("VIA_BTC_SENDER_PRIVATE_KEY", "Malformed operator pk")?;
-        let musig2_session_pk =
-            pk_from_env("VIA_VERIFIER_PRIVATE_KEY", "Malformed musig2 session pk")?;
+
+        let verifier_address =
+            pk_from_env("VIA_VERIFIER_WALLET_ADDRESS", "Malformed verifier address")?;
+        let verifier_pk = pk_from_env("VIA_VERIFIER_PRIVATE_KEY", "Malformed verifier pk")?;
 
         Ok(Self {
             state_keeper: wallets.state_keeper,
             token_multiplier_setter: wallets.token_multiplier_setter,
             btc_sender: Some(ViaWallet {
+                address: btc_sender_address.unwrap_or_default(),
                 private_key: btc_sender_pk.clone().unwrap_or_default(),
             }),
             vote_operator: Some(ViaWallet {
-                private_key: musig2_session_pk.unwrap_or_default(),
+                address: verifier_address.unwrap_or_default(),
+                private_key: verifier_pk.unwrap_or_default(),
             }),
         })
     }

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
@@ -79,7 +79,10 @@ impl WiringLayer for ViaBtcInscriptionAggregatorLayer {
         let master_pool = input.master_pool.get().await.unwrap();
 
         let inscriber = Inscriber::new(
-            self.secrets.rpc_url.expose_str(),
+            &self.via_btc_client.rpc_url(
+                self.secrets.rpc_url.expose_str().into(),
+                self.wallet.address.clone(),
+            ),
             self.via_btc_client.network(),
             self.secrets.auth_node(),
             &self.wallet.private_key,

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
@@ -79,7 +79,10 @@ impl WiringLayer for ViaInscriptionManagerLayer {
         let master_pool = input.master_pool.get().await.unwrap();
 
         let inscriber = Inscriber::new(
-            self.secrets.rpc_url.expose_str(),
+            &self.via_btc_client.rpc_url(
+                self.secrets.rpc_url.expose_str().into(),
+                self.wallet.address.clone(),
+            ),
             self.via_btc_client.network(),
             self.secrets.auth_node(),
             &self.wallet.private_key,

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/vote_manager.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/vote_manager.rs
@@ -79,7 +79,10 @@ impl WiringLayer for ViaInscriptionManagerLayer {
         let master_pool = input.master_pool.get().await.unwrap();
 
         let inscriber = Inscriber::new(
-            self.secrets.rpc_url.expose_str(),
+            &self.via_btc_client.rpc_url(
+                self.secrets.rpc_url.expose_str().into(),
+                self.wallet.address.clone(),
+            ),
             self.via_btc_client.network(),
             self.secrets.auth_node(),
             &self.wallet.private_key,

--- a/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
@@ -77,7 +77,7 @@ impl WiringLayer for ViaCoordinatorApiLayer {
             BitcoinClient::new(
                 &self.via_btc_client.rpc_url(
                     self.secrets.rpc_url.expose_str().to_string(),
-                    self.via_genesis_config.bridge_address()?.to_string(),
+                    self.via_genesis_config.bridge_address.clone(),
                 ),
                 self.via_btc_client.network(),
                 self.secrets.auth_node(),

--- a/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
@@ -75,10 +75,9 @@ impl WiringLayer for ViaCoordinatorApiLayer {
 
         let btc_client = Arc::new(
             BitcoinClient::new(
-                &format!(
-                    "{}/wallet/{}",
-                    self.secrets.rpc_url.expose_str(),
-                    self.via_genesis_config.bridge_address()?.to_string()
+                &self.via_btc_client.rpc_url(
+                    self.secrets.rpc_url.expose_str().to_string(),
+                    self.via_genesis_config.bridge_address()?.to_string(),
                 ),
                 self.via_btc_client.network(),
                 self.secrets.auth_node(),

--- a/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
@@ -75,7 +75,11 @@ impl WiringLayer for ViaCoordinatorApiLayer {
 
         let btc_client = Arc::new(
             BitcoinClient::new(
-                self.secrets.rpc_url.expose_str(),
+                &format!(
+                    "{}/wallet/{}",
+                    self.secrets.rpc_url.expose_str(),
+                    self.via_genesis_config.bridge_address()?.to_string()
+                ),
                 self.via_btc_client.network(),
                 self.secrets.auth_node(),
             )

--- a/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
@@ -82,10 +82,9 @@ impl WiringLayer for ViaWithdrawalVerifierLayer {
 
         let btc_client = Arc::new(
             BitcoinClient::new(
-                &format!(
-                    "{}/wallet/{}",
-                    self.secrets.rpc_url.expose_str(),
-                    self.wallet.address
+                &self.via_btc_client.rpc_url(
+                    self.secrets.rpc_url.expose_str().to_string(),
+                    self.wallet.address.clone(),
                 ),
                 self.via_btc_client.network(),
                 self.secrets.auth_node(),

--- a/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
@@ -82,7 +82,11 @@ impl WiringLayer for ViaWithdrawalVerifierLayer {
 
         let btc_client = Arc::new(
             BitcoinClient::new(
-                self.secrets.rpc_url.expose_str(),
+                &format!(
+                    "{}/wallet/{}",
+                    self.secrets.rpc_url.expose_str(),
+                    self.wallet.address
+                ),
                 self.via_btc_client.network(),
                 self.secrets.auth_node(),
             )

--- a/etc/env/base/via_private.toml
+++ b/etc/env/base/via_private.toml
@@ -9,6 +9,7 @@ test_database_prover_url = "postgres://postgres:notsecurepassword@localhost:5433
 [via_btc_sender]
 # The btc sender private key.
 private_key = "cVZduZu265sWeAqFYygoDEE1FZ7wV9rpW5qdqjRkUehjaUMWLT1R"
+wallet_address = "bcrt1qx2lk0unukm80qmepjp49hwf9z6xnz0s73k9j56"
 
 [via_celestia_client]
 # The celestia auth token.

--- a/etc/env/configs/via_coordinator.toml
+++ b/etc/env/configs/via_coordinator.toml
@@ -5,7 +5,9 @@ __imports__ = ["base", "l2-inits/via_coordinator.init.env"]
 role = "Coordinator"
 # The wallet used in musig2 sessions.
 private_key = "cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm"
+wallet_address = "bcrt1qw2mvkvm6alfhe86yf328kgvr7mupdx4vln7kpv"
 
 [via_btc_sender]
 # The wallet used in the btc sender.
 private_key = "cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm"
+wallet_address = "bcrt1qw2mvkvm6alfhe86yf328kgvr7mupdx4vln7kpv"

--- a/etc/env/configs/via_verifier.toml
+++ b/etc/env/configs/via_verifier.toml
@@ -5,7 +5,9 @@ __imports__ = ["base", "l2-inits/via_verifier.init.env"]
 role = "Verifier"
 # The wallet used in musig2 sessions.
 private_key = "cQ4UHjdsGWFMcQ8zXcaSr7m4Kxq9x7g9EKqguTaFH7fA34mZAnqW"
+wallet_address = "bcrt1qk8mkhrmgtq24nylzyzejznfzws6d98g4kmuuh4"
 
 [via_btc_sender]
 # The wallet used in the btc sender.
 private_key = "cQ4UHjdsGWFMcQ8zXcaSr7m4Kxq9x7g9EKqguTaFH7fA34mZAnqW"
+wallet_address = "bcrt1qk8mkhrmgtq24nylzyzejznfzws6d98g4kmuuh4"


### PR DESCRIPTION
## What ❔

- Add the wallet endpoint to the bitcoin RPC url. 


## Why ❔

To track and list he utxos, the wallet needs to be added to the node, this will index the utxos. And to list those utxos on  `Testnet` and `Bitcoin` networks we have to set the wallet endpoint `http://127.0.0.1:8332/wallet/testwallet`,
Without this fix, the node will returns empty list of utxos.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
