### PR TITLE
fix: handle multiple inscription inputs

### DIFF
--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -60,6 +60,18 @@ services:
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${BRIDGE_TEST_ADDRESS} 300
         echo "Sent 300 BTC to BRIDGE_TEST_ADDRESS: $${BRIDGE_TEST_ADDRESS}"
 
+        echo "BRIDGE_TEST_ADDRESS2: $${BRIDGE_TEST_ADDRESS2}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${BRIDGE_TEST_ADDRESS2} 1
+        echo "Sent 300 BTC to BRIDGE_TEST_ADDRESS2: $${BRIDGE_TEST_ADDRESS2}"
+
+        echo "BRIDGE_TEST_ADDRESS2: $${BRIDGE_TEST_ADDRESS2}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${BRIDGE_TEST_ADDRESS2} 1
+        echo "Sent 300 BTC to BRIDGE_TEST_ADDRESS2: $${BRIDGE_TEST_ADDRESS2}"
+
+        echo "BRIDGE_TEST_ADDRESS2: $${BRIDGE_TEST_ADDRESS2}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${BRIDGE_TEST_ADDRESS2} 1
+        echo "Sent 300 BTC to BRIDGE_TEST_ADDRESS2: $${BRIDGE_TEST_ADDRESS2}"
+
         echo "VERIFIER_2_ADDRESS: $${VERIFIER_2_ADDRESS}"
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${VERIFIER_2_ADDRESS} 300
         echo "Sent 300 BTC to VERIFIER_2_ADDRESS: $${VERIFIER_2_ADDRESS}"
@@ -115,6 +127,7 @@ services:
       - VERIFIER_2_ADDRESS=bcrt1qk8mkhrmgtq24nylzyzejznfzws6d98g4kmuuh4
       - VERIFIER_3_ADDRESS=bcrt1q23lgaa90s85jvtl6dsrkvn0g949cwjkwuyzwdm
       - BRIDGE_TEST_ADDRESS=bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg
+      - BRIDGE_TEST_ADDRESS2=bcrt1pm4rre0xv8ryr9lr5lrnzx5tpyk0xr43kfw3aja68c0845vsu5wus3u40fp
       - VIA_LOADNEXT_TEST_ADDRESS=bcrt1q8tuqv885kehnzucdfskuw6mrhxcj7cjs4gfk5z
       - RPC_ARGS=-chain=regtest -rpcconnect=bitcoind -rpcwait -rpcuser=rpcuser -rpcpassword=rpcpassword
       - SLEEP_SECONDS=1

--- a/via_verifier/lib/via_musig2/examples/verify_partial_sig.rs
+++ b/via_verifier/lib/via_musig2/examples/verify_partial_sig.rs
@@ -2,7 +2,7 @@
 
 //! Demonstrate verify a partial signaturecreating a transaction that spends to and from p2tr outputs with musig2.
 
