### PR TITLE
Feat/default btc client ressource

### DIFF
--- a/core/node/node_framework/src/implementations/layers/via_btc_client.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_client.rs
@@ -51,7 +51,14 @@ impl WiringLayer for BtcClientLayer {
     }
 
     async fn wire(self, _: Self::Input) -> Result<Self::Output, WiringError> {
-        let mut btc_client_resource = BtcClientResource::new();
+        let default_btc_client = BitcoinClient::new(
+            self.secrets.rpc_url.expose_str(),
+            self.secrets.auth_node(),
+            self.via_btc_client.clone(),
+        )
+        .map_err(|e| WiringError::Internal(e.into()))?;
+
+        let mut btc_client_resource = BtcClientResource::new(Arc::new(default_btc_client));
 
         if let Some(wallet) = self.wallets.btc_sender {
             let btc_client = BitcoinClient::new(

--- a/core/node/node_framework/src/implementations/resources/via_btc_client.rs
+++ b/core/node/node_framework/src/implementations/resources/via_btc_client.rs
@@ -6,14 +6,16 @@ use crate::Resource;
 
 #[derive(Debug, Clone)]
 pub struct BtcClientResource {
+    pub default: Arc<BitcoinClient>,
     pub btc_sender: Option<Arc<BitcoinClient>>,
     pub verifier: Option<Arc<BitcoinClient>>,
     pub bridge: Option<Arc<BitcoinClient>>,
 }
 
 impl BtcClientResource {
-    pub fn new() -> Self {
+    pub fn new(default: Arc<BitcoinClient>) -> Self {
         Self {
+            default,
             btc_sender: None,
             verifier: None,
             bridge: None,
@@ -22,6 +24,7 @@ impl BtcClientResource {
 
     pub fn with_btc_sender(self, btc_client: Arc<BitcoinClient>) -> Self {
         Self {
+            default: self.default,
             btc_sender: Some(btc_client),
             verifier: self.verifier.clone(),
             bridge: self.bridge.clone(),
@@ -30,6 +33,7 @@ impl BtcClientResource {
 
     pub fn with_verifier(self, btc_client: Arc<BitcoinClient>) -> Self {
         Self {
+            default: self.default,
             btc_sender: self.btc_sender.clone(),
             verifier: Some(btc_client),
             bridge: self.bridge.clone(),
@@ -38,6 +42,7 @@ impl BtcClientResource {
 
     pub fn with_bridge(self, btc_client: Arc<BitcoinClient>) -> Self {
         Self {
+            default: self.default,
             btc_sender: self.btc_sender.clone(),
             verifier: self.verifier.clone(),
             bridge: Some(btc_client),


### PR DESCRIPTION
## What ❔

- Add default btc client if no wallet set.

## Why ❔

- It's possible that we need a btc client in readonly mode, this doesn't requires to set a wallet address.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
