### PR TITLE
Fix/via mutex deadlock

### DIFF
--- a/via_verifier/lib/via_musig2/src/transaction_builder.rs
+++ b/via_verifier/lib/via_musig2/src/transaction_builder.rs
@@ -83,6 +83,8 @@ impl TransactionBuilder {
             .select_utxos_by_target_value(&available_utxos, total_needed)
             .await?;
 
+        tracing::debug!("Selected UTXOs {:?}", &selected_utxos);
+
         // Calculate total input amount
         let total_input_amount: Amount = selected_utxos
             .iter()

--- a/via_verifier/node/via_verifier_coordinator/Cargo.toml
+++ b/via_verifier/node/via_verifier_coordinator/Cargo.toml
@@ -23,7 +23,7 @@ via_verifier_types.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 tokio = { workspace = true, features = ["time"] }
-tower-http = { workspace = true, features = ["cors"] }
+tower-http = { workspace = true, features = ["cors", "timeout"] }
 tower = { workspace = true }
 tracing.workspace = true
 serde.workspace = true

--- a/via_verifier/node/via_verifier_coordinator/src/coordinator/api_impl.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/coordinator/api_impl.rs
@@ -148,7 +148,12 @@ impl RestApi {
                     partial_sig,
                     &session_op.get_message_to_sign(),
                 ) {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        tracing::debug!(
+                            "Valid partial signature submitted by {:?}",
+                            individual_pubkey_str
+                        );
+                    }
                     Err(e) => {
                         // Reset the session if a partial signature is not valid.
                         // This will force the verifier to submit a new valid signature.

--- a/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/verifier/mod.rs
@@ -376,7 +376,8 @@ impl ViaWithdrawalVerifier {
             Ok(())
         } else {
             anyhow::bail!(
-                "Failed to submit partial signature, response: {}, url: {}, headers: {:?}, body: {:?} ",
+                "Failed to submit partial signature, status: {} response: {}, url: {}, headers: {:?}, body: {:?} ",
+                resp.status().as_str(),
                 resp.text().await?,
                 url,
                 headers,
@@ -408,7 +409,8 @@ impl ViaWithdrawalVerifier {
 
         if !resp.status().is_success() {
             tracing::warn!(
-                "Failed to create a new session, response: {}, url: {}, headers: {:?}",
+                "Failed to create a new session, status: {}, response: {}, url: {}, headers: {:?}",
+                resp.status().as_str(),
                 resp.text().await?,
                 url,
                 headers


### PR DESCRIPTION
## What ❔

- Fix Mutex dead lock.
- Add debug logs.
- Add `timeout` to the coordinator API

## Why ❔

- After processing a withdrawal the coordinator get stuck because of a Mutex deadlock logic in the `utxo_manager`.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
