### PR TITLE
Fix/via btc sender batch criterion

### DIFF
--- a/core/lib/config/src/configs/via_btc_sender.rs
+++ b/core/lib/config/src/configs/via_btc_sender.rs
@@ -26,6 +26,15 @@ pub struct ViaBtcSenderConfig {
 
     /// The btc sender wallet address.
     pub wallet_address: String,
+
+    /// The number of blocks to wait before considering an inscription stuck.
+    pub stuck_inscription_block_number: Option<u32>,
+
+    /// The required time (seconds) to wait before create a commit inscription.
+    pub block_time_to_commit: Option<u32>,
+
+    /// The required time (seconds) to wait before create a proof inscription.
+    pub block_time_to_proof: Option<u32>,
 }
 
 impl ViaBtcSenderConfig {
@@ -38,6 +47,18 @@ impl ViaBtcSenderConfig {
             .as_ref()
             .unwrap_or(&String::from(DEFAULT_DA_LAYER))
             .clone()
+    }
+
+    pub fn block_time_to_commit(&self) -> u32 {
+        self.block_time_to_commit.unwrap_or_default()
+    }
+
+    pub fn block_time_to_proof(&self) -> u32 {
+        self.block_time_to_proof.unwrap_or_default()
+    }
+
+    pub fn stuck_inscription_block_number(&self) -> u32 {
+        self.stuck_inscription_block_number.unwrap_or(6)
     }
 }
 
@@ -52,6 +73,9 @@ impl ViaBtcSenderConfig {
             block_confirmations: 0,
             da_identifier: None,
             wallet_address: "".into(),
+            block_time_to_commit: None,
+            block_time_to_proof: None,
+            stuck_inscription_block_number: None,
         }
     }
 }

--- a/core/node/via_btc_sender/src/aggregator.rs
+++ b/core/node/via_btc_sender/src/aggregator.rs
@@ -31,7 +31,7 @@ impl ViaAggregator {
                     limit: config.max_aggregated_blocks_to_commit as u32,
                 }),
                 Box::from(TimestampDeadlineCriterion {
-                    deadline_seconds: BLOCK_TIME_TO_COMMIT,
+                    deadline_seconds: config.block_time_to_commit(),
                 }),
             ],
             commit_proof_criteria: vec![
@@ -39,7 +39,7 @@ impl ViaAggregator {
                     limit: config.max_aggregated_proofs_to_commit as u32,
                 }),
                 Box::from(TimestampDeadlineCriterion {
-                    deadline_seconds: BLOCK_TIME_TO_PROOF,
+                    deadline_seconds: config.block_time_to_proof(),
                 }),
             ],
             config,

