### PR TITLE
Fix/via indexer sql

### DIFF
--- a/via_indexer/lib/via_indexer_dal/migrations/20250604191948_deposit_withdraw.up.sql
+++ b/via_indexer/lib/via_indexer_dal/migrations/20250604191948_deposit_withdraw.up.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS bridge_withdrawals (
     "vsize" BIGINT NOT NULL,
     "total_size" BIGINT NOT NULL,
     "withdrawals_count" BIGINT NOT NULL,
-    "block_number" BIGINT NOT NULL UNIQUE,
+    "block_number" BIGINT NOT NULL,
     "created_at" TIMESTAMP NOT NULL DEFAULT NOW()
 );
 


### PR DESCRIPTION
## What ❔

- Remove UNIQUE from the bridge withdrawal block_number column.

## Why ❔

It's possible that we will have 2 transactions with same block number.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
