### PR TITLE
Feat/via estimation fee fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9518,6 +9518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "vise",
  "zksync_basic_types",
  "zksync_config",
  "zksync_object_store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9707,6 +9707,7 @@ dependencies = [
  "via_da_clients",
  "via_verifier_types",
  "via_withdrawal_client",
+ "zksync_config",
  "zksync_dal",
 ]
 

--- a/core/lib/config/src/configs/via_btc_client.rs
+++ b/core/lib/config/src/configs/via_btc_client.rs
@@ -11,7 +11,7 @@ pub struct ViaBtcClientConfig {
     pub external_apis: Vec<String>,
     /// Fee strategies
     pub fee_strategies: Vec<String>,
-    /// Use external api to get the inscription fee rate.
+    /// Use the RPC node as main fee rate provider.
     pub use_rpc_for_fee_rate: Option<bool>,
 }
 

--- a/core/lib/config/src/configs/via_btc_client.rs
+++ b/core/lib/config/src/configs/via_btc_client.rs
@@ -6,7 +6,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ViaBtcClientConfig {
     /// Name of the used Bitcoin network
-    network: String,
+    pub network: String,
+    /// External fee APIs
+    pub external_apis: Vec<String>,
+    /// Fee strategies
+    pub fee_strategies: Vec<String>,
+    /// Use external api to get the inscription fee rate.
+    pub use_rpc_for_fee_rate: Option<bool>,
 }
 
 impl ViaBtcClientConfig {
@@ -20,12 +26,14 @@ impl ViaBtcClientConfig {
             return base_rpc_url;
         }
         // Include the wallet endpoint to fetch the utxos.
-        let base_rpc_url = format!("{}wallet/{}", base_rpc_url, wallet);
-        println!(
-            "------------------------------------------- {}",
-            base_rpc_url.clone()
-        );
-        base_rpc_url
+        format!("{}wallet/{}", base_rpc_url, wallet)
+    }
+
+    pub fn use_rpc_for_fee_rate(&self) -> bool {
+        if let Some(use_external_api) = self.use_rpc_for_fee_rate {
+            return use_external_api;
+        }
+        true
     }
 }
 
@@ -34,6 +42,9 @@ impl ViaBtcClientConfig {
     pub fn for_tests() -> Self {
         Self {
             network: Network::Regtest.to_string(),
+            external_apis: vec![],
+            fee_strategies: vec![],
+            use_rpc_for_fee_rate: Some(false),
         }
     }
 }

--- a/core/lib/via_btc_client/Cargo.toml
+++ b/core/lib/via_btc_client/Cargo.toml
@@ -82,3 +82,7 @@ path = "examples/deposit_opreturn.rs"
 [[example]]
 name = "upgrade_system_contracts"
 path = "examples/upgrade_system_contracts.rs"
+
+[[example]]
+name = "fee_rate"
+path = "examples/fee_rate.rs"

--- a/core/lib/via_btc_client/Cargo.toml
+++ b/core/lib/via_btc_client/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+vise.workspace = true
 zksync_types.workspace = true
 zksync_config.workspace = true
 zksync_basic_types.workspace = true
@@ -82,7 +83,3 @@ path = "examples/deposit_opreturn.rs"
 [[example]]
 name = "upgrade_system_contracts"
 path = "examples/upgrade_system_contracts.rs"
-
-[[example]]
-name = "fee_rate"
-path = "examples/fee_rate.rs"

--- a/core/lib/via_btc_client/examples/fee_rate.rs
+++ b/core/lib/via_btc_client/examples/fee_rate.rs
@@ -1,0 +1,39 @@
+use std::{env, str::FromStr, sync::Arc};
+
+use anyhow::{Context, Result};
+use tracing::info;
+use via_btc_client::{
+    client::BitcoinClient,
+    inscriber::Inscriber,
+    traits::BitcoinOps,
+    types::{BitcoinNetwork, NodeAuth},
+};
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
+
+const RPC_URL: &str = "http://0.0.0.0:18443";
+const RPC_USERNAME: &str = "rpcuser";
+const RPC_PASSWORD: &str = "rpcpassword";
+const NETWORK: BitcoinNetwork = BitcoinNetwork::Regtest;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let use_rpc_for_fee_rate = bool::from_str(&args[1].to_string())?;
+
+    let auth = NodeAuth::UserPass(RPC_USERNAME.to_string(), RPC_PASSWORD.to_string());
+    let config = ViaBtcClientConfig {
+        network: NETWORK.to_string(),
+        external_apis: vec!["https://mempool.space/testnet/api/v1/fees/recommended".into()],
+        fee_strategies: vec!["fastestFee".into()],
+        use_rpc_for_fee_rate: Some(use_rpc_for_fee_rate),
+    };
+    let client = Arc::new(BitcoinClient::new(&RPC_URL, auth, config)?);
+    let fee_rate = client.get_fee_rate(1).await?;
+    info!("Fee rate {:?}", fee_rate);
+
+    Ok(())
+}

--- a/core/lib/via_btc_client/examples/fee_rate.rs
+++ b/core/lib/via_btc_client/examples/fee_rate.rs
@@ -1,10 +1,9 @@
 use std::{env, str::FromStr, sync::Arc};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use tracing::info;
 use via_btc_client::{
     client::BitcoinClient,
-    inscriber::Inscriber,
     traits::BitcoinOps,
     types::{BitcoinNetwork, NodeAuth},
 };

--- a/core/lib/via_btc_client/examples/indexer_init_example.rs
+++ b/core/lib/via_btc_client/examples/indexer_init_example.rs
@@ -1,10 +1,19 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use tracing_subscriber;
 use via_btc_client::{
+    client::BitcoinClient,
     indexer::BitcoinInscriptionIndexer,
     regtest::BitcoinRegtest,
     types::{BitcoinNetwork, NodeAuth},
 };
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
+
+const RPC_URL: &str = "http://0.0.0.0:18443";
+const RPC_USERNAME: &str = "rpcuser";
+const RPC_PASSWORD: &str = "rpcpassword";
+const NETWORK: BitcoinNetwork = BitcoinNetwork::Regtest;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,13 +25,17 @@ async fn main() -> Result<()> {
     let context = BitcoinRegtest::new()?;
     let miner = context.get_miner_address()?;
     tracing::info!("miner address: {}", miner);
-    let indexer = BitcoinInscriptionIndexer::new(
-        &context.get_url(),
-        BitcoinNetwork::Regtest,
-        NodeAuth::UserPass("via".to_string(), "via".to_string()),
-        vec![],
-    )
-    .await;
+
+    let auth = NodeAuth::UserPass(RPC_USERNAME.to_string(), RPC_PASSWORD.to_string());
+    let config = ViaBtcClientConfig {
+        network: NETWORK.to_string(),
+        external_apis: vec![],
+        fee_strategies: vec![],
+        use_rpc_for_fee_rate: None,
+    };
+    let client = Arc::new(BitcoinClient::new(RPC_URL, auth, config.clone())?);
+
+    let indexer = BitcoinInscriptionIndexer::new(client, config, vec![]).await;
 
     if let Err(e) = indexer {
         tracing::error!("Failed to create indexer: {:?}", e);

--- a/core/lib/via_btc_client/src/client/mod.rs
+++ b/core/lib/via_btc_client/src/client/mod.rs
@@ -12,6 +12,7 @@ mod rpc_client;
 
 use crate::{
     client::{fee_limits::FeeRateLimits, rpc_client::BitcoinRpcClient},
+    metrics::{RpcMethodLabel, METRICS},
     traits::{BitcoinOps, BitcoinRpc},
     types::{BitcoinClientResult, BitcoinError, BitcoinNetwork, NodeAuth},
 };
@@ -139,6 +140,10 @@ impl BitcoinOps for BitcoinClient {
                     }
                 }
                 Err(err) => {
+                    METRICS.rpc_errors[&RpcMethodLabel {
+                        method: "rpc_estimate_smart_fee".into(),
+                    }]
+                        .inc();
                     error!("Failed to estimate smart fee via RPC: {:?}", err);
                     None
                 }
@@ -176,6 +181,10 @@ impl BitcoinOps for BitcoinClient {
                         }
                     },
                     Err(e) => {
+                        METRICS.rpc_errors[&RpcMethodLabel {
+                            method: "estimate_smart_fee".into(),
+                        }]
+                            .inc();
                         error!("Failed to fetch from {}: {:?}", api_url, e);
                     }
                 }

