### PR TITLE
feat: validate the bridge withdrawal inscription

### DIFF
--- a/core/lib/via_btc_client/src/indexer/parser.rs
+++ b/core/lib/via_btc_client/src/indexer/parser.rs
@@ -775,7 +775,7 @@ impl MessageParser {
                 return None;
             }
 
-            let start = OP_RETURN_WITHDRAW_PREFIX.len();
+            let start = OP_RETURN_WITHDRAW_PREFIX.len() + 1;
             // Parse l1_batch_reveal_tx_id from OP_RETURN data
             let l1_batch_proof_reveal_tx_id =
                 match Txid::from_slice(&op_return_data[start..start + 32]) {

--- a/via_verifier/lib/verifier_dal/.sqlx/query-91c394e34bb6a1595233ad927cc85ab341dd742c177c2b16c7a88749726b8854.json
+++ b/via_verifier/lib/verifier_dal/.sqlx/query-91c394e34bb6a1595233ad927cc85ab341dd742c177c2b16c7a88749726b8854.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                l1_batch_number,\n                bridge_tx_id\n            FROM\n                via_votable_transactions\n            WHERE\n                proof_reveal_tx_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "bridge_tx_id",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "91c394e34bb6a1595233ad927cc85ab341dd742c177c2b16c7a88749726b8854"
+}

--- a/via_verifier/lib/verifier_dal/.sqlx/query-b5ca9a8c4de88ba04dcc3ff43d2402c8f34128f88006928567d026fb78e08cbf.json
+++ b/via_verifier/lib/verifier_dal/.sqlx/query-b5ca9a8c4de88ba04dcc3ff43d2402c8f34128f88006928567d026fb78e08cbf.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE via_votable_transactions\n            SET\n                bridge_tx_id = $1\n            WHERE\n                l1_batch_number = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b5ca9a8c4de88ba04dcc3ff43d2402c8f34128f88006928567d026fb78e08cbf"
+}

--- a/via_verifier/node/via_btc_watch/src/lib.rs
+++ b/via_verifier/node/via_btc_watch/src/lib.rs
@@ -1,7 +1,7 @@
 mod message_processors;
 mod metrics;
 
-use message_processors::GovernanceUpgradesEventProcessor;
+use message_processors::{GovernanceUpgradesEventProcessor, WithdrawalProcessor};
 use tokio::sync::watch;
 // re-export via_btc_client types
 use via_btc_client::indexer::BitcoinInscriptionIndexer;