-use std::{io::Read, str::FromStr};
+use std::str::FromStr;
 
 use bitcoin::{
     hashes::Hash,
@@ -14,20 +14,12 @@ use bitcoin::{
     transaction, Address, Amount, Network, OutPoint, PrivateKey, ScriptBuf, Sequence, TapTweakHash,
     Transaction, TxIn, TxOut, Txid, Witness,
 };
-use musig2::{
-    secp::{MaybeScalar, Scalar},
-    verify_partial, AggNonce, KeyAggContext, PartialSignature,
-};
+use musig2::{secp::Scalar, KeyAggContext, PartialSignature};
 use rand::Rng;
 use secp256k1_musig2::schnorr::Signature;
-use via_btc_client::{inscriber::Inscriber, types::NodeAuth};
 use via_musig2::utils::verify_partial_signature;
 
-const RPC_URL: &str = "http://0.0.0.0:18443";
-const RPC_USERNAME: &str = "rpcuser";
-const RPC_PASSWORD: &str = "rpcpassword";
 const NETWORK: Network = Network::Regtest;
-const PK: &str = "cRaUbRSn8P8cXUcg6cMZ7oTZ1wbDjktYTsbdGw62tuqqD9ttQWMm";
 const SPEND_AMOUNT: Amount = Amount::from_sat(5_000_000);
 
 #[tokio::main]

--- a/via_verifier/lib/via_musig2/src/transaction_builder.rs
+++ b/via_verifier/lib/via_musig2/src/transaction_builder.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use bitcoin::{
     absolute,
+    hashes::Hash,
     script::PushBytesBuf,
     sighash::{Prevouts, SighashCache},
-    transaction, Address, Amount, OutPoint, ScriptBuf, Sequence, TapSighash, TapSighashType,
-    Transaction, TxIn, TxOut, Witness,
+    transaction, Address, Amount, OutPoint, ScriptBuf, Sequence, TapSighashType, Transaction, TxIn,
+    TxOut, Witness,
 };
 use tracing::{debug, instrument};
 use via_btc_client::traits::BitcoinOps;
@@ -171,19 +172,25 @@ impl TransactionBuilder {
     }
 
     #[instrument(skip(self, unsigned_tx), target = "bitcoin_transaction_builder")]
-    pub fn get_tr_sighash(&self, unsigned_tx: &UnsignedBridgeTx) -> anyhow::Result<TapSighash> {
+    pub fn get_tr_sighashes(&self, unsigned_tx: &UnsignedBridgeTx) -> anyhow::Result<Vec<Vec<u8>>> {
         let mut sighash_cache = SighashCache::new(&unsigned_tx.tx);
         let sighash_type = TapSighashType::All;
-        let mut txout_list = Vec::with_capacity(unsigned_tx.utxos.len());
 
-        for (_, txout) in unsigned_tx.utxos.clone() {
-            txout_list.push(txout);
+        let txout_list: Vec<TxOut> = unsigned_tx
+            .utxos
+            .iter()
+            .map(|(_, txout)| txout.clone())
+            .collect();
+
+        let mut sighashes = vec![];
+        for (i, _) in txout_list.iter().enumerate() {
+            let sighash = sighash_cache
+                .taproot_key_spend_signature_hash(i, &Prevouts::All(&txout_list), sighash_type)
+                .with_context(|| "Error taproot_key_spend_signature_hash")?;
+            sighashes.push(sighash.to_raw_hash().to_byte_array().to_vec());
         }
-        let sighash = sighash_cache
-            .taproot_key_spend_signature_hash(0, &Prevouts::All(&txout_list), sighash_type)
-            .with_context(|| "Error taproot_key_spend_signature_hash")?;
 
-        Ok(sighash)
+        Ok(sighashes)
     }
 
     // Helper function to create OP_RETURN script

--- a/via_verifier/node/via_verifier_coordinator/src/types.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/types.rs
@@ -1,4 +1,4 @@
-use std::{clone::Clone, collections::HashMap, fmt, sync::Arc};
+use std::{clone::Clone, collections::BTreeMap, fmt, sync::Arc};
 
 use bincode::{deserialize, serialize};
 use musig2::{PartialSignature, PubNonce};
@@ -27,7 +27,7 @@ impl fmt::Display for SessionType {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SessionOperation {
-    Withdrawal(i64, UnsignedBridgeTx, Vec<u8>, Vec<u8>),
+    Withdrawal(i64, UnsignedBridgeTx, Vec<Vec<u8>>, Vec<u8>),
 }
 
 impl SessionOperation {
@@ -43,7 +43,7 @@ impl SessionOperation {
         }
     }
 
-    pub fn get_message_to_sign(&self) -> Vec<u8> {
+    pub fn get_message_to_sign(&self) -> Vec<Vec<u8>> {
         match self {
             Self::Withdrawal(_, _, message, _) => message.clone(),
         }
@@ -61,7 +61,7 @@ impl SessionOperation {
         }
     }
 
-    pub fn session(&self) -> Option<(&UnsignedBridgeTx, &Vec<u8>)> {
+    pub fn session(&self) -> Option<(&UnsignedBridgeTx, &Vec<Vec<u8>>)> {
         match self {
             Self::Withdrawal(_, unsigned_tx, message, _) => Some((unsigned_tx, message)),
         }
@@ -92,8 +92,8 @@ pub struct ViaWithdrawalState {
 #[derive(Default, Debug, Clone)]
 pub struct SigningSession {
     pub session_op: Option<SessionOperation>,
-    pub received_nonces: HashMap<usize, PubNonce>,
-    pub received_sigs: HashMap<usize, PartialSignature>,
+    pub received_nonces: BTreeMap<usize, BTreeMap<usize, PubNonce>>,
+    pub received_sigs: BTreeMap<usize, BTreeMap<usize, PartialSignature>>,
     pub created_at: u64,
 }
 
@@ -117,7 +117,7 @@ pub struct PartialSignaturePair {
 pub struct SigningSessionResponse {
     pub session_op: Vec<u8>,
     pub required_signers: usize,
-    pub received_nonces: usize,
-    pub received_partial_signatures: usize,
+    pub received_nonces: BTreeMap<usize, usize>,
+    pub received_partial_signatures: BTreeMap<usize, usize>,
     pub created_at: u64,
 }

--- a/via_verifier/node/via_verifier_coordinator/src/utils.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/utils.rs
@@ -1,39 +1,9 @@
-use std::str::FromStr;
-
 use anyhow::Context;
 use base64::Engine;
-use bitcoin::{hashes::Hash, PrivateKey, Txid};
+use bitcoin::{hashes::Hash, Txid};
 use musig2::{BinaryEncoding, PartialSignature, PubNonce};
-use secp256k1_musig2::{PublicKey, Secp256k1, SecretKey};
-use via_musig2::Signer;
 
 use crate::types::{NoncePair, PartialSignaturePair};
-
-pub fn get_signer(
-    private_key_wif: &str,
-    verifiers_pub_keys_str: Vec<String>,
-) -> anyhow::Result<Signer> {
-    let private_key = PrivateKey::from_wif(private_key_wif)?;
-    let secret_key = SecretKey::from_byte_array(&private_key.inner.secret_bytes())
-        .with_context(|| "Error to compute the coordinator sk")?;
-    let secp = Secp256k1::new();
-    let public_key = PublicKey::from_secret_key(&secp, &secret_key);
-
-    let mut all_pubkeys = Vec::new();
-
-    let mut signer_index = 0;
-
-    for (i, key) in verifiers_pub_keys_str.iter().enumerate() {
-        let pk = PublicKey::from_str(key)?;
-        all_pubkeys.push(pk);
-        if pk == public_key {
-            signer_index = i;
-        }
-    }
-
-    let signer = Signer::new(secret_key, signer_index, all_pubkeys.clone())?;
-    Ok(signer)
-}
 
 pub fn decode_signature(signature: String) -> anyhow::Result<PartialSignature> {
     let decoded_sig = base64::engine::general_purpose::STANDARD


### PR DESCRIPTION
## What ❔

- Update the verifier and coordinator to support multiple inputs inscriptions.
- Fix withdrawal example

## Why ❔
- When a transaction requires more than one input, the transaction is rejected because of invalid signature.

## Testing ❔
1. Start the sequencer and the verifier network
2. Deposit 6 times, 1 BTC each time.
3. Request withdrawal 1 BTC, this will requires 1 input.
![Screenshot from 2025-06-15 10-57-20](https://github.com/user-attachments/assets/5eae5681-c01e-43c8-8e09-6229ed19f292)

4. Request withdrawal 2 BTC, this will requires 2 inputs.
![Screenshot from 2025-06-15 10-57-01](https://github.com/user-attachments/assets/3568e5c9-6011-447e-9617-3d329160fbf1)

5. Request withdrawal 3 BTC, this will requires 3 inputs.
![Screenshot from 2025-06-15 10-56-48](https://github.com/user-attachments/assets/bd20a512-530b-4557-b577-4b1e9a38433f)


## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