--- a/core/lib/via_btc_client/src/client/mod.rs
+++ b/core/lib/via_btc_client/src/client/mod.rs
@@ -5,6 +5,7 @@ use bitcoin::{Address, Block, BlockHash, Network, OutPoint, Transaction, TxOut, 
 use bitcoincore_rpc::json::{EstimateMode, GetBlockStatsResult};
 use futures::future::join_all;
 use tracing::{debug, error, instrument};
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
 
 mod fee_limits;
 mod rpc_client;
@@ -18,12 +19,16 @@ use crate::{
 #[derive(Debug)]
 pub struct BitcoinClient {
     rpc: Arc<dyn BitcoinRpc>,
-    network: BitcoinNetwork,
+    pub config: ViaBtcClientConfig,
 }
 
 impl BitcoinClient {
     #[instrument(skip(auth), target = "bitcoin_client")]
-    pub fn new(rpc_url: &str, network: BitcoinNetwork, auth: NodeAuth) -> BitcoinClientResult<Self>
+    pub fn new(
+        rpc_url: &str,
+        auth: NodeAuth,
+        config: ViaBtcClientConfig,
+    ) -> BitcoinClientResult<Self>
     where
         Self: Sized,
     {
@@ -31,7 +36,7 @@ impl BitcoinClient {
         let rpc = BitcoinRpcClient::new(rpc_url, auth)?;
         Ok(Self {
             rpc: Arc::new(rpc),
-            network,
+            config,
         })
     }
 }
@@ -41,7 +46,7 @@ impl BitcoinOps for BitcoinClient {
     #[instrument(skip(self), target = "bitcoin_client")]
     async fn get_balance(&self, address: &Address) -> BitcoinClientResult<u128> {
         debug!("Getting balance");
-        match self.network {
+        match self.config.network() {
             BitcoinNetwork::Regtest => {
                 let balance = self.rpc.get_balance_scan(address).await?;
                 Ok(balance as u128)
@@ -70,7 +75,7 @@ impl BitcoinOps for BitcoinClient {
     #[instrument(skip(self), target = "bitcoin_client")]
     async fn fetch_utxos(&self, address: &Address) -> BitcoinClientResult<Vec<(OutPoint, TxOut)>> {
         debug!("Fetching UTXOs");
-        let outpoints = match self.network {
+        let outpoints = match self.config.network() {
             Network::Regtest => self.rpc.list_unspent(address).await?,
             _ => self.rpc.list_unspent_based_on_node_wallet(address).await?,
         };
@@ -110,55 +115,102 @@ impl BitcoinOps for BitcoinClient {
     #[instrument(skip(self), target = "bitcoin_client")]
     async fn get_fee_rate(&self, conf_target: u16) -> BitcoinClientResult<u64> {
         debug!("Estimating fee rate");
-        let estimation = self
-            .rpc
-            .estimate_smart_fee(conf_target, Some(EstimateMode::Economical))
-            .await?;
+        let mut fee_rate_sat_kb: Option<u64> = None;
 
-        let mempool_info = self.rpc.get_mempool_info().await?;
+        if self.config.use_rpc_for_fee_rate() {
+            let estimation_result = self
+                .rpc
+                .estimate_smart_fee(conf_target, Some(EstimateMode::Economical))
+                .await;
 
-        match estimation.fee_rate {
-            Some(fee_rate) => {
-                // Select the maximum fee between the estimated fee and the minimum required mempool fee.
-                let mut fee_rate_sat_kb =
-                    std::cmp::max(fee_rate.to_sat(), mempool_info.mempool_min_fee.to_sat());
-
-                // Add 1 sat/kB to avoid precision loss when converting to sat/byte.
-                fee_rate_sat_kb += 1000;
-
-                let fee_rate_sat_byte = fee_rate_sat_kb.checked_div(1000);
-                match fee_rate_sat_byte {
-                    Some(fee_rate_sat_byte) => {
-                        // Get network-specific fee rate limits
-                        let limits = FeeRateLimits::from_network(self.network);
-
-                        // Cap between network-specific max and min values
-                        let capped_fee_rate =
-                            std::cmp::min(fee_rate_sat_byte, limits.max_fee_rate());
-                        let final_fee_rate = std::cmp::max(capped_fee_rate, limits.min_fee_rate());
-
-                        debug!("Final fee rate used: {} (sat/vB)", final_fee_rate);
-
-                        Ok(final_fee_rate)
+            fee_rate_sat_kb = match estimation_result {
+                Ok(estimation) => {
+                    if let Some(fee_rate) = estimation.fee_rate {
+                        Some(fee_rate.to_sat())
+                    } else {
+                        error!(
+                            "RPC fee estimate missing value: {}",
+                            estimation
+                                .errors
+                                .map(|e| e.join(", "))
+                                .unwrap_or_else(|| "Unknown error".to_string())
+                        );
+                        None
                     }
-                    None => Err(BitcoinError::FeeEstimationFailed(
-                        "Invalid fee rate".to_string(),
-                    )),
+                }
+                Err(err) => {
+                    error!("Failed to estimate smart fee via RPC: {:?}", err);
+                    None
+                }
+            };
+        }
+
+        // Fallback to external APIs if RPC failed or returned no fee
+        if fee_rate_sat_kb.is_none() {
+            let client = reqwest::Client::new();
+
+            for (api_url, fee_target_key) in self
+                .config
+                .external_apis
+                .iter()
+                .zip(self.config.fee_strategies.iter())
+            {
+                match client.get(api_url).send().await {
+                    Ok(resp) => match resp.json::<serde_json::Value>().await {
+                        Ok(json) => {
+                            if let Some(fee_rate_vb) =
+                                json.get(fee_target_key).and_then(|v| v.as_f64())
+                            {
+                                fee_rate_sat_kb = Some((fee_rate_vb * 1000.0).round() as u64);
+                                debug!(
+                                    "Fee rate from API {} [{}]: {} sat/vB",
+                                    api_url, fee_target_key, fee_rate_vb
+                                );
+                                break;
+                            } else {
+                                error!("Missing '{}' in response from {}", fee_target_key, api_url);
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to parse JSON from {}: {:?}", api_url, e);
+                        }
+                    },
+                    Err(e) => {
+                        error!("Failed to fetch from {}: {:?}", api_url, e);
+                    }
                 }
             }
-            None => {
-                let err = estimation
-                    .errors
-                    .map(|errors| errors.join(", "))
-                    .unwrap_or_else(|| "Unknown error during fee estimation".to_string());
-                error!("Fee estimation failed: {}", err);
-                Err(BitcoinError::FeeEstimationFailed(err))
-            }
         }
+
+        // If no fee estimate was obtained
+        let mut fee_rate_sat_kb = fee_rate_sat_kb.ok_or_else(|| {
+            BitcoinError::FeeEstimationFailed("All fee estimation methods failed".into())
+        })?;
+
+        // Add a small buffer to avoid precision loss
+        fee_rate_sat_kb += 1000;
+
+        // Get mempool minimum fee
+        let mempool_info = self.rpc.get_mempool_info().await?;
+        let mempool_min_fee_sat_kb = mempool_info.mempool_min_fee.to_sat();
+        fee_rate_sat_kb = std::cmp::max(fee_rate_sat_kb, mempool_min_fee_sat_kb);
+
+        // Convert to sat/vB
+        let fee_rate_sat_vb = fee_rate_sat_kb.checked_div(1000).ok_or_else(|| {
+            BitcoinError::FeeEstimationFailed("Failed to convert sat/kB to sat/vB".into())
+        })?;
+
+        // Apply network-specific caps
+        let limits = FeeRateLimits::from_network(self.config.network());
+        let capped = std::cmp::min(fee_rate_sat_vb, limits.max_fee_rate());
+        let final_rate = std::cmp::max(capped, limits.min_fee_rate());
+
+        debug!("Final fee rate used: {} sat/vB", final_rate);
+        Ok(final_rate)
     }
 
     fn get_network(&self) -> BitcoinNetwork {
-        self.network
+        self.config.network()
     }
 
     #[instrument(skip(self), target = "bitcoin_client")]
@@ -220,7 +272,7 @@ impl Clone for BitcoinClient {
     fn clone(&self) -> Self {
         Self {
             rpc: Arc::clone(&self.rpc),
-            network: self.network,
+            config: ViaBtcClientConfig::for_tests(),
         }
     }
 }
@@ -265,7 +317,7 @@ mod tests {
     fn get_client_with_mock(mock_bitcoin_rpc: MockBitcoinRpc) -> BitcoinClient {
         BitcoinClient {
             rpc: Arc::new(mock_bitcoin_rpc),
-            network: BitcoinNetwork::Bitcoin,
+            config: ViaBtcClientConfig::for_tests(),
         }
     }
 

--- a/core/lib/via_btc_client/src/indexer/mod.rs
+++ b/core/lib/via_btc_client/src/indexer/mod.rs
@@ -85,21 +85,11 @@ impl BitcoinInscriptionIndexer {
         client: Arc<BitcoinClient>,
         config: ViaBtcClientConfig,
         bootstrap_txids: Vec<Txid>,
-        // rpc_url: &str,
-        // network: Network,
-        // auth: Auth,
     ) -> BitcoinIndexerResult<Self>
     where
         Self: Sized,
     {
         info!("Creating new BitcoinInscriptionIndexer");
-        // let client = Arc::new(BitcoinClient::new(
-        //     rpc_url,
-        //     network,
-        //     auth,
-        //     vec![],
-        //     "".into(),
-        // )?);
         let mut parser = MessageParser::new(config.network());
         let mut bootstrap_state = BootstrapState::new();
 

--- a/core/lib/via_btc_client/src/inscriber/mod.rs
+++ b/core/lib/via_btc_client/src/inscriber/mod.rs
@@ -167,7 +167,7 @@ impl Inscriber {
         let inscriber_info = self
             .prepare_inscribe(&input, recipient)
             .await
-            .context("Error prepare inscriber infos")?;
+            .with_context(|| "Error prepare inscriber infos")?;
 
         self.broadcast_inscription(
             &inscriber_info.final_commit_tx,
@@ -433,7 +433,7 @@ impl Inscriber {
                     input.utxo_amounts[index],
                     sighash_type,
                 )
-                .context("Failed to create sighash")?;
+                .with_context(|| "Failed to create commit sighash")?;
 
             // Sign the sighash using the signer
             let msg = Message::from(sighash);
@@ -666,7 +666,7 @@ impl Inscriber {
                 input.prev_outs[REVEAL_TX_FEE_INPUT_INDEX as usize].value,
                 sighash_type,
             )
-            .context("Failed to create sighash")?;
+            .with_context(|| "Failed to create reveal sighash payer")?;
 
         // Sign the fee payer sighash using the signer
         let fee_payer_msg = Message::from(fee_payer_input_sighash);
@@ -701,7 +701,7 @@ impl Inscriber {
                 ),
                 sighash_type,
             )
-            .context("Failed to create sighash")?;
+            .with_context(|| "Failed to create reveal sighash")?;
 
         // Sign the tapscript reveal sighash using the signer
         let msg = Message::from_digest(reveal_input_sighash.to_byte_array());

--- a/core/lib/via_btc_client/src/inscriber/script_builder.rs
+++ b/core/lib/via_btc_client/src/inscriber/script_builder.rs
@@ -74,7 +74,7 @@ impl InscriptionData {
         let mut builder = TaprootBuilder::new();
         builder = builder
             .add_leaf(0, inscription_script.clone())
-            .context("adding leaf should work")?;
+            .with_context(|| "Adding leaf should work")?;
 
         let taproot_spend_info = builder
             .finalize(secp, internal_key)

--- a/core/lib/via_btc_client/src/lib.rs
+++ b/core/lib/via_btc_client/src/lib.rs
@@ -4,6 +4,7 @@ pub mod types;
 pub mod client;
 pub mod indexer;
 pub mod inscriber;
+pub mod metrics;
 #[cfg(feature = "regtest")]
 pub mod regtest;
 pub(crate) mod signer;

--- a/core/lib/via_btc_client/src/metrics.rs
+++ b/core/lib/via_btc_client/src/metrics.rs
@@ -1,0 +1,19 @@
+use vise::{Counter, EncodeLabelSet, Family, Metrics};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub struct RpcMethodLabel {
+    pub method: String,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "via_btc_client")]
+pub struct ViaBtcClientMetrics {
+    /// Number of RPC errors encountered, by method and error type
+    pub rpc_errors: Family<RpcMethodLabel, Counter>,
+
+    /// Number of RPC errors encountered, by method and error type
+    pub rpc_max_retries_exceeded: Family<RpcMethodLabel, Counter>,
+}
+
+#[vise::register]
+pub static METRICS: vise::Global<ViaBtcClientMetrics> = vise::Global::new();

--- a/core/node/node_framework/src/implementations/layers/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/mod.rs
@@ -35,6 +35,7 @@ pub mod sync_state_updater;
 pub mod tee_verifier_input_producer;
 pub mod tree_data_fetcher;
 pub mod validate_chain_ids;
+pub mod via_btc_client;
 pub mod via_btc_sender;
 pub mod via_btc_watch;
 pub mod via_da_dispatcher;

--- a/core/node/node_framework/src/implementations/layers/via_btc_client.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_client.rs
@@ -1,0 +1,53 @@
+use via_btc_client::client::BitcoinClient;
+use zksync_config::configs::{via_btc_client::ViaBtcClientConfig, via_secrets::ViaL1Secrets};
+
+use crate::{
+    implementations::resources::via_btc_client::BtcClientResource,
+    wiring_layer::{WiringError, WiringLayer},
+    IntoContext,
+};
+
+#[derive(Debug)]
+pub struct BtcClientLayer {
+    via_btc_client: ViaBtcClientConfig,
+    secrets: ViaL1Secrets,
+}
+
+#[derive(Debug, IntoContext)]
+#[context(crate = crate)]
+pub struct Output {
+    pub btc_client_resource: BtcClientResource,
+}
+
+impl BtcClientLayer {
+    pub fn new(via_btc_client: ViaBtcClientConfig, secrets: ViaL1Secrets) -> Self {
+        Self {
+            via_btc_client,
+            secrets,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for BtcClientLayer {
+    type Input = ();
+    type Output = Output;
+
+    fn layer_name(&self) -> &'static str {
+        "btc_client_layer"
+    }
+
+    async fn wire(self, _: Self::Input) -> Result<Self::Output, WiringError> {
+        let client = BitcoinClient::new(
+            self.secrets.rpc_url.expose_str(),
+            self.secrets.auth_node(),
+            self.via_btc_client,
+        )
+        .map_err(|e| WiringError::Internal(e.into()))?;
+        let btc_client_resource = BtcClientResource::from(client);
+
+        Ok(Output {
+            btc_client_resource,
+        })
+    }
+}

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
@@ -1,14 +1,12 @@
 use via_btc_client::inscriber::Inscriber;
 use via_btc_sender::btc_inscription_aggregator::ViaBtcInscriptionAggregator;
-use zksync_config::{
-    configs::{
-        via_btc_client::ViaBtcClientConfig, via_secrets::ViaL1Secrets, via_wallets::ViaWallet,
-    },
-    ViaBtcSenderConfig,
-};
+use zksync_config::{configs::via_wallets::ViaWallet, ViaBtcSenderConfig};
 
 use crate::{
-    implementations::resources::pools::{MasterPool, PoolResource},
+    implementations::resources::{
+        pools::{MasterPool, PoolResource},
+        via_btc_client::BtcClientResource,
+    },
     service::StopReceiver,
     task::{Task, TaskId},
     wiring_layer::{WiringError, WiringLayer},
@@ -30,16 +28,15 @@ use crate::{
 /// - `ViaBtcInscriptionAggregator`
 #[derive(Debug)]
 pub struct ViaBtcInscriptionAggregatorLayer {
-    via_btc_client: ViaBtcClientConfig,
     config: ViaBtcSenderConfig,
     wallet: ViaWallet,
-    secrets: ViaL1Secrets,
 }
 
 #[derive(Debug, FromContext)]
 #[context(crate = crate)]
 pub struct Input {
     pub master_pool: PoolResource<MasterPool>,
+    pub btc_client_resource: BtcClientResource,
 }
 
 #[derive(Debug, IntoContext)]
@@ -50,18 +47,8 @@ pub struct Output {
 }
 
 impl ViaBtcInscriptionAggregatorLayer {
-    pub fn new(
-        via_btc_client: ViaBtcClientConfig,
-        config: ViaBtcSenderConfig,
-        wallet: ViaWallet,
-        secrets: ViaL1Secrets,
-    ) -> Self {
-        Self {
-            via_btc_client,
-            config,
-            wallet,
-            secrets,
-        }
+    pub fn new(config: ViaBtcSenderConfig, wallet: ViaWallet) -> Self {
+        Self { config, wallet }
     }
 }
 
@@ -77,19 +64,11 @@ impl WiringLayer for ViaBtcInscriptionAggregatorLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         // Get resources.
         let master_pool = input.master_pool.get().await.unwrap();
+        let client = input.btc_client_resource.0;
 
-        let inscriber = Inscriber::new(
-            &self.via_btc_client.rpc_url(
-                self.secrets.rpc_url.expose_str().into(),
-                self.wallet.address.clone(),
-            ),
-            self.via_btc_client.network(),
-            self.secrets.auth_node(),
-            &self.wallet.private_key,
-            None,
-        )
-        .await
-        .unwrap();
+        let inscriber = Inscriber::new(client, &self.wallet.private_key, None)
+            .await
+            .unwrap();
 
         let via_btc_inscription_aggregator =
             ViaBtcInscriptionAggregator::new(inscriber, master_pool, self.config).await?;

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
@@ -1,15 +1,13 @@
 use anyhow::Context;
 use via_btc_client::inscriber::Inscriber;
 use via_btc_sender::btc_inscription_manager::ViaBtcInscriptionManager;
-use zksync_config::{
-    configs::{
-        via_btc_client::ViaBtcClientConfig, via_secrets::ViaL1Secrets, via_wallets::ViaWallet,
-    },
-    ViaBtcSenderConfig,
-};
+use zksync_config::{configs::via_wallets::ViaWallet, ViaBtcSenderConfig};
 
 use crate::{
-    implementations::resources::pools::{MasterPool, PoolResource},
+    implementations::resources::{
+        pools::{MasterPool, PoolResource},
+        via_btc_client::BtcClientResource,
+    },
     service::StopReceiver,
     task::{Task, TaskId},
     wiring_layer::{WiringError, WiringLayer},
@@ -30,16 +28,15 @@ use crate::{
 /// - `ViaBtcInscriptionManager`
 #[derive(Debug)]
 pub struct ViaInscriptionManagerLayer {
-    via_btc_client: ViaBtcClientConfig,
     config: ViaBtcSenderConfig,
     wallet: ViaWallet,
-    secrets: ViaL1Secrets,
 }
 
 #[derive(Debug, FromContext)]
 #[context(crate = crate)]
 pub struct Input {
     pub master_pool: PoolResource<MasterPool>,
+    pub btc_client_resource: BtcClientResource,
 }
 
 #[derive(Debug, IntoContext)]
@@ -50,18 +47,8 @@ pub struct Output {
 }
 
 impl ViaInscriptionManagerLayer {
-    pub fn new(
-        via_btc_client: ViaBtcClientConfig,
-        config: ViaBtcSenderConfig,
-        wallet: ViaWallet,
-        secrets: ViaL1Secrets,
-    ) -> Self {
-        Self {
-            via_btc_client,
-            config,
-            wallet,
-            secrets,
-        }
+    pub fn new(config: ViaBtcSenderConfig, wallet: ViaWallet) -> Self {
+        Self { config, wallet }
     }
 }
 
@@ -77,19 +64,11 @@ impl WiringLayer for ViaInscriptionManagerLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         // Get resources.
         let master_pool = input.master_pool.get().await.unwrap();
+        let client = input.btc_client_resource.0;
 
-        let inscriber = Inscriber::new(
-            &self.via_btc_client.rpc_url(
-                self.secrets.rpc_url.expose_str().into(),
-                self.wallet.address.clone(),
-            ),
-            self.via_btc_client.network(),
-            self.secrets.auth_node(),
-            &self.wallet.private_key,
-            None,
-        )
-        .await
-        .with_context(|| "Error init inscriber")?;
+        let inscriber = Inscriber::new(client, &self.wallet.private_key, None)
+            .await
+            .with_context(|| "Error init inscriber")?;
 
         let via_btc_inscription_manager =
             ViaBtcInscriptionManager::new(inscriber, master_pool, self.config)

--- a/core/node/node_framework/src/implementations/layers/via_gas_adjuster.rs
+++ b/core/node/node_framework/src/implementations/layers/via_gas_adjuster.rs
@@ -65,8 +65,8 @@ impl WiringLayer for ViaGasAdjusterLayer {
         let btc_client = Arc::new(
             BitcoinClient::new(
                 self.secrets.rpc_url.expose_str(),
-                self.via_btc_client.network(),
                 self.secrets.auth_node(),
+                self.via_btc_client,
             )
             .unwrap(),
         );

--- a/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
@@ -1,13 +1,9 @@
-use std::sync::Arc;
-
 use anyhow::Context;
-use via_btc_client::client::BitcoinClient;
 use via_verifier_coordinator::verifier::ViaWithdrawalVerifier;
 use via_withdrawal_client::client::WithdrawalClient;
 use zksync_config::{
     configs::{
-        via_btc_client::ViaBtcClientConfig, via_consensus::ViaGenesisConfig,
-        via_secrets::ViaL1Secrets, via_wallets::ViaWallet,
+        via_btc_client::ViaBtcClientConfig, via_consensus::ViaGenesisConfig, via_wallets::ViaWallet,
     },
     ViaVerifierConfig,
 };
@@ -16,6 +12,7 @@ use crate::{
     implementations::resources::{
         da_client::DAClientResource,
         pools::{PoolResource, VerifierPool},
+        via_btc_client::BtcClientResource,
     },
     service::StopReceiver,
     task::{Task, TaskId},
@@ -29,7 +26,6 @@ pub struct ViaWithdrawalVerifierLayer {
     via_genesis_config: ViaGenesisConfig,
     via_btc_client: ViaBtcClientConfig,
     verifier_config: ViaVerifierConfig,
-    secrets: ViaL1Secrets,
     wallet: ViaWallet,
 }
 
@@ -37,7 +33,8 @@ pub struct ViaWithdrawalVerifierLayer {
 #[context(crate = crate)]
 pub struct Input {
     pub master_pool: PoolResource<VerifierPool>,
-    pub client: DAClientResource,
+    pub da_client: DAClientResource,
+    pub btc_client_resource: BtcClientResource,
 }
 
 #[derive(IntoContext)]
@@ -52,14 +49,12 @@ impl ViaWithdrawalVerifierLayer {
         via_genesis_config: ViaGenesisConfig,
         via_btc_client: ViaBtcClientConfig,
         verifier_config: ViaVerifierConfig,
-        secrets: ViaL1Secrets,
         wallet: ViaWallet,
     ) -> Self {
         Self {
             via_genesis_config,
             via_btc_client,
             verifier_config,
-            secrets,
             wallet,
         }
     }
@@ -78,19 +73,9 @@ impl WiringLayer for ViaWithdrawalVerifierLayer {
         let master_pool = input.master_pool.get().await?;
 
         let withdrawal_client =
-            WithdrawalClient::new(input.client.0, self.via_btc_client.network());
+            WithdrawalClient::new(input.da_client.0, self.via_btc_client.network());
 
-        let btc_client = Arc::new(
-            BitcoinClient::new(
-                &self.via_btc_client.rpc_url(
-                    self.secrets.rpc_url.expose_str().to_string(),
-                    self.wallet.address.clone(),
-                ),
-                self.via_btc_client.network(),
-                self.secrets.auth_node(),
-            )
-            .unwrap(),
-        );
+        let btc_client = input.btc_client_resource.0;
 
         let via_withdrawal_verifier_task = ViaWithdrawalVerifier::new(
             self.verifier_config,

--- a/core/node/node_framework/src/implementations/resources/mod.rs
+++ b/core/node/node_framework/src/implementations/resources/mod.rs
@@ -14,6 +14,7 @@ pub mod price_api_client;
 pub mod reverter;
 pub mod state_keeper;
 pub mod sync_state;
+pub mod via_btc_client;
 pub mod via_btc_indexer;
 pub mod via_gas_adjuster;
 pub mod via_state_keeper;

--- a/core/node/node_framework/src/implementations/resources/via_btc_client.rs
+++ b/core/node/node_framework/src/implementations/resources/via_btc_client.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use via_btc_client::client::BitcoinClient;
+
+use crate::Resource;
+
+#[derive(Debug, Clone)]
+pub struct BtcClientResource(pub Arc<BitcoinClient>);
+
+impl Resource for BtcClientResource {
+    fn name() -> String {
+        "btc_client_resource".into()
+    }
+}
+
+impl From<BitcoinClient> for BtcClientResource {
+    fn from(btc_client: BitcoinClient) -> Self {
+        Self(Arc::new(btc_client))
+    }
+}

--- a/core/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/core/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -160,6 +160,9 @@ impl ViaBtcInscriptionManager {
             }
         }
 
+        let balance = self.inscriber.get_balance().await?;
+        METRICS.btc_sender_account_balance.set(balance as usize);
+
         Ok(())
     }
 
@@ -226,9 +229,6 @@ impl ViaBtcInscriptionManager {
         };
 
         latency.observe();
-
-        let balance = self.inscriber.get_balance().await?;
-        METRICS.btc_sender_account_balance.set(balance as usize);
 
         let signed_commit_tx = serialize(&inscribe_info.final_commit_tx.tx)
             .with_context(|| "Error serializing the commit tx")?;

--- a/core/tests/via_loadnext/src/account/btc_deposit.rs
+++ b/core/tests/via_loadnext/src/account/btc_deposit.rs
@@ -16,6 +16,7 @@ use via_btc_client::{
     traits::BitcoinOps,
     types::{BitcoinAddress, NodeAuth},
 };
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
 use zksync_types::Address as EVMAddress;
 
 pub async fn deposit(
@@ -45,10 +46,17 @@ pub async fn deposit(
         .parse::<BitcoinAddress<NetworkUnchecked>>()?
         .assume_checked();
 
+    let config = ViaBtcClientConfig {
+        network: network.to_string(),
+        external_apis: vec![],
+        fee_strategies: vec![],
+        use_rpc_for_fee_rate: None,
+    };
+
     let client = BitcoinClient::new(
         &rpc_url,
-        network,
         NodeAuth::UserPass(rpc_username, rpc_password),
+        config,
     )?;
 
     // Fetch UTXOs available at our address.

--- a/core/tests/via_loadnext/src/account/tx_command_executor.rs
+++ b/core/tests/via_loadnext/src/account/tx_command_executor.rs
@@ -5,6 +5,7 @@ use via_btc_client::{
     traits::BitcoinOps,
     types::{BitcoinError, BitcoinNetwork, NodeAuth},
 };
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
 use zksync_types::{
     api::{BlockNumber, TransactionReceipt},
     l2::L2Tx,
@@ -80,13 +81,20 @@ impl AccountLifespan {
     async fn l1_btc_balances(&self) -> Result<U256, ClientError> {
         let wallet = &self.btc_wallet;
 
+        let config = ViaBtcClientConfig {
+            network: BitcoinNetwork::Regtest.to_string(),
+            external_apis: vec![],
+            fee_strategies: vec![],
+            use_rpc_for_fee_rate: None,
+        };
+
         let btc_client = BitcoinClient::new(
             &self.config.l1_btc_rpc_address,
-            BitcoinNetwork::Regtest,
             NodeAuth::UserPass(
                 self.config.l1_btc_rpc_username.clone(),
                 self.config.l1_btc_rpc_password.clone(),
             ),
+            config,
         )?;
 
         let balance = btc_client.get_balance(&wallet.btc_address).await?;

--- a/core/tests/via_loadnext/src/executor.rs
+++ b/core/tests/via_loadnext/src/executor.rs
@@ -7,6 +7,7 @@ use via_btc_client::{
     traits::BitcoinOps,
     types::{BitcoinNetwork, NodeAuth},
 };
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
 use zksync_types::{api::BlockNumber, L2_BASE_TOKEN_ADDRESS, U256};
 
 use crate::{
@@ -88,13 +89,20 @@ impl Executor {
         tracing::info!("Master Account: Checking BTC balance");
         let master_wallet = &mut self.pool.btc_master_wallet;
 
+        let config = ViaBtcClientConfig {
+            network: BitcoinNetwork::Regtest.to_string(),
+            external_apis: vec![],
+            fee_strategies: vec![],
+            use_rpc_for_fee_rate: None,
+        };
+
         let btc_client = BitcoinClient::new(
             &self.config.l1_btc_rpc_address,
-            BitcoinNetwork::Regtest,
             NodeAuth::UserPass(
                 self.config.l1_btc_rpc_username.clone(),
                 self.config.l1_btc_rpc_password.clone(),
             ),
+            config,
         )?;
 
         let btc_balance = btc_client.get_balance(&master_wallet.btc_address).await?;

--- a/core/tests/via_loadnext/src/sdk/operations/execute_contract.rs
+++ b/core/tests/via_loadnext/src/sdk/operations/execute_contract.rs
@@ -168,11 +168,8 @@ where
             .await
             .map_err(Into::into);
 
-        match &res {
-            Err(err) => {
-                println!("Failed to estimate fee: {err}");
-            }
-            _ => (),
+        if let Err(err) = &res {
+            println!("Failed to estimate fee: {err}");
         }
 
         res

--- a/core/tests/via_loadnext/src/sdk/signer.rs
+++ b/core/tests/via_loadnext/src/sdk/signer.rs
@@ -92,6 +92,7 @@ impl<S: EthereumSigner> Signer<S> {
         Ok(transfer)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn sign_execute_contract(
         &self,
         contract: Address,
@@ -114,6 +115,7 @@ impl<S: EthereumSigner> Signer<S> {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn sign_execute_contract_for_deploy(
         &self,
         contract: Address,

--- a/etc/env/base/via_btc_client.toml
+++ b/etc/env/base/via_btc_client.toml
@@ -6,3 +6,9 @@
 network = "regtest"
 # The Bitcoin RPC URL.
 rpc_url = "http://0.0.0.0:18443"
+# External fee APIs
+external_apis = ["https://mempool.space/testnet/api/v1/fees/recommended"]
+# Fee strategies
+fee_strategies = ["fastestFee"]
+# Use RPC to get the fee rate
+use_rpc_for_fee_rate = true

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -43,6 +43,7 @@ zksync_dal.workspace = true
 dotenv = "0.15"
 via_da_clients.workspace = true
 async-trait.workspace = true
+zksync_config.workspace = true
 mockall = "0.13.0"
 bitcoincore-rpc = "0.19.0"
 

--- a/via_verifier/lib/via_musig2/examples/coordinator.rs
+++ b/via_verifier/lib/via_musig2/examples/coordinator.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 use via_btc_client::{client::BitcoinClient, types::BitcoinNetwork};
 use via_musig2::{transaction_builder::TransactionBuilder, verify_signature, Signer};
 use via_verifier_types::{transaction::UnsignedBridgeTx, withdrawal::WithdrawalRequest};
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -505,7 +506,14 @@ async fn create_test_withdrawal_builder(
     let rpc_url = "http://localhost:18443";
     let network = BitcoinNetwork::Regtest;
     let auth = bitcoincore_rpc::Auth::None;
-    let btc_client = Arc::new(BitcoinClient::new(rpc_url, network, auth).unwrap());
+    let config = ViaBtcClientConfig {
+        network: network.to_string(),
+        external_apis: vec![],
+        fee_strategies: vec![],
+        use_rpc_for_fee_rate: None,
+    };
+
+    let btc_client = Arc::new(BitcoinClient::new(rpc_url, auth, config).unwrap());
 
     let builder = TransactionBuilder::new(btc_client, bridge_address.clone())?;
     Ok(builder)

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -8,6 +8,7 @@ use musig2::{
 use rand::{rngs::OsRng, Rng};
 use secp256k1_musig2::{PublicKey, Secp256k1, SecretKey};
 pub mod transaction_builder;
+pub mod utils;
 pub mod utxo_manager;
 
 #[derive(Debug)]

--- a/via_verifier/lib/via_musig2/src/utils.rs
+++ b/via_verifier/lib/via_musig2/src/utils.rs
@@ -1,0 +1,335 @@
+use std::str::FromStr;
+
+use bitcoin::TapTweakHash;
+use musig2::{verify_partial, AggNonce, KeyAggContext, PartialSignature, PubNonce};
+use secp256k1_musig2::PublicKey;
+
+pub fn verify_partial_signature(
+    nonce: PubNonce,
+    nonces: Vec<PubNonce>,
+    individual_pubkey_str: String,
+    pubkeys_str: Vec<String>,
+    partial_sig: PartialSignature,
+    message: &[u8],
+) -> anyhow::Result<()> {
+    let pubkeys = pubkeys_str
+        .iter()
+        .map(|pubkey_str| musig2::secp256k1::PublicKey::from_str(pubkey_str))
+        .collect::<Result<Vec<PublicKey>, _>>()?;
+
+    let aggregated_nonce = AggNonce::sum(nonces);
+    let mut musig_key_agg_cache = KeyAggContext::new(pubkeys.clone())?;
+
+    let agg_pubkey = musig_key_agg_cache.aggregated_pubkey::<secp256k1_musig2::PublicKey>();
+    let (xonly_agg_key, _) = agg_pubkey.x_only_public_key();
+
+    // Convert to bitcoin XOnlyPublicKey first
+    let internal_key = bitcoin::XOnlyPublicKey::from_slice(&xonly_agg_key.serialize())?;
+
+    // Calculate taproot tweak
+    let tap_tweak = TapTweakHash::from_key_and_tweak(internal_key, None);
+    let tweak = tap_tweak.to_scalar();
+    let tweak_bytes = tweak.to_be_bytes();
+    let tweak = secp256k1_musig2::Scalar::from_be_bytes(tweak_bytes).unwrap();
+
+    // Apply tweak to the key aggregation context before signing
+    musig_key_agg_cache = musig_key_agg_cache.with_xonly_tweak(tweak)?;
+
+    let individual_pubkey = PublicKey::from_str(&individual_pubkey_str)?;
+
+    verify_partial(
+        &musig_key_agg_cache,
+        partial_sig,
+        &aggregated_nonce,
+        individual_pubkey,
+        &nonce,
+        message,
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::{
+        hashes::Hash,
+        hex::DisplayHex,
+        key::Keypair,
+        locktime::absolute,
+        secp256k1::{Secp256k1, SecretKey},
+        sighash::{Prevouts, SighashCache, TapSighashType},
+        transaction, Address, Amount, Network, OutPoint, PrivateKey, ScriptBuf, Sequence,
+        TapTweakHash, Transaction, TxIn, TxOut, Txid, Witness,
+    };
+    use musig2::{secp::Scalar, KeyAggContext, PartialSignature};
+    use rand::Rng;
+    use secp256k1_musig2::schnorr::Signature;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_verify_partial_signature() -> anyhow::Result<()> {
+        let secp = Secp256k1::new();
+
+        // Get a keypair we control. In a real application these would come from a stored secret.
+        let private_key_1 =
+            PrivateKey::from_wif("cVZduZu265sWeAqFYygoDEE1FZ7wV9rpW5qdqjRkUehjaUMWLT1R").unwrap();
+
+        let private_key_2 =
+            PrivateKey::from_wif("cUWA5dZXc6NwLovW3Kr9DykfY5ysFigKZM5Annzty7J8a43Fe2YF").unwrap();
+
+        let private_key_3 =
+            PrivateKey::from_wif("cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm").unwrap();
+
+        let secret_key_1 = SecretKey::from_slice(&private_key_1.inner.secret_bytes()).unwrap();
+        let secret_key_2 = SecretKey::from_slice(&private_key_2.inner.secret_bytes()).unwrap();
+        let secret_key_3 = SecretKey::from_slice(&private_key_3.inner.secret_bytes()).unwrap();
+
+        let keypair_1 = Keypair::from_secret_key(&secp, &secret_key_1);
+        let keypair_2 = Keypair::from_secret_key(&secp, &secret_key_2);
+        let keypair_3 = Keypair::from_secret_key(&secp, &secret_key_3);
+
+        let (internal_key_1, parity_1) = keypair_1.x_only_public_key();
+        let (internal_key_2, parity_2) = keypair_2.x_only_public_key();
+        let (internal_key_3, parity_3) = keypair_3.x_only_public_key();
+
+        // -------------------------------------------
+        // Key aggregation (MuSig2)
+        // -------------------------------------------
+        let pubkeys = vec![
+            musig2::secp256k1::PublicKey::from_slice(
+                &internal_key_1.public_key(parity_1).serialize(),
+            )
+            .unwrap(),
+            musig2::secp256k1::PublicKey::from_slice(
+                &internal_key_2.public_key(parity_2).serialize(),
+            )
+            .unwrap(),
+            musig2::secp256k1::PublicKey::from_slice(
+                &internal_key_3.public_key(parity_3).serialize(),
+            )
+            .unwrap(),
+        ];
+
+        let mut musig_key_agg_cache = KeyAggContext::new(pubkeys.clone())?;
+
+        let agg_pubkey = musig_key_agg_cache.aggregated_pubkey::<secp256k1_musig2::PublicKey>();
+        let (xonly_agg_key, _) = agg_pubkey.x_only_public_key();
+
+        // Convert to bitcoin XOnlyPublicKey first
+        let internal_key = bitcoin::XOnlyPublicKey::from_slice(&xonly_agg_key.serialize())?;
+
+        // Calculate taproot tweak
+        let tap_tweak = TapTweakHash::from_key_and_tweak(internal_key, None);
+        let tweak = tap_tweak.to_scalar();
+        let tweak_bytes = tweak.to_be_bytes();
+        let tweak = secp256k1_musig2::Scalar::from_be_bytes(tweak_bytes).unwrap();
+
+        // Apply tweak to the key aggregation context before signing
+        musig_key_agg_cache = musig_key_agg_cache.with_xonly_tweak(tweak)?;
+
+        // -------------------------------------------
+        // Fetching UTXOs from node
+        // -------------------------------------------
+        let utxos = vec![(
+            OutPoint {
+                txid: Txid::all_zeros(),
+                vout: 0,
+            },
+            TxOut {
+                script_pubkey: ScriptBuf::new(),
+                value: Amount::from_sat(100000000),
+            },
+        )];
+
+        // Get an unspent output that is locked to the key above that we control.
+        // In a real application these would come from the chain.
+        let (dummy_out_point, dummy_utxo) = utxos[0].clone();
+        const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
+
+        let change_amount = dummy_utxo.value - SPEND_AMOUNT - Amount::from_sat(1000);
+
+        // Get an address to send to.
+        let address = receivers_address();
+
+        // The input for the transaction we are constructing.
+        let input = TxIn {
+            previous_output: dummy_out_point, // The dummy output we are spending.
+            script_sig: ScriptBuf::default(), // For a p2tr script_sig is empty.
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::default(), // Filled in after signing.
+        };
+
+        // The spend output is locked to a key controlled by the receiver.
+        let spend = TxOut {
+            value: SPEND_AMOUNT,
+            script_pubkey: address.script_pubkey(),
+        };
+
+        // The change output is locked to a key controlled by us.
+        let change = TxOut {
+            value: change_amount,
+            script_pubkey: ScriptBuf::new_p2tr(&secp, internal_key, None), // Change comes back to us.
+        };
+
+        // The transaction we want to sign and broadcast.
+        let mut unsigned_tx = Transaction {
+            version: transaction::Version::TWO,  // Post BIP-68.
+            lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
+            input: vec![input],                  // Input goes into index 0.
+            output: vec![spend, change],         // Outputs, order does not matter.
+        };
+        let input_index = 0;
+
+        // Get the sighash to sign.
+        let sighash_type = TapSighashType::Default;
+        let prevouts = vec![dummy_utxo];
+        let prevouts = Prevouts::All(&prevouts);
+
+        let mut sighasher = SighashCache::new(&mut unsigned_tx);
+        let sighash = sighasher
+            .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
+            .expect("failed to construct sighash");
+
+        // -------------------------------------------
+        // MuSig2 Signing Process
+        // -------------------------------------------
+        use musig2::{FirstRound, SecNonceSpices};
+        use rand::thread_rng;
+
+        // Convert bitcoin::SecretKey to musig2::SecretKey for each participant
+        let secret_key_1 = musig2::secp256k1::SecretKey::from_slice(&secret_key_1[..]).unwrap();
+        let secret_key_2 = musig2::secp256k1::SecretKey::from_slice(&secret_key_2[..]).unwrap();
+        let secret_key_3 = musig2::secp256k1::SecretKey::from_slice(&secret_key_3[..]).unwrap();
+
+        // First round: Generate nonces
+        let mut first_round_1 = FirstRound::new(
+            musig_key_agg_cache.clone(), // Use tweaked context
+            thread_rng().gen::<[u8; 32]>(),
+            0,
+            SecNonceSpices::new()
+                .with_seckey(secret_key_1)
+                .with_message(&sighash.to_byte_array()),
+        )?;
+
+        let mut first_round_2 = FirstRound::new(
+            musig_key_agg_cache.clone(),
+            thread_rng().gen::<[u8; 32]>(),
+            1,
+            SecNonceSpices::new()
+                .with_seckey(secret_key_2)
+                .with_message(&sighash.to_byte_array()),
+        )?;
+
+        let mut first_round_3 = FirstRound::new(
+            musig_key_agg_cache.clone(),
+            thread_rng().gen::<[u8; 32]>(),
+            2,
+            SecNonceSpices::new()
+                .with_seckey(secret_key_3)
+                .with_message(&sighash.to_byte_array()),
+        )?;
+
+        // Exchange nonces
+        let nonce_1 = first_round_1.our_public_nonce();
+        let nonce_2 = first_round_2.our_public_nonce();
+        let nonce_3 = first_round_3.our_public_nonce();
+
+        first_round_1.receive_nonce(1, nonce_2.clone())?;
+        first_round_1.receive_nonce(2, nonce_3.clone())?;
+        first_round_2.receive_nonce(0, nonce_1.clone())?;
+        first_round_2.receive_nonce(2, nonce_3.clone())?;
+        first_round_3.receive_nonce(0, nonce_1.clone())?;
+        first_round_3.receive_nonce(1, nonce_2.clone())?;
+
+        // Second round: Create partial signatures
+        let binding = sighash.to_byte_array();
+        let mut second_round_1 = first_round_1.finalize(secret_key_1, &binding)?;
+        let second_round_2 = first_round_2.finalize(secret_key_2, &binding)?;
+        let second_round_3 = first_round_3.finalize(secret_key_3, &binding)?;
+        // Combine partial signatures
+        let partial_sig_1: [u8; 32] = second_round_1.our_signature();
+        let partial_sig_2: [u8; 32] = second_round_2.our_signature();
+        let partial_sig_3: [u8; 32] = second_round_3.our_signature();
+
+        let pubkeys_str = vec![
+            internal_key_1
+                .clone()
+                .public_key(parity_1)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            internal_key_2
+                .clone()
+                .public_key(parity_2)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            internal_key_3
+                .clone()
+                .public_key(parity_3)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+        ];
+
+        // Verify partial signatures
+        verify_partial_signature(
+            nonce_2.clone(),
+            vec![nonce_1.clone(), nonce_2.clone(), nonce_3.clone()],
+            internal_key_2
+                .public_key(parity_2)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            pubkeys_str.clone(),
+            PartialSignature::from_slice(&partial_sig_2.to_vec())?,
+            sighash.as_byte_array(),
+        )?;
+
+        verify_partial_signature(
+            nonce_1.clone(),
+            vec![nonce_1.clone(), nonce_2.clone(), nonce_3.clone()],
+            internal_key_1
+                .public_key(parity_1)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            pubkeys_str.clone(),
+            PartialSignature::from_slice(&partial_sig_1.to_vec())?,
+            sighash.as_byte_array(),
+        )?;
+
+        verify_partial_signature(
+            nonce_3.clone(),
+            vec![nonce_1.clone(), nonce_2.clone(), nonce_3.clone()],
+            internal_key_3
+                .public_key(parity_3)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            pubkeys_str.clone(),
+            PartialSignature::from_slice(&partial_sig_3.to_vec())?,
+            sighash.as_byte_array(),
+        )?;
+
+        second_round_1.receive_signature(1, Scalar::from_slice(&partial_sig_2).unwrap())?;
+        second_round_1.receive_signature(2, Scalar::from_slice(&partial_sig_3).unwrap())?;
+
+        let final_signature: Signature = second_round_1.finalize()?;
+
+        // Update the witness stack with the aggregated signature
+        let signature = bitcoin::taproot::Signature {
+            signature: bitcoin::secp256k1::schnorr::Signature::from_slice(
+                &final_signature.to_byte_array(),
+            )?,
+            sighash_type,
+        };
+        *sighasher.witness_mut(input_index).unwrap() = Witness::p2tr_key_spend(&signature);
+
+        Ok(())
+    }
+
+    fn receivers_address() -> Address {
+        Address::from_str("bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va")
+            .expect("a valid address")
+            .require_network(Network::Bitcoin)
+            .expect("valid address for mainnet")
+    }
+}

--- a/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -143,6 +143,9 @@ impl ViaBtcInscriptionManager {
             }
         }
 
+        let balance = self.inscriber.get_balance().await?;
+        METRICS.btc_sender_account_balance.set(balance as usize);
+
         Ok(())
     }
 
@@ -208,9 +211,6 @@ impl ViaBtcInscriptionManager {
             }
         };
         latency.observe();
-
-        let balance = self.inscriber.get_balance().await?;
-        METRICS.btc_sender_account_balance.set(balance as usize);
 
         let signed_commit_tx = serialize(&inscribe_info.final_commit_tx.tx)
             .with_context(|| "Error serializing the commit tx")?;

--- a/via_verifier/node/via_verifier_coordinator/src/metrics.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/metrics.rs
@@ -4,6 +4,18 @@ use vise::{Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Hi
 
 use crate::types::SessionType;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(rename_all = "snake_case")]
+pub enum ErrorKind {
+    PartialSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub struct VerifierErrorLabel {
+    pub pubkey: String,
+    pub kind: ErrorKind,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "error_type", rename_all = "snake_case")]
 pub enum MetricSessionType {
@@ -36,6 +48,9 @@ pub struct ViaVerifierCoordinatorMetrics {
 
     /// The BTC balance of the account used in musig2 sessions.
     pub musig2_session_account_balance: Gauge<usize>,
+
+    /// Errors
+    pub verifier_errors: Family<VerifierErrorLabel, Counter>,
 }
 
 #[vise::register]


### PR DESCRIPTION
## What ❔

- Fetch the fee rate from external APIs when the RPC node failed to returns a valid value. 
- Refactor the inscriber initialization by adding a `btc_client_ressource`

This PR introduce new ENVs
```txt
VIA_BTC_CLIENT_EXTERNAL_APIS="https://mempool.space/testnet/api/v1/fees/recommended"
VIA_BTC_CLIENT_FEE_STRATEGIES="fastestFee"
VIA_BTC_CLIENT_USE_RPC_FOR_FEE_RATE=true
```
## Why ❔

- This PR aims to solve the issue we have on testnet related to not enough data to estimate fee.

## Testing

### Test 1
Run the example fee rate to trigger the fallback
- Run `make base` and `cargo run --example fee_rate true`

### Test 2
- Start the sequencer
- Update the `VIA_BTC_CLIENT_USE_RPC_FOR_FEE_RATE=false`, this will disable fetching the fee rate from the RPC and use only the external API.
- The sequencer should create inscriptions.
- Done :)

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