--- a/core/node/via_btc_sender/src/aggregator.rs
+++ b/core/node/via_btc_sender/src/aggregator.rs
@@ -10,7 +10,6 @@ use zksync_types::{
 
 use crate::{
     aggregated_operations::ViaAggregatedOperation,
-    config::{BLOCK_TIME_TO_COMMIT, BLOCK_TIME_TO_PROOF},
     publish_criterion::{
         TimestampDeadlineCriterion, ViaBtcL1BatchCommitCriterion, ViaNumberCriterion,
     },
@@ -260,18 +259,24 @@ async fn extract_ready_subrange(
         let l1_batch_by_criterion = criterion
             .last_l1_batch_to_publish(&uncommited_l1_batches)
             .await;
+        if l1_batch_by_criterion.is_none() {
+            return None;
+        }
+
         if let Some(l1_batch) = l1_batch_by_criterion {
             last_l1_batch = Some(last_l1_batch.map_or(l1_batch, |number| number.min(l1_batch)));
         }
     }
 
-    let last_l1_batch = last_l1_batch?;
-    Some(
-        uncommited_l1_batches
-            .into_iter()
-            .take_while(|l1_batch| l1_batch.number <= last_l1_batch)
-            .collect(),
-    )
+    if let Some(last_l1_batch_number) = last_l1_batch {
+        return Some(
+            uncommited_l1_batches
+                .into_iter()
+                .take_while(|l1_batch| l1_batch.number <= last_l1_batch_number)
+                .collect(),
+        );
+    }
+    None
 }
 
 fn validate_l1_batch_sequence(

--- a/core/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/core/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -11,7 +11,7 @@ use zksync_types::{
     via_btc_sender::ViaBtcInscriptionRequest,
 };
 
-use crate::{config::INSCRIPTION_EXECUTION_BLOCK_DELAY, metrics::METRICS};
+use crate::metrics::METRICS;
 
 #[derive(Debug)]
 pub struct ViaBtcInscriptionManager {
@@ -130,7 +130,7 @@ impl ViaBtcInscriptionManager {
                         .await?;
 
                     if last_inscription_history.sent_at_block
-                        + INSCRIPTION_EXECUTION_BLOCK_DELAY as i64
+                        + self.config.stuck_inscription_block_number() as i64
                         > current_block as i64
                     {
                         continue;
@@ -140,7 +140,7 @@ impl ViaBtcInscriptionManager {
                         let l1_batch_number = storage
                             .via_blocks_dal()
                             .get_first_stuck_l1_batch_number_inscription_request(
-                                INSCRIPTION_EXECUTION_BLOCK_DELAY,
+                                self.config.stuck_inscription_block_number(),
                                 current_block,
                             )
                             .await?;
@@ -152,9 +152,10 @@ impl ViaBtcInscriptionManager {
                         report_blocked_l1_batch_inscription = Some(l1_batch_number);
 
                         tracing::warn!(
-                        "Inscription {reveal_tx} stuck for more than {INSCRIPTION_EXECUTION_BLOCK_DELAY} block.",
-                        reveal_tx = last_inscription_history.reveal_tx_id
-                    );
+                            "Inscription {} stuck for more than {} block.",
+                            last_inscription_history.reveal_tx_id,
+                            self.config.stuck_inscription_block_number()
+                        );
                     }
                 }
             }

--- a/core/node/via_btc_sender/src/config.rs
+++ b/core/node/via_btc_sender/src/config.rs
@@ -1,8 +1,0 @@
-// Number of blocks to wait before increasing the inscription fee.
-pub const INSCRIPTION_EXECUTION_BLOCK_DELAY: u32 = 6;
-
-// The delay time (seconds) required to include in a commit inscription.
-pub const BLOCK_TIME_TO_COMMIT: u32 = 3600;
-
-// The delay time (seconds) required to include in a proof inscription.
-pub const BLOCK_TIME_TO_PROOF: u32 = 7200;

--- a/core/node/via_btc_sender/src/lib.rs
+++ b/core/node/via_btc_sender/src/lib.rs
@@ -2,7 +2,6 @@ mod aggregated_operations;
 pub mod aggregator;
 pub mod btc_inscription_aggregator;
 pub mod btc_inscription_manager;
-mod config;
 mod metrics;
 mod publish_criterion;
 #[cfg(test)]

--- a/etc/env/base/via_btc_sender.toml
+++ b/etc/env/base/via_btc_sender.toml
@@ -11,3 +11,9 @@ max_txs_in_flight = 1
 da_identifier = "celestia"
 # The number of L1 block to mark the inscription as finalized. 
 block_confirmations = 0
+# The number of blocks to wait before considering an inscription stuck.
+stuck_inscription_block_number = 6
+# The required time (seconds) to wait before create a commit inscription.
+block_time_to_commit = 0
+# The required time (seconds) to wait before create a proof inscription.
+block_time_to_proof = 0

--- a/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
+++ b/via_verifier/node/via_btc_sender/src/btc_inscription_manager.rs
@@ -6,7 +6,7 @@ use via_verifier_dal::{Connection, ConnectionPool, Verifier, VerifierDal};
 use zksync_config::ViaBtcSenderConfig;
 use zksync_types::via_btc_sender::ViaBtcInscriptionRequest;
 
-use crate::{config::INSCRIPTION_EXECUTION_BLOCK_DELAY, metrics::METRICS};
+use crate::metrics::METRICS;
 
 #[derive(Debug)]
 pub struct ViaBtcInscriptionManager {
@@ -114,7 +114,7 @@ impl ViaBtcInscriptionManager {
                         .await?;
 
                     if last_inscription_history.sent_at_block
-                        + INSCRIPTION_EXECUTION_BLOCK_DELAY as i64
+                        + self.config.stuck_inscription_block_number() as i64
                         > current_block as i64
                     {
                         continue;
@@ -124,7 +124,7 @@ impl ViaBtcInscriptionManager {
                         let l1_batch_number = storage
                             .via_block_dal()
                             .get_first_stuck_l1_batch_number_inscription_request(
-                                INSCRIPTION_EXECUTION_BLOCK_DELAY,
+                                self.config.stuck_inscription_block_number(),
                                 current_block,
                             )
                             .await?;
@@ -135,8 +135,9 @@ impl ViaBtcInscriptionManager {
 
                         report_blocked_l1_batch_inscription = Some(l1_batch_number);
                         tracing::warn!(
-                            "Inscription {reveal_tx} stuck for more than {INSCRIPTION_EXECUTION_BLOCK_DELAY} block.",
-                            reveal_tx = last_inscription_history.reveal_tx_id
+                            "Inscription {} stuck for more than {} block.",
+                            last_inscription_history.reveal_tx_id,
+                            self.config.stuck_inscription_block_number()
                         );
                     }
                 }

--- a/via_verifier/node/via_btc_sender/src/config.rs
+++ b/via_verifier/node/via_btc_sender/src/config.rs
@@ -1,2 +1,0 @@
-// Number of blocks to wait before increasing the inscription fee.
-pub const INSCRIPTION_EXECUTION_BLOCK_DELAY: u32 = 6;

--- a/via_verifier/node/via_btc_sender/src/lib.rs
+++ b/via_verifier/node/via_btc_sender/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod btc_inscription_manager;
 pub mod btc_vote_inscription;
-mod config;
 mod metrics;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## What ❔
This PR allows to fix the logic related to add a delay before create a proof inscription.

- Refactor the btc_sender constant config by moving them to the ENV config.
- Fix the logic to select ready batches for inscription to avoid escape a batch commit criterion (If the None it escaped but should return). 

## Why ❔

This PR resolves an issue in the BTC_sender logic that runs prior to creating an inscription. Previously, even when a delay was set, the logic proceeded without properly validating all the required criteria. Now, the criteria are evaluated sequentially, and if any criterion fails, all previous checks are rolled back and no inscription is created.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
