### PR TITLE
feat: add verify partial signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9518,6 +9518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "vise",
  "zksync_basic_types",
  "zksync_config",
  "zksync_object_store",

--- a/core/lib/via_btc_client/Cargo.toml
+++ b/core/lib/via_btc_client/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+vise.workspace = true
 zksync_types.workspace = true
 zksync_config.workspace = true
 zksync_basic_types.workspace = true
@@ -82,7 +83,3 @@ path = "examples/deposit_opreturn.rs"
 [[example]]
 name = "upgrade_system_contracts"
 path = "examples/upgrade_system_contracts.rs"
-
-[[example]]
-name = "fee_rate"
-path = "examples/fee_rate.rs"

--- a/core/lib/via_btc_client/src/client/mod.rs
+++ b/core/lib/via_btc_client/src/client/mod.rs
@@ -12,6 +12,7 @@ mod rpc_client;
 
 use crate::{
     client::{fee_limits::FeeRateLimits, rpc_client::BitcoinRpcClient},
+    metrics::{RpcMethodLabel, METRICS},
     traits::{BitcoinOps, BitcoinRpc},
     types::{BitcoinClientResult, BitcoinError, BitcoinNetwork, NodeAuth},
 };
@@ -139,6 +140,10 @@ impl BitcoinOps for BitcoinClient {
                     }
                 }
                 Err(err) => {
+                    METRICS.rpc_errors[&RpcMethodLabel {
+                        method: "rpc_estimate_smart_fee".into(),
+                    }]
+                        .inc();
                     error!("Failed to estimate smart fee via RPC: {:?}", err);
                     None
                 }
@@ -176,6 +181,10 @@ impl BitcoinOps for BitcoinClient {
                         }
                     },
                     Err(e) => {
+                        METRICS.rpc_errors[&RpcMethodLabel {
+                            method: "estimate_smart_fee".into(),
+                        }]
+                            .inc();
                         error!("Failed to fetch from {}: {:?}", api_url, e);
                     }
                 }

--- a/core/lib/via_btc_client/src/inscriber/mod.rs
+++ b/core/lib/via_btc_client/src/inscriber/mod.rs
@@ -167,7 +167,7 @@ impl Inscriber {
         let inscriber_info = self
             .prepare_inscribe(&input, recipient)
             .await
-            .context("Error prepare inscriber infos")?;
+            .with_context(|| "Error prepare inscriber infos")?;
 
         self.broadcast_inscription(
             &inscriber_info.final_commit_tx,
@@ -433,7 +433,7 @@ impl Inscriber {
                     input.utxo_amounts[index],
                     sighash_type,
                 )
-                .context("Failed to create sighash")?;
+                .with_context(|| "Failed to create commit sighash")?;
 
             // Sign the sighash using the signer
             let msg = Message::from(sighash);
@@ -666,7 +666,7 @@ impl Inscriber {
                 input.prev_outs[REVEAL_TX_FEE_INPUT_INDEX as usize].value,
                 sighash_type,
             )
-            .context("Failed to create sighash")?;
+            .with_context(|| "Failed to create reveal sighash payer")?;
 
         // Sign the fee payer sighash using the signer
         let fee_payer_msg = Message::from(fee_payer_input_sighash);
@@ -701,7 +701,7 @@ impl Inscriber {
                 ),
                 sighash_type,
             )
-            .context("Failed to create sighash")?;
+            .with_context(|| "Failed to create reveal sighash")?;
 
         // Sign the tapscript reveal sighash using the signer
         let msg = Message::from_digest(reveal_input_sighash.to_byte_array());

--- a/core/lib/via_btc_client/src/inscriber/script_builder.rs
+++ b/core/lib/via_btc_client/src/inscriber/script_builder.rs
@@ -74,7 +74,7 @@ impl InscriptionData {
         let mut builder = TaprootBuilder::new();
         builder = builder
             .add_leaf(0, inscription_script.clone())
-            .context("adding leaf should work")?;
+            .with_context(|| "Adding leaf should work")?;
 
         let taproot_spend_info = builder
             .finalize(secp, internal_key)

--- a/core/lib/via_btc_client/src/lib.rs
+++ b/core/lib/via_btc_client/src/lib.rs
@@ -4,6 +4,7 @@ pub mod types;
 pub mod client;
 pub mod indexer;
 pub mod inscriber;
+pub mod metrics;
 #[cfg(feature = "regtest")]
 pub mod regtest;
 pub(crate) mod signer;

--- a/core/lib/via_btc_client/src/metrics.rs
+++ b/core/lib/via_btc_client/src/metrics.rs
@@ -1,0 +1,19 @@
+use vise::{Counter, EncodeLabelSet, Family, Metrics};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub struct RpcMethodLabel {
+    pub method: String,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "via_btc_client")]
+pub struct ViaBtcClientMetrics {
+    /// Number of RPC errors encountered, by method and error type
+    pub rpc_errors: Family<RpcMethodLabel, Counter>,
+
+    /// Number of RPC errors encountered, by method and error type
+    pub rpc_max_retries_exceeded: Family<RpcMethodLabel, Counter>,
+}
+
+#[vise::register]
+pub static METRICS: vise::Global<ViaBtcClientMetrics> = vise::Global::new();

--- a/core/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/core/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -160,6 +160,9 @@ impl ViaBtcInscriptionManager {
             }
         }
 