@@ -51,6 +51,7 @@ impl VerifierBtcWatch {
             Box::new(GovernanceUpgradesEventProcessor::new()),
             Box::new(L1ToL2MessageProcessor::new(indexer.get_state().0)),
             Box::new(VerifierMessageProcessor::new(zk_agreement_threshold)),
+            Box::new(WithdrawalProcessor::new()),
         ];
 
         Ok(Self {

--- a/via_verifier/node/via_btc_watch/src/message_processors/mod.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/mod.rs
@@ -6,11 +6,13 @@ use via_btc_client::{
     types::{BitcoinTxid, FullInscriptionMessage, IndexerError},
 };
 use via_verifier_dal::{Connection, Verifier};
+pub(crate) use withdrawal::WithdrawalProcessor;
 use zksync_types::H256;
 
 mod governance_upgrade;
 mod l1_to_l2;
 mod verifier;
+mod withdrawal;
 
 #[derive(Debug, thiserror::Error)]
 pub(super) enum MessageProcessorError {
@@ -18,6 +20,8 @@ pub(super) enum MessageProcessorError {
     Internal(#[from] anyhow::Error),
     #[error("database error: {0}")]
     DatabaseError(String),
+    #[error("sync error: {0}")]
+    SyncError(String),
 }
 
 impl From<IndexerError> for MessageProcessorError {

--- a/via_verifier/node/via_btc_watch/src/message_processors/withdrawal.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/withdrawal.rs
@@ -1,0 +1,89 @@
+use via_btc_client::{
+    indexer::BitcoinInscriptionIndexer,
+    types::{BitcoinSecp256k1::hashes::Hash, FullInscriptionMessage},
+};
+use via_verifier_dal::{Connection, Verifier, VerifierDal};
+use zksync_types::H256;
+
+use super::{MessageProcessor, MessageProcessorError};
+use crate::metrics::{InscriptionStage, METRICS};
+
+#[derive(Debug)]
+pub struct WithdrawalProcessor;
+
+impl WithdrawalProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl MessageProcessor for WithdrawalProcessor {
+    async fn process_messages(
+        &mut self,
+        storage: &mut Connection<'_, Verifier>,
+        msgs: Vec<FullInscriptionMessage>,
+        _: &mut BitcoinInscriptionIndexer,
+    ) -> Result<(), MessageProcessorError> {
+        for msg in msgs {
+            if let FullInscriptionMessage::BridgeWithdrawal(withdrawal_msg) = msg {
+                tracing::info!("Processing withdrawal bridge transaction...");
+
+                let mut proof_reveal_tx_id_bytes =
+                    withdrawal_msg.input.l1_batch_proof_reveal_tx_id.clone();
+                proof_reveal_tx_id_bytes.reverse();
+                let proof_reveal_tx_id = H256::from_slice(&proof_reveal_tx_id_bytes);
+                let indexed_bridge_tx_id = withdrawal_msg
+                    .common
+                    .tx_id
+                    .as_raw_hash()
+                    .to_byte_array()
+                    .to_vec();
+
+                let Some((l1_batch_number, bridge_tx_id)) = storage
+                    .via_votes_dal()
+                    .get_vote_transaction_info(proof_reveal_tx_id.clone())
+                    .await
+                    .map_err(|e| MessageProcessorError::DatabaseError(e.to_string()))?
+                else {
+                    tracing::warn!(
+                        "Votable transaction for proof_reveal_tx_id {} not found",
+                        proof_reveal_tx_id.clone()
+                    );
+                    continue;
+                };
+
+                if let Some(existing_tx_id) = bridge_tx_id {
+                    if existing_tx_id == indexed_bridge_tx_id {
+                        tracing::info!(
+                            "Withdrawal already processed for batch {}. Skipping.",
+                            l1_batch_number
+                        );
+                        return Ok(());
+                    }
+
+                    // TODO: cover the case where an L1 batch contains a lots of withdrawals that can not be included in one transaction.
+                    return Err(MessageProcessorError::SyncError(format!(
+                        "Multiple withdrawals detected for L1 batch {}",
+                        l1_batch_number
+                    )));
+                }
+
+                storage
+                    .via_votes_dal()
+                    .update_bridge_tx_id(H256::from_slice(&indexed_bridge_tx_id), l1_batch_number)
+                    .await
+                    .map_err(|e| MessageProcessorError::DatabaseError(e.to_string()))?;
+
+                tracing::info!(
+                    "Marked withdrawal for L1 batch {} as processed",
+                    l1_batch_number
+                );
+                METRICS.inscriptions_processed[&InscriptionStage::Withdrawal]
+                    .set(l1_batch_number as usize);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/via_verifier/node/via_btc_watch/src/metrics.rs
+++ b/via_verifier/node/via_btc_watch/src/metrics.rs
@@ -7,6 +7,7 @@ pub enum InscriptionStage {
     Deposit,
     Upgrade,
     Vote,
+    Withdrawal,
 }
 
 #[derive(Debug, Metrics)]

--- a/via_verifier/node/via_verifier_coordinator/src/traits.rs
+++ b/via_verifier/node/via_verifier_coordinator/src/traits.rs
@@ -1,10 +1,12 @@
+use std::any::Any;
+
 use axum::async_trait;
 use bitcoin::Txid;
 
 use crate::types::SessionOperation;
 
 #[async_trait]
-pub trait ISession: Send + Sync {
+pub trait ISession: Any + Send + Sync {
     async fn session(&self) -> anyhow::Result<Option<SessionOperation>>;
 
     async fn is_session_in_progress(
@@ -26,4 +28,6 @@ pub trait ISession: Send + Sync {
         txid: Txid,
         session_op: &SessionOperation,
     ) -> anyhow::Result<bool>;
+
+    fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
## What ❔

- Add validation logic  to check if the expected bridge address created the inscription.

## Why ❔
- This PR allows to ignore inscriptions that where not created by the authorized bridge address.

## Testing
- This PR is a parent of the #206 , follow the PR description for more details about testing process.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
