### PR TITLE
fix: fix the btc client resource to support multiple wallets

### DIFF
--- a/core/bin/via_server/src/node_builder.rs
+++ b/core/bin/via_server/src/node_builder.rs
@@ -178,8 +178,12 @@ impl ViaNodeBuilder {
         let via_btc_client_config = try_load_config!(self.configs.via_btc_client_config);
         let secrets = self.secrets.via_l1.clone().unwrap();
 
-        self.node
-            .add_layer(BtcClientLayer::new(via_btc_client_config, secrets));
+        self.node.add_layer(BtcClientLayer::new(
+            via_btc_client_config,
+            secrets,
+            self.wallets.clone(),
+            None,
+        ));
         Ok(self)
     }
 

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/aggregator.rs
@@ -64,7 +64,7 @@ impl WiringLayer for ViaBtcInscriptionAggregatorLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         // Get resources.
         let master_pool = input.master_pool.get().await.unwrap();
-        let client = input.btc_client_resource.0;
+        let client = input.btc_client_resource.btc_sender.unwrap();
 
         let inscriber = Inscriber::new(client, &self.wallet.private_key, None)
             .await

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/manager.rs
@@ -64,7 +64,7 @@ impl WiringLayer for ViaInscriptionManagerLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         // Get resources.
         let master_pool = input.master_pool.get().await.unwrap();
-        let client = input.btc_client_resource.0;
+        let client = input.btc_client_resource.btc_sender.unwrap();
 
         let inscriber = Inscriber::new(client, &self.wallet.private_key, None)
             .await

--- a/core/node/node_framework/src/implementations/layers/via_btc_sender/vote_manager.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_sender/vote_manager.rs
@@ -64,7 +64,7 @@ impl WiringLayer for ViaInscriptionManagerLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         // Get resources.
         let master_pool = input.master_pool.get().await.unwrap();
-        let client = input.btc_client_resource.0;
+        let client = input.btc_client_resource.btc_sender.unwrap();
 
         let inscriber = Inscriber::new(client, &self.wallet.private_key, None)
             .await

--- a/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
@@ -67,7 +67,7 @@ impl WiringLayer for BtcWatchLayer {
 
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         let main_pool = input.master_pool.get().await?;
-        let client = input.btc_client_resource.0;
+        let client = input.btc_client_resource.btc_sender.unwrap();
         let indexer = BitcoinInscriptionIndexer::new(
             client,
             self.via_btc_client.clone(),

--- a/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/coordinator_api.rs
@@ -68,7 +68,7 @@ impl WiringLayer for ViaCoordinatorApiLayer {
 
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         let master_pool = input.master_pool.get().await?;
-        let btc_client = input.btc_client_resource.0;
+        let btc_client = input.btc_client_resource.bridge.unwrap();
 
         let withdrawal_client =
             WithdrawalClient::new(input.da_client.0, self.via_btc_client.network());

--- a/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
@@ -75,7 +75,7 @@ impl WiringLayer for ViaWithdrawalVerifierLayer {
         let withdrawal_client =
             WithdrawalClient::new(input.da_client.0, self.via_btc_client.network());
 
-        let btc_client = input.btc_client_resource.0;
+        let btc_client = input.btc_client_resource.verifier.unwrap();
 
         let via_withdrawal_verifier_task = ViaWithdrawalVerifier::new(
             self.verifier_config,

--- a/core/node/node_framework/src/implementations/layers/via_verifier_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier_btc_watch.rs
@@ -68,7 +68,7 @@ impl WiringLayer for VerifierBtcWatchLayer {
 
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         let main_pool = input.master_pool.get().await?;
-        let client = input.btc_client_resource.0;
+        let client = input.btc_client_resource.btc_sender.unwrap();
         let indexer = BitcoinInscriptionIndexer::new(
             client,
             self.via_btc_client.clone(),

--- a/core/node/node_framework/src/implementations/resources/via_btc_client.rs
+++ b/core/node/node_framework/src/implementations/resources/via_btc_client.rs
@@ -5,16 +5,48 @@ use via_btc_client::client::BitcoinClient;
 use crate::Resource;
 
 #[derive(Debug, Clone)]
-pub struct BtcClientResource(pub Arc<BitcoinClient>);
+pub struct BtcClientResource {
+    pub btc_sender: Option<Arc<BitcoinClient>>,
+    pub verifier: Option<Arc<BitcoinClient>>,
+    pub bridge: Option<Arc<BitcoinClient>>,
+}
+
+impl BtcClientResource {
+    pub fn new() -> Self {
+        Self {
+            btc_sender: None,
+            verifier: None,
+            bridge: None,
+        }
+    }
+
+    pub fn with_btc_sender(self, btc_client: Arc<BitcoinClient>) -> Self {
+        Self {
+            btc_sender: Some(btc_client),
+            verifier: self.verifier.clone(),
+            bridge: self.bridge.clone(),
+        }
+    }
+
+    pub fn with_verifier(self, btc_client: Arc<BitcoinClient>) -> Self {
+        Self {
+            btc_sender: self.btc_sender.clone(),
+            verifier: Some(btc_client),
+            bridge: self.bridge.clone(),
+        }
+    }
+
+    pub fn with_bridge(self, btc_client: Arc<BitcoinClient>) -> Self {
+        Self {
+            btc_sender: self.btc_sender.clone(),
+            verifier: self.verifier.clone(),
+            bridge: Some(btc_client),
+        }
+    }
+}
 
 impl Resource for BtcClientResource {
     fn name() -> String {
         "btc_client_resource".into()
-    }
-}
-
-impl From<BitcoinClient> for BtcClientResource {
-    fn from(btc_client: BitcoinClient) -> Self {
-        Self(Arc::new(btc_client))
     }
 }

--- a/via_verifier/bin/verifier_server/src/node_builder.rs
+++ b/via_verifier/bin/verifier_server/src/node_builder.rs
@@ -75,9 +75,14 @@ impl ViaNodeBuilder {
     fn add_btc_client_layer(mut self) -> anyhow::Result<Self> {
         let via_btc_client_config = try_load_config!(self.configs.via_btc_client_config);
         let secrets = self.secrets.via_l1.clone().unwrap();
+        let via_genesis_config = try_load_config!(self.configs.via_genesis_config);
 
-        self.node
-            .add_layer(BtcClientLayer::new(via_btc_client_config, secrets));
+        self.node.add_layer(BtcClientLayer::new(
+            via_btc_client_config,
+            secrets,
+            self.wallets.clone(),
+            Some(via_genesis_config.bridge_address),
+        ));
         Ok(self)
     }
 


### PR DESCRIPTION
## What ❔

- Fix the btc client resource to init a client per wallet. 

## Why ❔

 This PR fix a bug introduced in a previous PR where we need to set the wallet address in URL to be able to fetch utxos per wallet or balance on testnet.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Code has been formatted via `zk fmt` and `zk lint`.