+        let balance = self.inscriber.get_balance().await?;
+        METRICS.btc_sender_account_balance.set(balance as usize);
+
         Ok(())
     }
 
@@ -226,9 +229,6 @@ impl ViaBtcInscriptionManager {
         };
 
         latency.observe();
-
-        let balance = self.inscriber.get_balance().await?;
-        METRICS.btc_sender_account_balance.set(balance as usize);
 
         let signed_commit_tx = serialize(&inscribe_info.final_commit_tx.tx)
             .with_context(|| "Error serializing the commit tx")?;

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -8,6 +8,7 @@ use musig2::{
 use rand::{rngs::OsRng, Rng};
 use secp256k1_musig2::{PublicKey, Secp256k1, SecretKey};
 pub mod transaction_builder;
+pub mod utils;
 pub mod utxo_manager;
 
 #[derive(Debug)]

--- a/via_verifier/lib/via_musig2/src/utils.rs
+++ b/via_verifier/lib/via_musig2/src/utils.rs
@@ -1,0 +1,335 @@
+use std::str::FromStr;
+
+use bitcoin::TapTweakHash;
+use musig2::{verify_partial, AggNonce, KeyAggContext, PartialSignature, PubNonce};
+use secp256k1_musig2::PublicKey;
+
+pub fn verify_partial_signature(
+    nonce: PubNonce,
+    nonces: Vec<PubNonce>,
+    individual_pubkey_str: String,
+    pubkeys_str: Vec<String>,
+    partial_sig: PartialSignature,
+    message: &[u8],
+) -> anyhow::Result<()> {
+    let pubkeys = pubkeys_str
+        .iter()
+        .map(|pubkey_str| musig2::secp256k1::PublicKey::from_str(pubkey_str))
+        .collect::<Result<Vec<PublicKey>, _>>()?;
+
+    let aggregated_nonce = AggNonce::sum(nonces);
+    let mut musig_key_agg_cache = KeyAggContext::new(pubkeys.clone())?;
+
+    let agg_pubkey = musig_key_agg_cache.aggregated_pubkey::<secp256k1_musig2::PublicKey>();
+    let (xonly_agg_key, _) = agg_pubkey.x_only_public_key();
+
+    // Convert to bitcoin XOnlyPublicKey first
+    let internal_key = bitcoin::XOnlyPublicKey::from_slice(&xonly_agg_key.serialize())?;
+
+    // Calculate taproot tweak
+    let tap_tweak = TapTweakHash::from_key_and_tweak(internal_key, None);
+    let tweak = tap_tweak.to_scalar();
+    let tweak_bytes = tweak.to_be_bytes();
+    let tweak = secp256k1_musig2::Scalar::from_be_bytes(tweak_bytes).unwrap();
+
+    // Apply tweak to the key aggregation context before signing
+    musig_key_agg_cache = musig_key_agg_cache.with_xonly_tweak(tweak)?;
+
+    let individual_pubkey = PublicKey::from_str(&individual_pubkey_str)?;
+
+    verify_partial(
+        &musig_key_agg_cache,
+        partial_sig,
+        &aggregated_nonce,
+        individual_pubkey,
+        &nonce,
+        message,
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::{
+        hashes::Hash,
+        hex::DisplayHex,
+        key::Keypair,
+        locktime::absolute,
+        secp256k1::{Secp256k1, SecretKey},
+        sighash::{Prevouts, SighashCache, TapSighashType},
+        transaction, Address, Amount, Network, OutPoint, PrivateKey, ScriptBuf, Sequence,
+        TapTweakHash, Transaction, TxIn, TxOut, Txid, Witness,
+    };
+    use musig2::{secp::Scalar, KeyAggContext, PartialSignature};
+    use rand::Rng;
+    use secp256k1_musig2::schnorr::Signature;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_verify_partial_signature() -> anyhow::Result<()> {
+        let secp = Secp256k1::new();
+
+        // Get a keypair we control. In a real application these would come from a stored secret.
+        let private_key_1 =
+            PrivateKey::from_wif("cVZduZu265sWeAqFYygoDEE1FZ7wV9rpW5qdqjRkUehjaUMWLT1R").unwrap();
+
+        let private_key_2 =
+            PrivateKey::from_wif("cUWA5dZXc6NwLovW3Kr9DykfY5ysFigKZM5Annzty7J8a43Fe2YF").unwrap();
+
+        let private_key_3 =
+            PrivateKey::from_wif("cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm").unwrap();
+
+        let secret_key_1 = SecretKey::from_slice(&private_key_1.inner.secret_bytes()).unwrap();
+        let secret_key_2 = SecretKey::from_slice(&private_key_2.inner.secret_bytes()).unwrap();
+        let secret_key_3 = SecretKey::from_slice(&private_key_3.inner.secret_bytes()).unwrap();
+
+        let keypair_1 = Keypair::from_secret_key(&secp, &secret_key_1);
+        let keypair_2 = Keypair::from_secret_key(&secp, &secret_key_2);
+        let keypair_3 = Keypair::from_secret_key(&secp, &secret_key_3);
+
+        let (internal_key_1, parity_1) = keypair_1.x_only_public_key();
+        let (internal_key_2, parity_2) = keypair_2.x_only_public_key();
+        let (internal_key_3, parity_3) = keypair_3.x_only_public_key();
+
+        // -------------------------------------------
+        // Key aggregation (MuSig2)
+        // -------------------------------------------
+        let pubkeys = vec![
+            musig2::secp256k1::PublicKey::from_slice(
+                &internal_key_1.public_key(parity_1).serialize(),
+            )
+            .unwrap(),
+            musig2::secp256k1::PublicKey::from_slice(
+                &internal_key_2.public_key(parity_2).serialize(),
+            )
+            .unwrap(),
+            musig2::secp256k1::PublicKey::from_slice(
+                &internal_key_3.public_key(parity_3).serialize(),
+            )
+            .unwrap(),
+        ];
+
+        let mut musig_key_agg_cache = KeyAggContext::new(pubkeys.clone())?;
+
+        let agg_pubkey = musig_key_agg_cache.aggregated_pubkey::<secp256k1_musig2::PublicKey>();
+        let (xonly_agg_key, _) = agg_pubkey.x_only_public_key();
+
+        // Convert to bitcoin XOnlyPublicKey first
+        let internal_key = bitcoin::XOnlyPublicKey::from_slice(&xonly_agg_key.serialize())?;
+
+        // Calculate taproot tweak
+        let tap_tweak = TapTweakHash::from_key_and_tweak(internal_key, None);
+        let tweak = tap_tweak.to_scalar();
+        let tweak_bytes = tweak.to_be_bytes();
+        let tweak = secp256k1_musig2::Scalar::from_be_bytes(tweak_bytes).unwrap();
+
+        // Apply tweak to the key aggregation context before signing
+        musig_key_agg_cache = musig_key_agg_cache.with_xonly_tweak(tweak)?;
+
+        // -------------------------------------------
+        // Fetching UTXOs from node
+        // -------------------------------------------
+        let utxos = vec![(
+            OutPoint {
+                txid: Txid::all_zeros(),
+                vout: 0,
+            },
+            TxOut {
+                script_pubkey: ScriptBuf::new(),
+                value: Amount::from_sat(100000000),
+            },
+        )];
+
+        // Get an unspent output that is locked to the key above that we control.
+        // In a real application these would come from the chain.
+        let (dummy_out_point, dummy_utxo) = utxos[0].clone();
+        const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
+
+        let change_amount = dummy_utxo.value - SPEND_AMOUNT - Amount::from_sat(1000);
+
+        // Get an address to send to.
+        let address = receivers_address();
+
+        // The input for the transaction we are constructing.
+        let input = TxIn {
+            previous_output: dummy_out_point, // The dummy output we are spending.
+            script_sig: ScriptBuf::default(), // For a p2tr script_sig is empty.
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::default(), // Filled in after signing.
+        };
+
+        // The spend output is locked to a key controlled by the receiver.
+        let spend = TxOut {
+            value: SPEND_AMOUNT,
+            script_pubkey: address.script_pubkey(),
+        };
+
+        // The change output is locked to a key controlled by us.
+        let change = TxOut {
+            value: change_amount,
+            script_pubkey: ScriptBuf::new_p2tr(&secp, internal_key, None), // Change comes back to us.
+        };
+
+        // The transaction we want to sign and broadcast.
+        let mut unsigned_tx = Transaction {
+            version: transaction::Version::TWO,  // Post BIP-68.
+            lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
+            input: vec![input],                  // Input goes into index 0.
+            output: vec![spend, change],         // Outputs, order does not matter.
+        };
+        let input_index = 0;
+
+        // Get the sighash to sign.
+        let sighash_type = TapSighashType::Default;
+        let prevouts = vec![dummy_utxo];
+        let prevouts = Prevouts::All(&prevouts);
+
+        let mut sighasher = SighashCache::new(&mut unsigned_tx);
+        let sighash = sighasher
+            .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
+            .expect("failed to construct sighash");
+
+        // -------------------------------------------
+        // MuSig2 Signing Process
+        // -------------------------------------------
+        use musig2::{FirstRound, SecNonceSpices};
+        use rand::thread_rng;
+
+        // Convert bitcoin::SecretKey to musig2::SecretKey for each participant
+        let secret_key_1 = musig2::secp256k1::SecretKey::from_slice(&secret_key_1[..]).unwrap();
+        let secret_key_2 = musig2::secp256k1::SecretKey::from_slice(&secret_key_2[..]).unwrap();
+        let secret_key_3 = musig2::secp256k1::SecretKey::from_slice(&secret_key_3[..]).unwrap();
+
+        // First round: Generate nonces
+        let mut first_round_1 = FirstRound::new(
+            musig_key_agg_cache.clone(), // Use tweaked context
+            thread_rng().gen::<[u8; 32]>(),
+            0,
+            SecNonceSpices::new()
+                .with_seckey(secret_key_1)
+                .with_message(&sighash.to_byte_array()),
+        )?;
+
+        let mut first_round_2 = FirstRound::new(
+            musig_key_agg_cache.clone(),
+            thread_rng().gen::<[u8; 32]>(),
+            1,
+            SecNonceSpices::new()
+                .with_seckey(secret_key_2)
+                .with_message(&sighash.to_byte_array()),
+        )?;
+
+        let mut first_round_3 = FirstRound::new(
+            musig_key_agg_cache.clone(),
+            thread_rng().gen::<[u8; 32]>(),
+            2,
+            SecNonceSpices::new()
+                .with_seckey(secret_key_3)
+                .with_message(&sighash.to_byte_array()),
+        )?;
+
+        // Exchange nonces
+        let nonce_1 = first_round_1.our_public_nonce();
+        let nonce_2 = first_round_2.our_public_nonce();
+        let nonce_3 = first_round_3.our_public_nonce();
+
+        first_round_1.receive_nonce(1, nonce_2.clone())?;
+        first_round_1.receive_nonce(2, nonce_3.clone())?;
+        first_round_2.receive_nonce(0, nonce_1.clone())?;
+        first_round_2.receive_nonce(2, nonce_3.clone())?;
+        first_round_3.receive_nonce(0, nonce_1.clone())?;
+        first_round_3.receive_nonce(1, nonce_2.clone())?;
+
+        // Second round: Create partial signatures
+        let binding = sighash.to_byte_array();
+        let mut second_round_1 = first_round_1.finalize(secret_key_1, &binding)?;
+        let second_round_2 = first_round_2.finalize(secret_key_2, &binding)?;
+        let second_round_3 = first_round_3.finalize(secret_key_3, &binding)?;
+        // Combine partial signatures
+        let partial_sig_1: [u8; 32] = second_round_1.our_signature();
+        let partial_sig_2: [u8; 32] = second_round_2.our_signature();
+        let partial_sig_3: [u8; 32] = second_round_3.our_signature();
+
+        let pubkeys_str = vec![
+            internal_key_1
+                .clone()
+                .public_key(parity_1)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            internal_key_2
+                .clone()
+                .public_key(parity_2)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            internal_key_3
+                .clone()
+                .public_key(parity_3)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+        ];
+
+        // Verify partial signatures
+        verify_partial_signature(
+            nonce_2.clone(),
+            vec![nonce_1.clone(), nonce_2.clone(), nonce_3.clone()],
+            internal_key_2
+                .public_key(parity_2)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            pubkeys_str.clone(),
+            PartialSignature::from_slice(&partial_sig_2.to_vec())?,
+            sighash.as_byte_array(),
+        )?;
+
+        verify_partial_signature(
+            nonce_1.clone(),
+            vec![nonce_1.clone(), nonce_2.clone(), nonce_3.clone()],
+            internal_key_1
+                .public_key(parity_1)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            pubkeys_str.clone(),
+            PartialSignature::from_slice(&partial_sig_1.to_vec())?,
+            sighash.as_byte_array(),
+        )?;
+
+        verify_partial_signature(
+            nonce_3.clone(),
+            vec![nonce_1.clone(), nonce_2.clone(), nonce_3.clone()],
+            internal_key_3
+                .public_key(parity_3)
+                .serialize()
+                .to_hex_string(bitcoin::hex::Case::Lower),
+            pubkeys_str.clone(),
+            PartialSignature::from_slice(&partial_sig_3.to_vec())?,
+            sighash.as_byte_array(),
+        )?;
+
+        second_round_1.receive_signature(1, Scalar::from_slice(&partial_sig_2).unwrap())?;
+        second_round_1.receive_signature(2, Scalar::from_slice(&partial_sig_3).unwrap())?;
+
+        let final_signature: Signature = second_round_1.finalize()?;
+
+        // Update the witness stack with the aggregated signature
+        let signature = bitcoin::taproot::Signature {
+            signature: bitcoin::secp256k1::schnorr::Signature::from_slice(
+                &final_signature.to_byte_array(),
+            )?,
+            sighash_type,
+        };
+        *sighasher.witness_mut(input_index).unwrap() = Witness::p2tr_key_spend(&signature);
+
+        Ok(())
+    }
+
+    fn receivers_address() -> Address {
+        Address::from_str("bc1p0dq0tzg2r780hldthn5mrznmpxsxc0jux5f20fwj0z3wqxxk6fpqm7q0va")
+            .expect("a valid address")
+            .require_network(Network::Bitcoin)
+            .expect("valid address for mainnet")
+    }
+}

--- a/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -143,6 +143,9 @@ impl ViaBtcInscriptionManager {
             }
         }
 
+        let balance = self.inscriber.get_balance().await?;
+        METRICS.btc_sender_account_balance.set(balance as usize);
+
         Ok(())
     }
 
