### PR TITLE
chore: bump um celestia and improve docker local setup

### DIFF
--- a/docker-compose-via-btc-explorer.yml
+++ b/docker-compose-via-btc-explorer.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   web:
     container_name: btc-explorer-frontend

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   bitcoind:
     image: 'lightninglabs/bitcoin-core:27'
@@ -135,14 +133,13 @@ services:
 
   celestia-node:
     user: 1000:1000
-    image: "ghcr.io/celestiaorg/celestia-node:v0.20.4-mocha"
-    container_name: celestia-node
+    image: "ghcr.io/celestiaorg/celestia-node:v0.23.0-mocha"
     volumes:
       - type: bind
         source: ./volumes/celestia
         target: /home/celestia
       - ./celestia-keys/keys:/home/celestia/keys
-    command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip full.consensus.mocha-4.celestia-mocha.com --p2p.network mocha --keyring.backend test --keyring.keyname via
+    command: celestia light start --headers.trusted-hash ${VIA_CELESTIA_CLIENT_TRUSTED_BLOCK_HASH} --core.ip rpc-mocha.pops.one --p2p.network mocha --keyring.backend test --keyring.keyname via
     ports:
       - '26658:26658'
     environment:

--- a/infrastructure/via/src/transactions.ts
+++ b/infrastructure/via/src/transactions.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
 import * as utils from 'utils';
+import { VIA_DOCKER_COMPOSE } from './docker';
 
-const CONTAINER_NAME = 'via-core-bitcoin-cli-1';
+const CONTAINER_NAME = 'bitcoin-cli';
 const RPC_USER = 'rpcuser';
 const RPC_PASSWORD = 'rpcpassword';
 const WALLET = 'Alice';
@@ -57,7 +58,7 @@ export const generateRandomTransactions = async () => {
                     let unfundedTx = '';
                     await runRpcCall(async () => {
                         const unfundedTxResult = await utils.exec(
-                            `docker exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} createrawtransaction "[]" "{\\"${DESTINATION_ADDRESS}\\":0.005}"`
+                            `docker compose -f ${VIA_DOCKER_COMPOSE} exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} createrawtransaction "[]" "{\\"${DESTINATION_ADDRESS}\\":0.005}"`
                         );
                         unfundedTx = unfundedTxResult.stdout.trim();
                     });
@@ -69,19 +70,19 @@ export const generateRandomTransactions = async () => {
                     fundTxLock = fundTxLock.then(async () => {
                         await runRpcCall(async () => {
                             const fundTxResult = await utils.exec(
-                                `docker exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} -named fundrawtransaction hexstring="${unfundedTx}" options='${options}'`
+                                `docker compose -f ${VIA_DOCKER_COMPOSE} exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} -named fundrawtransaction hexstring="${unfundedTx}" options='${options}'`
                             );
                             const fundTxJson = JSON.parse(fundTxResult.stdout.trim());
                             const fundedTxHex = fundTxJson.hex;
 
                             const signTxResult = await utils.exec(
-                                `docker exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} signrawtransactionwithwallet "${fundedTxHex}"`
+                                `docker compose -f ${VIA_DOCKER_COMPOSE} exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} signrawtransactionwithwallet "${fundedTxHex}"`
                             );
                             const signTxJson = JSON.parse(signTxResult.stdout.trim());
                             const signedTxHex = signTxJson.hex;
 
                             await utils.exec(
-                                `docker exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} sendrawtransaction "${signedTxHex}"`
+                                `docker compose -f ${VIA_DOCKER_COMPOSE} exec ${CONTAINER_NAME} bitcoin-cli ${RPC_ARGS} sendrawtransaction "${signedTxHex}"`
                             );
                         });
                     });


### PR DESCRIPTION
## What ❔

- Bumps the Celestia light node version to `v0.23.0`.
- Removes the fixed prefix (`via-core`) in container names used to reference containers for command execution. Instead, a more flexible approach using the `docker compose exec` command is implemented.

## Why ❔

- The newest stable version of Celestia has effectively deprecated older versions.
- The hardcoded prefixes in container names restricted the setup script to only work within a `via-core` folder (typically created by the `git clone` command). When specifying a different folder name (e.g., `git clone <url> via-local`), the setup script would fail as it couldn't locate containers with the expected names.