@@ -208,9 +211,6 @@ impl ViaBtcInscriptionManager {
             }
         };
         latency.observe();
-
-        let balance = self.inscriber.get_balance().await?;
-        METRICS.btc_sender_account_balance.set(balance as usize);
 
         let signed_commit_tx = serialize(&inscribe_info.final_commit_tx.tx)
             .with_context(|| "Error serializing the commit tx")?;

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api_impl.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api_impl.rs
@@ -6,6 +6,7 @@ use musig2::{BinaryEncoding, PubNonce};
 use serde::Serialize;
 use tracing::instrument;
 use via_btc_client::traits::Serializable;
+use via_musig2::utils::verify_partial_signature;
 use zksync_utils::time::seconds_since_epoch;
 
 use super::{api_decl::RestApi, error::ApiError};
@@ -116,10 +117,55 @@ impl RestApi {
             Ok(sig) => sig,
             Err(_) => {
                 return Err(ApiError::BadRequest(
-                    "Invalid partial signature submitted".to_string(),
+                    "Error when decode the partial signature".to_string(),
                 ))
             }
         };
+
+        // Verify if the partial sig is valid.
+        let session = self_.state.signing_session.read().await.clone();
+        if let Some(session_op) = session.session_op {
+            let pubkeys_str = self_
+                .state
+                .verifiers_pub_keys
+                .iter()
+                .map(|pubkey| pubkey.to_string())
+                .collect::<Vec<String>>();
+
+            let individual_pubkey_str = pubkeys_str[sig_pair.signer_index].clone();
+            if let Some(nonce) = session.received_nonces.get(&sig_pair.signer_index) {
+                let nonces = session
+                    .received_nonces
+                    .values()
+                    .cloned()
+                    .collect::<Vec<PubNonce>>();
+
+                match verify_partial_signature(
+                    nonce.clone(),
+                    nonces,
+                    individual_pubkey_str.clone(),
+                    pubkeys_str,
+                    partial_sig,
+                    &session_op.get_message_to_sign(),
+                ) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        // Reset the session if a partial signature is not valid.
+                        // This will force the verifier to submit a new valid signature.
+                        self_.reset_session().await;
+                        tracing::info!("Reset session due to: {}", e);
+                        return Err(ApiError::BadRequest(
+                            format!("Invalid partial signature for verifier pubkey: {individual_pubkey_str}"),
+                        ));
+                    }
+                }
+            } else {
+                return Err(ApiError::BadRequest(
+                    "Session nonce not found for  verifier pubkey: {individual_pubkey_str}"
+                        .to_string(),
+                ));
+            }
+        }
 
         {
             let mut session = self_.state.signing_session.write().await;

--- a/via_verifier/node/via_verifier_coordinator/src/metrics.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/metrics.rs
@@ -4,6 +4,18 @@ use vise::{Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Hi
 
 use crate::types::SessionType;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(rename_all = "snake_case")]
+pub enum ErrorKind {
+    PartialSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub struct VerifierErrorLabel {
+    pub pubkey: String,
+    pub kind: ErrorKind,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "error_type", rename_all = "snake_case")]
 pub enum MetricSessionType {
@@ -36,6 +48,9 @@ pub struct ViaVerifierCoordinatorMetrics {
 
     /// The BTC balance of the account used in musig2 sessions.
     pub musig2_session_account_balance: Gauge<usize>,
+
+    /// Errors
+    pub verifier_errors: Family<VerifierErrorLabel, Counter>,
 }
 
 #[vise::register]


### PR DESCRIPTION
## What ❔

- Verify the partial signature if valid.
- Added unit test to verify the partial signature.
- Integrate the logic into the withdrawal session.

![Screenshot from 2025-05-18 13-35-40](https://github.com/user-attachments/assets/b0595bb0-b4fb-4992-8675-cb8993a2cdab)

## Why ❔
When a new session is initialized, some verifiers may still use stale session data. This can result in invalid partial signatures being submitted to the coordinator. If such signatures are accepted, they can corrupt the session state and require a manual restart of the coordinator to clean up memory.

This PR addresses the issue by introducing validation of partial signatures. If a submitted signature is found to be invalid, the session is reset. This mechanism ensures that verifiers are forced to clear their local state and fetch the latest valid session data from the coordinator.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
