### PR TITLE
Feat/via mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9827,6 +9827,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "via_mempool"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+ "zksync_types",
+]
+
+[[package]]
 name = "via_musig2"
 version = "0.1.0"
 dependencies = [
@@ -9901,6 +9909,7 @@ dependencies = [
  "tracing",
  "via_btc_client",
  "via_fee_model",
+ "via_mempool",
  "vise",
  "zksync_config",
  "zksync_contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ members = [
     "core/tests/via_loadnext",
     "core/bin/via_external_node",
     'core/node/via_consistency_checker',
+    "core/lib/via_mempool",
 
     # VIA Verifier
     "via_verifier/bin/verifier_server",
@@ -347,6 +348,7 @@ via_fee_model = { version = "0.1.0", path = "core/node/via_fee_model" }
 via_state_keeper = { version = "0.1.0", path = "core/node/via_state_keeper" }
 via_block_reverter = { version = "0.1.0", path = "core/node/via_block_reverter" }
 via_consistency_checker = { version = "0.1.0", path = "core/node/via_consistency_checker" }
+via_mempool = { version = "0.1.0", path = "core/lib/via_mempool" }
 
 # VIA Verifier
 via_withdrawal_client = { version = "0.1.0", path = "via_verifier/lib/via_withdrawal_client" }

--- a/core/lib/via_mempool/Cargo.toml
+++ b/core/lib/via_mempool/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "via_mempool"
+description = "VIA mempool implementation"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+zksync_types.workspace = true
+tracing.workspace = true

--- a/core/lib/via_mempool/src/lib.rs
+++ b/core/lib/via_mempool/src/lib.rs
@@ -1,0 +1,9 @@
+mod mempool_store;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use crate::{
+    mempool_store::{MempoolInfo, MempoolStats, MempoolStore},
+    types::L2TxFilter,
+};

--- a/core/lib/via_mempool/src/mempool_store.rs
+++ b/core/lib/via_mempool/src/mempool_store.rs
@@ -1,0 +1,246 @@
+use std::collections::{hash_map, BTreeMap, BTreeSet, HashMap, HashSet};
+
+use zksync_types::{
+    l1::L1Tx, l2::L2Tx, Address, ExecuteTransactionCommon, Nonce, PriorityOpId, Transaction,
+};
+
+use crate::types::{AccountTransactions, L2TxFilter, MempoolScore};
+
+#[derive(Debug)]
+pub struct MempoolInfo {
+    pub stashed_accounts: Vec<Address>,
+    pub purged_accounts: Vec<Address>,
+}
+
+#[derive(Debug)]
+pub struct MempoolStats {
+    pub l1_transaction_count: usize,
+    pub l2_transaction_count: u64,
+    pub l2_priority_queue_size: usize,
+}
+
+#[derive(Debug)]
+pub struct MempoolStore {
+    /// Pending L1 transactions
+    l1_transactions: BTreeMap<PriorityOpId, L1Tx>,
+    /// Pending L2 transactions grouped by initiator address
+    l2_transactions_per_account: HashMap<Address, AccountTransactions>,
+    /// Global priority queue for L2 transactions. Used for scoring
+    l2_priority_queue: BTreeSet<MempoolScore>,
+    /// Last priority operation
+    last_priority_id: PriorityOpId,
+    stashed_accounts: Vec<Address>,
+    /// Number of L2 transactions in the mempool.
+    size: u64,
+    capacity: u64,
+}
+
+impl MempoolStore {
+    pub fn new(last_priority_id: PriorityOpId, capacity: u64) -> Self {
+        Self {
+            l1_transactions: BTreeMap::new(),
+            l2_transactions_per_account: HashMap::new(),
+            l2_priority_queue: BTreeSet::new(),
+            last_priority_id,
+            stashed_accounts: vec![],
+            size: 0,
+            capacity,
+        }
+    }
+
+    /// Inserts batch of new transactions to mempool
+    /// `initial_nonces` provides current committed nonce information to mempool
+    /// variable is used only if account is not present in mempool yet and we have to bootstrap it
+    /// in other cases mempool relies on state keeper and its internal state to keep that info up to date
+    pub fn insert(
+        &mut self,
+        transactions: Vec<Transaction>,
+        initial_nonces: HashMap<Address, Nonce>,
+    ) {
+        for transaction in transactions {
+            let Transaction {
+                common_data,
+                execute,
+                received_timestamp_ms,
+                raw_bytes,
+            } = transaction;
+            match common_data {
+                ExecuteTransactionCommon::L1(data) => {
+                    if self.last_priority_id > data.serial_id {
+                        continue;
+                    }
+                    tracing::trace!("inserting L1 transaction {}", data.serial_id);
+                    self.l1_transactions.insert(
+                        data.serial_id,
+                        L1Tx {
+                            execute,
+                            common_data: data,
+                            received_timestamp_ms,
+                        },
+                    );
+                }
+                ExecuteTransactionCommon::L2(data) => {
+                    tracing::trace!("inserting L2 transaction {}", data.nonce);
+                    self.insert_l2_transaction(
+                        L2Tx {
+                            execute,
+                            common_data: data,
+                            received_timestamp_ms,
+                            raw_bytes,
+                        },
+                        &initial_nonces,
+                    );
+                }
+                ExecuteTransactionCommon::ProtocolUpgrade(_) => {
+                    panic!("Protocol upgrade tx is not supposed to be inserted into mempool");
+                }
+            }
+        }
+    }
+
+    fn insert_l2_transaction(
+        &mut self,
+        transaction: L2Tx,
+        initial_nonces: &HashMap<Address, Nonce>,
+    ) {
+        let account = transaction.initiator_account();
+
+        let metadata = match self.l2_transactions_per_account.entry(account) {
+            hash_map::Entry::Occupied(mut txs) => txs.get_mut().insert(transaction),
+            hash_map::Entry::Vacant(entry) => {
+                let account_nonce = initial_nonces.get(&account).cloned().unwrap_or(Nonce(0));
+                entry
+                    .insert(AccountTransactions::new(account_nonce))
+                    .insert(transaction)
+            }
+        };
+        if let Some(score) = metadata.previous_score {
+            self.l2_priority_queue.remove(&score);
+        }
+        if let Some(score) = metadata.new_score {
+            self.l2_priority_queue.insert(score);
+        }
+        if metadata.is_new {
+            self.size += 1;
+        }
+    }
+
+    /// Returns `true` if there is a transaction in the mempool satisfying the filter.
+    pub fn has_next(&self, filter: &L2TxFilter) -> bool {
+        self.l1_transactions.iter().next().is_some()
+            || self
+                .l2_priority_queue
+                .iter()
+                .rfind(|el| el.matches_filter(filter))
+                .is_some()
+    }
+
+    /// Returns next transaction for execution from mempool
+    pub fn next_transaction(&mut self, filter: &L2TxFilter) -> Option<Transaction> {
+        if let Some((_, transaction)) = self.l1_transactions.pop_first() {
+            self.last_priority_id = transaction.common_data.serial_id;
+            return Some(transaction.into());
+        }
+
+        let mut removed = 0;
+        // We want to fetch the next transaction that would match the fee requirements.
+        let tx_pointer = self
+            .l2_priority_queue
+            .iter()
+            .rfind(|el| el.matches_filter(filter))?
+            .clone();
+
+        // Stash all observed transactions that don't meet criteria
+        for stashed_pointer in self
+            .l2_priority_queue
+            .split_off(&tx_pointer)
+            .into_iter()
+            .skip(1)
+        {
+            removed += self
+                .l2_transactions_per_account
+                .remove(&stashed_pointer.account)
+                .expect("mempool: dangling pointer in priority queue")
+                .len();
+
+            self.stashed_accounts.push(stashed_pointer.account);
+        }
+        // insert pointer to the next transaction if it exists
+        let (transaction, score) = self
+            .l2_transactions_per_account
+            .get_mut(&tx_pointer.account)
+            .expect("mempool: dangling pointer in priority queue")
+            .next();
+
+        if let Some(score) = score {
+            self.l2_priority_queue.insert(score);
+        }
+        self.size = self
+            .size
+            .checked_sub((removed + 1) as u64)
+            .expect("mempool size can't be negative");
+        Some(transaction.into())
+    }
+
+    /// When a state_keeper starts the block over after a rejected transaction,
+    /// we have to rollback the nonces/ids in the mempool and
+    /// reinsert the transactions from the block back into mempool.
+    pub fn rollback(&mut self, tx: &Transaction) {
+        // rolling back the nonces and priority ids
+        match &tx.common_data {
+            ExecuteTransactionCommon::L1(data) => {
+                // reset next priority id
+                self.last_priority_id = self.last_priority_id.min(data.serial_id);
+            }
+            ExecuteTransactionCommon::L2(_) => {
+                if let Some(score) = self
+                    .l2_transactions_per_account
+                    .get_mut(&tx.initiator_account())
+                    .expect("account is not available in mempool")
+                    .reset(tx)
+                {
+                    self.l2_priority_queue.remove(&score);
+                }
+            }
+            ExecuteTransactionCommon::ProtocolUpgrade(_) => {
+                panic!("Protocol upgrade tx is not supposed to be in mempool");
+            }
+        }
+    }
+
+    pub fn get_mempool_info(&mut self) -> MempoolInfo {
+        MempoolInfo {
+            stashed_accounts: std::mem::take(&mut self.stashed_accounts),
+            purged_accounts: self.gc(),
+        }
+    }
+
+    pub fn stats(&self) -> MempoolStats {
+        MempoolStats {
+            l1_transaction_count: self.l1_transactions.len(),
+            l2_transaction_count: self.size,
+            l2_priority_queue_size: self.l2_priority_queue.len(),
+        }
+    }
+
+    fn gc(&mut self) -> Vec<Address> {
+        if self.size >= self.capacity {
+            let index: HashSet<_> = self
+                .l2_priority_queue
+                .iter()
+                .map(|pointer| pointer.account)
+                .collect();
+            let transactions = std::mem::take(&mut self.l2_transactions_per_account);
+            let (kept, drained) = transactions
+                .into_iter()
+                .partition(|(address, _)| index.contains(address));
+            self.l2_transactions_per_account = kept;
+            self.size = self
+                .l2_transactions_per_account
+                .iter()
+                .fold(0, |agg, (_, tnxs)| agg + tnxs.len() as u64);
+            return drained.into_keys().collect();
+        }
+        vec![]
+    }
+}

--- a/core/lib/via_mempool/src/tests.rs
+++ b/core/lib/via_mempool/src/tests.rs
@@ -1,0 +1,441 @@
+use std::{
+    collections::{HashMap, HashSet},
+    iter::FromIterator,
+};
+
+use zksync_types::{
+    fee::Fee,
+    helpers::unix_timestamp_ms,
+    l1::{OpProcessingType, PriorityQueueType},
+    l2::L2Tx,
+    Address, Execute, ExecuteTransactionCommon, L1TxCommonData, Nonce, PriorityOpId, Transaction,
+    H256, U256,
+};
+
+use crate::{mempool_store::MempoolStore, types::L2TxFilter};
+
+#[test]
+fn basic_flow() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account0 = Address::random();
+    let account1 = Address::random();
+    let transactions = vec![
+        gen_l2_tx(account0, Nonce(0)),
+        gen_l2_tx(account0, Nonce(1)),
+        gen_l2_tx(account0, Nonce(2)),
+        gen_l2_tx(account0, Nonce(3)),
+        gen_l2_tx(account1, Nonce(1)),
+    ];
+    assert_eq!(mempool.next_transaction(&L2TxFilter::default()), None);
+    mempool.insert(transactions, HashMap::new());
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account0, 0)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account0, 1)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account0, 2)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account0, 3)
+    );
+    assert_eq!(mempool.next_transaction(&L2TxFilter::default()), None);
+    // unclog second account and insert more transactions
+    mempool.insert(
+        vec![gen_l2_tx(account1, Nonce(0)), gen_l2_tx(account0, Nonce(3))],
+        HashMap::new(),
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account1, 0)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account1, 1)
+    );
+    assert_eq!(mempool.next_transaction(&L2TxFilter::default()), None);
+}
+
+#[test]
+fn missing_txns() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account = Address::random();
+    let transactions = vec![
+        gen_l2_tx(account, Nonce(6)),
+        gen_l2_tx(account, Nonce(7)),
+        gen_l2_tx(account, Nonce(9)),
+    ];
+    let mut nonces = HashMap::new();
+    nonces.insert(account, Nonce(5));
+    mempool.insert(transactions, nonces);
+    assert_eq!(mempool.next_transaction(&L2TxFilter::default()), None);
+    // missing transaction unclogs mempool
+    mempool.insert(vec![gen_l2_tx(account, Nonce(5))], HashMap::new());
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 5)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 6)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 7)
+    );
+
+    // filling remaining gap
+    mempool.insert(vec![gen_l2_tx(account, Nonce(8))], HashMap::new());
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 8)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 9)
+    );
+}
+
+#[test]
+fn prioritize_l1_txns() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account = Address::random();
+    let transactions = vec![
+        gen_l2_tx(account, Nonce(0)),
+        gen_l2_tx(account, Nonce(1)),
+        gen_l1_tx(PriorityOpId(0)),
+    ];
+    mempool.insert(transactions, HashMap::new());
+    assert!(mempool
+        .next_transaction(&L2TxFilter::default())
+        .unwrap()
+        .is_l1())
+}
+
+#[test]
+fn l1_txns_priority_id() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let transactions = vec![
+        gen_l1_tx(PriorityOpId(1)),
+        gen_l1_tx(PriorityOpId(2)),
+        gen_l1_tx(PriorityOpId(3)),
+    ];
+    mempool.insert(transactions, HashMap::new());
+    // assert!(mempool.next_transaction(&L2TxFilter::default()).is_none());
+    mempool.insert(vec![gen_l1_tx(PriorityOpId(0))], HashMap::new());
+    for idx in 0..4 {
+        let data = mempool
+            .next_transaction(&L2TxFilter::default())
+            .unwrap()
+            .common_data;
+        match data {
+            ExecuteTransactionCommon::L1(data) => {
+                assert_eq!(data.serial_id, PriorityOpId(idx as u64));
+            }
+            _ => unreachable!("expected L1 transaction"),
+        }
+    }
+}
+
+#[test]
+fn rejected_tx() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account = Address::random();
+    let transactions = vec![
+        gen_l2_tx(account, Nonce(0)),
+        gen_l2_tx(account, Nonce(1)),
+        gen_l2_tx(account, Nonce(2)),
+        gen_l2_tx(account, Nonce(3)),
+        gen_l2_tx(account, Nonce(5)),
+    ];
+    mempool.insert(transactions, HashMap::new());
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 0)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 1)
+    );
+
+    mempool.rollback(&gen_l2_tx(account, Nonce(1)));
+    assert!(mempool.next_transaction(&L2TxFilter::default()).is_none());
+
+    // replace transaction and unblock account
+    mempool.insert(vec![gen_l2_tx(account, Nonce(1))], HashMap::new());
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 1)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 2)
+    );
+    assert_eq!(
+        view(mempool.next_transaction(&L2TxFilter::default())),
+        (account, 3)
+    );
+}
+
+#[test]
+fn replace_tx() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account = Address::random();
+    mempool.insert(vec![gen_l2_tx(account, Nonce(0))], HashMap::new());
+    // replace it
+    mempool.insert(
+        vec![gen_l2_tx_with_timestamp(
+            account,
+            Nonce(0),
+            unix_timestamp_ms() + 10,
+        )],
+        HashMap::new(),
+    );
+    assert!(mempool.next_transaction(&L2TxFilter::default()).is_some());
+    assert!(mempool.next_transaction(&L2TxFilter::default()).is_none());
+}
+
+#[test]
+fn two_ready_txs() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account0 = Address::random();
+    let account1 = Address::random();
+    let transactions = vec![gen_l2_tx(account0, Nonce(0)), gen_l2_tx(account1, Nonce(0))];
+    mempool.insert(transactions, HashMap::new());
+    assert_eq!(
+        HashSet::<(_, _)>::from_iter(vec![
+            view(mempool.next_transaction(&L2TxFilter::default())),
+            view(mempool.next_transaction(&L2TxFilter::default()))
+        ]),
+        HashSet::<(_, _)>::from_iter(vec![(account0, 0), (account1, 0)]),
+    );
+}
+
+#[test]
+fn mempool_size() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account0 = Address::random();
+    let account1 = Address::random();
+    let transactions = vec![
+        gen_l2_tx(account0, Nonce(0)),
+        gen_l2_tx(account0, Nonce(1)),
+        gen_l2_tx(account0, Nonce(2)),
+        gen_l2_tx(account0, Nonce(3)),
+        gen_l2_tx(account1, Nonce(1)),
+    ];
+    mempool.insert(transactions, HashMap::new());
+    assert_eq!(mempool.stats().l2_transaction_count, 5);
+    // replacement
+    mempool.insert(vec![gen_l2_tx(account0, Nonce(2))], HashMap::new());
+    assert_eq!(mempool.stats().l2_transaction_count, 5);
+    // load next
+    mempool.next_transaction(&L2TxFilter::default());
+    mempool.next_transaction(&L2TxFilter::default());
+    assert_eq!(mempool.stats().l2_transaction_count, 3);
+}
+
+/// Checks whether filtering transactions based on their fee works as expected.
+#[test]
+fn filtering() {
+    // Filter to find transactions with non-zero `gas_per_pubdata` values.
+    let filter_non_zero = L2TxFilter {
+        fee_input: Default::default(),
+        fee_per_gas: 0u64,
+        gas_per_pubdata: 1u32,
+    };
+    // No-op filter that fetches any transaction.
+    let filter_zero = L2TxFilter {
+        fee_input: Default::default(),
+        fee_per_gas: 0u64,
+        gas_per_pubdata: 0u32,
+    };
+
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account0 = Address::random();
+    let account1 = Address::random();
+
+    // First account will have two transactions: one with too low pubdata price and one with the right value.
+    // Second account will have just one transaction with the right value.
+    mempool.insert(
+        gen_transactions_for_filtering(vec![
+            (account0, Nonce(0), unix_timestamp_ms(), 0),
+            (account0, Nonce(1), unix_timestamp_ms(), 1),
+            (account1, Nonce(0), unix_timestamp_ms() - 10, 1),
+        ]),
+        HashMap::new(),
+    );
+
+    // First transaction from first account doesn't match the filter, so we should get the transaction
+    // from the second account.
+    assert_eq!(
+        view(mempool.next_transaction(&filter_non_zero)),
+        (account1, 0)
+    );
+    // No more transactions can be executed with the non-zero filter.
+    assert_eq!(mempool.next_transaction(&filter_non_zero), None);
+
+    // Now we apply zero filter and get the transaction as expected.
+    assert_eq!(view(mempool.next_transaction(&filter_zero)), (account0, 0));
+    assert_eq!(view(mempool.next_transaction(&filter_zero)), (account0, 1));
+    assert_eq!(mempool.next_transaction(&filter_zero), None);
+}
+
+#[test]
+fn stashed_accounts() {
+    let filter_non_zero = L2TxFilter {
+        fee_input: Default::default(),
+        fee_per_gas: 0u64,
+        gas_per_pubdata: 1u32,
+    };
+    // No-op filter that fetches any transaction.
+    let filter_zero = L2TxFilter {
+        fee_input: Default::default(),
+        fee_per_gas: 0u64,
+        gas_per_pubdata: 0u32,
+    };
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 100);
+    let account0 = Address::random();
+    let account1 = Address::random();
+
+    mempool.insert(
+        gen_transactions_for_filtering(vec![
+            (account0, Nonce(0), unix_timestamp_ms(), 0),
+            (account0, Nonce(1), unix_timestamp_ms(), 1),
+            (account1, Nonce(0), unix_timestamp_ms() + 10, 1),
+        ]),
+        HashMap::new(),
+    );
+    assert!(mempool.get_mempool_info().stashed_accounts.is_empty());
+    assert_eq!(
+        view(mempool.next_transaction(&filter_non_zero)),
+        (account1, 0)
+    );
+    assert_eq!(mempool.get_mempool_info().stashed_accounts, vec![account0]);
+    assert!(mempool.next_transaction(&filter_zero).is_none());
+}
+
+#[test]
+fn mempool_capacity() {
+    let mut mempool = MempoolStore::new(PriorityOpId(0), 5);
+    let account0 = Address::random();
+    let account1 = Address::random();
+    let account2 = Address::random();
+    let transactions = vec![
+        gen_l2_tx(account0, Nonce(0)),
+        gen_l2_tx(account0, Nonce(1)),
+        gen_l2_tx(account0, Nonce(2)),
+        gen_l2_tx(account1, Nonce(1)),
+        gen_l2_tx(account2, Nonce(1)),
+    ];
+    mempool.insert(transactions, HashMap::new());
+    // the mempool is full. Accounts with non-sequential nonces got stashed
+    assert_eq!(
+        HashSet::<_>::from_iter(mempool.get_mempool_info().purged_accounts),
+        HashSet::<_>::from_iter(vec![account1, account2]),
+    );
+    // verify that existing good-to-go transactions and new ones got picked
+    mempool.insert(
+        vec![gen_l2_tx_with_timestamp(
+            account1,
+            Nonce(0),
+            unix_timestamp_ms() + 1,
+        )],
+        HashMap::new(),
+    );
+    for _ in 0..3 {
+        assert_eq!(
+            mempool
+                .next_transaction(&L2TxFilter::default())
+                .unwrap()
+                .initiator_account(),
+            account0
+        );
+    }
+    assert_eq!(
+        mempool
+            .next_transaction(&L2TxFilter::default())
+            .unwrap()
+            .initiator_account(),
+        account1
+    );
+}
+
+fn gen_l2_tx(address: Address, nonce: Nonce) -> Transaction {
+    gen_l2_tx_with_timestamp(address, nonce, unix_timestamp_ms())
+}
+
+fn gen_l2_tx_with_timestamp(address: Address, nonce: Nonce, received_at_ms: u64) -> Transaction {
+    let mut txn = L2Tx::new(
+        Address::default(),
+        Vec::new(),
+        nonce,
+        Fee::default(),
+        address,
+        U256::zero(),
+        vec![],
+        Default::default(),
+    );
+    txn.received_timestamp_ms = received_at_ms;
+    txn.into()
+}
+
+fn gen_l1_tx(priority_id: PriorityOpId) -> Transaction {
+    let execute = Execute {
+        contract_address: Address::repeat_byte(0x11),
+        calldata: vec![1, 2, 3],
+        factory_deps: vec![],
+        value: U256::zero(),
+    };
+    let op_data = L1TxCommonData {
+        sender: Address::random(),
+        serial_id: priority_id,
+        layer_2_tip_fee: U256::zero(),
+        full_fee: U256::zero(),
+        gas_limit: U256::zero(),
+        max_fee_per_gas: U256::zero(),
+        gas_per_pubdata_limit: U256::one(),
+        op_processing_type: OpProcessingType::Common,
+        priority_queue_type: PriorityQueueType::Deque,
+        eth_block: 0,
+        canonical_tx_hash: H256::zero(),
+        to_mint: U256::zero(),
+        refund_recipient: Address::random(),
+    };
+
+    Transaction {
+        common_data: ExecuteTransactionCommon::L1(op_data),
+        execute,
+        received_timestamp_ms: 0,
+        raw_bytes: None,
+    }
+}
+
+fn view(transaction: Option<Transaction>) -> (Address, u32) {
+    let tx = transaction.unwrap();
+    (tx.initiator_account(), tx.nonce().unwrap().0)
+}
+
+fn gen_transactions_for_filtering(input: Vec<(Address, Nonce, u64, u32)>) -> Vec<Transaction> {
+    // Helper function to conveniently set `max_gas_per_pubdata_byte`.
+    fn set_max_gas_per_pubdata_byte(tx: &mut Transaction, value: u32) {
+        match &mut tx.common_data {
+            ExecuteTransactionCommon::L2(data) => {
+                data.fee.gas_per_pubdata_limit = U256::from(value)
+            }
+            _ => unreachable!(),
+        };
+    }
+    input
+        .into_iter()
+        .map(|(account, nonce, tst, max_gas_per_pubdata)| {
+            let mut tx = gen_l2_tx_with_timestamp(account, nonce, tst);
+            set_max_gas_per_pubdata_byte(&mut tx, max_gas_per_pubdata);
+            tx
+        })
+        .collect()
+}

--- a/core/lib/via_mempool/src/types.rs
+++ b/core/lib/via_mempool/src/types.rs
@@ -1,0 +1,201 @@
+use std::{cmp::Ordering, collections::HashMap};
+
+use zksync_types::{
+    fee::Fee, fee_model::BatchFeeInput, l2::L2Tx, Address, Nonce, Transaction, U256,
+};
+
+/// Pending mempool transactions of account
+#[derive(Debug)]
+pub(crate) struct AccountTransactions {
+    /// transactions that belong to given account keyed by transaction nonce
+    transactions: HashMap<Nonce, L2Tx>,
+    /// account nonce in mempool
+    /// equals to committed nonce in db + number of transactions sent to state keeper
+    nonce: Nonce,
+}
+
+impl AccountTransactions {
+    pub fn new(nonce: Nonce) -> Self {
+        Self {
+            transactions: HashMap::new(),
+            nonce,
+        }
+    }
+
+    /// Inserts new transaction for given account. Returns insertion metadata
+    pub fn insert(&mut self, transaction: L2Tx) -> InsertionMetadata {
+        let mut metadata = InsertionMetadata::default();
+        let nonce = transaction.common_data.nonce;
+        // skip insertion if transaction is old
+        if nonce < self.nonce {
+            return metadata;
+        }
+        let new_score = Self::score_for_transaction(&transaction);
+        let previous_score = self
+            .transactions
+            .insert(nonce, transaction)
+            .map(|tx| Self::score_for_transaction(&tx));
+        metadata.is_new = previous_score.is_none();
+        if nonce == self.nonce {
+            metadata.new_score = Some(new_score);
+            metadata.previous_score = previous_score;
+        }
+        metadata
+    }
+
+    /// Returns next transaction to be included in block and optional score of its successor
+    /// Panics if no such transaction exists
+    pub fn next(&mut self) -> (L2Tx, Option<MempoolScore>) {
+        let transaction = self
+            .transactions
+            .remove(&self.nonce)
+            .expect("missing transaction in mempool");
+        self.nonce += 1;
+        let score = self
+            .transactions
+            .get(&self.nonce)
+            .map(Self::score_for_transaction);
+        (transaction, score)
+    }
+
+    /// Handles transaction rejection. Returns optional score of its successor
+    pub fn reset(&mut self, transaction: &Transaction) -> Option<MempoolScore> {
+        // current nonce for the group needs to be reset
+        let tx_nonce = transaction
+            .nonce()
+            .expect("nonce is not set for L2 transaction");
+        self.nonce = self.nonce.min(tx_nonce);
+        self.transactions
+            .get(&(tx_nonce + 1))
+            .map(Self::score_for_transaction)
+    }
+
+    pub fn len(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn score_for_transaction(transaction: &L2Tx) -> MempoolScore {
+        MempoolScore {
+            account: transaction.initiator_account(),
+            received_at_ms: transaction.received_timestamp_ms,
+            fee_data: transaction.common_data.fee.clone(),
+        }
+    }
+}
+
+/// Mempool score of transaction. Used to prioritize L2 transactions in mempool
+/// Currently trivial ordering is used based on received at timestamp
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+pub struct MempoolScore {
+    pub account: Address,
+    pub received_at_ms: u64,
+    // Not used for actual scoring, but state keeper would request
+    // transactions that have acceptable fee values (so transactions
+    // with fee too low would be ignored until prices go down).
+    pub fee_data: Fee,
+}
+
+impl MempoolScore {
+    /// Checks whether transaction matches requirements provided by state keeper.
+    pub fn matches_filter(&self, filter: &L2TxFilter) -> bool {
+        self.fee_data.max_fee_per_gas >= U256::from(filter.fee_per_gas)
+            && self.fee_data.gas_per_pubdata_limit >= U256::from(filter.gas_per_pubdata)
+    }
+}
+
+impl Ord for MempoolScore {
+    fn cmp(&self, other: &MempoolScore) -> Ordering {
+        match self.received_at_ms.cmp(&other.received_at_ms).reverse() {
+            Ordering::Equal => {}
+            ordering => return ordering,
+        }
+        self.account.cmp(&other.account)
+    }
+}
+
+impl PartialOrd for MempoolScore {
+    fn partial_cmp(&self, other: &MempoolScore) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct InsertionMetadata {
+    pub new_score: Option<MempoolScore>,
+    pub previous_score: Option<MempoolScore>,
+    pub is_new: bool,
+}
+
+/// Structure that can be used by state keeper to describe
+/// criteria for transaction it wants to fetch.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct L2TxFilter {
+    /// Batch fee model input. It typically includes things like L1 gas price, L2 fair fee, etc.
+    pub fee_input: BatchFeeInput,
+    /// Effective fee price for the transaction. The price of 1 gas in wei.
+    pub fee_per_gas: u64,
+    /// Effective pubdata price in gas for transaction. The number of gas per 1 pubdata byte.
+    pub gas_per_pubdata: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks the filter logic.
+    #[test]
+    fn filter() {
+        fn filter(fee_per_gas: u64, gas_per_pubdata: u32) -> L2TxFilter {
+            L2TxFilter {
+                fee_input: BatchFeeInput::sensible_l1_pegged_default(),
+                fee_per_gas,
+                gas_per_pubdata,
+            }
+        }
+
+        const MAX_FEE_PER_GAS: u64 = 100u64;
+        const MAX_PRIORITY_FEE_PER_GAS: u32 = 100u32;
+        const GAS_PER_PUBDATA_LIMIT: u32 = 100u32;
+
+        let score = MempoolScore {
+            account: Address::random(),
+            received_at_ms: Default::default(), // Not important
+            fee_data: Fee {
+                gas_limit: Default::default(), // Not important
+                max_fee_per_gas: U256::from(MAX_FEE_PER_GAS),
+                max_priority_fee_per_gas: U256::from(MAX_PRIORITY_FEE_PER_GAS),
+                gas_per_pubdata_limit: U256::from(GAS_PER_PUBDATA_LIMIT),
+            },
+        };
+
+        let noop_filter = filter(0, 0);
+        assert!(
+            score.matches_filter(&noop_filter),
+            "Noop filter should always match"
+        );
+
+        let max_gas_filter = filter(MAX_FEE_PER_GAS, 0);
+        assert!(
+            score.matches_filter(&max_gas_filter),
+            "Correct max gas should be accepted"
+        );
+
+        let pubdata_filter = filter(0, GAS_PER_PUBDATA_LIMIT);
+        assert!(
+            score.matches_filter(&pubdata_filter),
+            "Correct pubdata price should be accepted"
+        );
+
+        let decline_gas_filter = filter(MAX_FEE_PER_GAS + 1, 0);
+        assert!(
+            !score.matches_filter(&decline_gas_filter),
+            "Incorrect max gas should be rejected"
+        );
+
+        let decline_pubdata_filter = filter(0, GAS_PER_PUBDATA_LIMIT + 1);
+        assert!(
+            !score.matches_filter(&decline_pubdata_filter),
+            "Incorrect pubdata price should be rejected"
+        );
+    }
+}

--- a/core/node/via_state_keeper/Cargo.toml
+++ b/core/node/via_state_keeper/Cargo.toml
@@ -19,6 +19,7 @@ zksync_dal.workspace = true
 zksync_state.workspace = true
 zksync_storage.workspace = true
 zksync_mempool.workspace = true
+via_mempool.workspace = true
 zksync_shared_metrics.workspace = true
 zksync_config.workspace = true
 zksync_utils.workspace = true

--- a/core/node/via_state_keeper/src/batch_executor/tests/tester.rs
+++ b/core/node/via_state_keeper/src/batch_executor/tests/tester.rs
@@ -25,8 +25,8 @@ use zksync_types::{
     system_contracts::get_system_smart_contracts,
     utils::storage_key_for_standard_token_balance,
     vm::FastVmMode,
-    AccountTreeId, Address, Execute, L1BatchNumber, L2BlockNumber, PriorityOpId, ProtocolVersionId,
-    StorageLog, Transaction, H256, L2_BASE_TOKEN_ADDRESS, U256,
+    AccountTreeId, Address, Execute, L1BatchNumber, L2BlockNumber, L2ChainId, PriorityOpId,
+    ProtocolVersionId, StorageLog, Transaction, H256, L2_BASE_TOKEN_ADDRESS, U256,
 };
 use zksync_utils::u256_to_h256;
 
@@ -243,6 +243,7 @@ impl Tester {
         if storage.blocks_dal().is_genesis_needed().await.unwrap() {
             create_genesis_l1_batch(
                 &mut storage,
+                L2ChainId::max(),
                 ProtocolSemanticVersion {
                     minor: ProtocolVersionId::latest(),
                     patch: 0.into(),

--- a/core/node/via_state_keeper/src/io/mempool.rs
+++ b/core/node/via_state_keeper/src/io/mempool.rs
@@ -11,7 +11,7 @@ use via_fee_model::BatchFeeModelInputProvider;
 use zksync_config::configs::chain::StateKeeperConfig;
 use zksync_contracts::BaseSystemContracts;
 use zksync_dal::{ConnectionPool, Core, CoreDal};
-use zksync_mempool::L2TxFilter;
+use via_mempool::L2TxFilter;
 use zksync_multivm::{interface::Halt, utils::derive_base_fee_and_gas_per_pubdata};
 use zksync_types::{
     protocol_upgrade::ProtocolUpgradeTx, utils::display_timestamp, Address, L1BatchNumber,

--- a/core/node/via_state_keeper/src/io/tests/mod.rs
+++ b/core/node/via_state_keeper/src/io/tests/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use test_casing::test_casing;
 use zksync_contracts::BaseSystemContractsHashes;
 use zksync_dal::{ConnectionPool, Core, CoreDal};
-use zksync_mempool::L2TxFilter;
+use via_mempool::L2TxFilter;
 use zksync_multivm::{
     interface::{TransactionExecutionMetrics, VmEvent, VmExecutionMetrics},
     utils::derive_base_fee_and_gas_per_pubdata,

--- a/core/node/via_state_keeper/src/io/tests/tester.rs
+++ b/core/node/via_state_keeper/src/io/tests/tester.rs
@@ -5,11 +5,10 @@ use std::{slice, sync::Arc, time::Duration};
 use via_btc_client::{
     client::BitcoinClient,
     inscriber::test_utils::{get_mock_inscriber_and_conditions, MockBitcoinOpsConfig},
-    types::BitcoinNetwork,
 };
 use via_fee_model::{ViaGasAdjuster, ViaMainNodeFeeInputProvider};
 use zksync_config::{
-    configs::{chain::StateKeeperConfig, wallets::Wallets},
+    configs::{chain::StateKeeperConfig, via_btc_client::ViaBtcClientConfig, wallets::Wallets},
     GasAdjusterConfig,
 };
 use zksync_contracts::BaseSystemContracts;
@@ -64,8 +63,8 @@ impl Tester {
         inscriber.get_client().await;
         let client = BitcoinClient::new(
             "",
-            BitcoinNetwork::Regtest,
             via_btc_client::types::NodeAuth::None,
+            ViaBtcClientConfig::for_tests(),
         )
         .unwrap();
         ViaMainNodeFeeInputProvider::new(
@@ -126,6 +125,7 @@ impl Tester {
         if storage.blocks_dal().is_genesis_needed().await.unwrap() {
             create_genesis_l1_batch(
                 &mut storage,
+                L2ChainId::max(),
                 ProtocolSemanticVersion {
                     minor: ProtocolVersionId::latest(),
                     patch: 0.into(),

--- a/core/node/via_state_keeper/src/mempool_actor.rs
+++ b/core/node/via_state_keeper/src/mempool_actor.rs
@@ -7,7 +7,7 @@ use tokio::sync::watch;
 use via_fee_model::BatchFeeModelInputProvider;
 use zksync_config::configs::chain::MempoolConfig;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
-use zksync_mempool::L2TxFilter;
+use via_mempool::L2TxFilter;
 use zksync_multivm::utils::derive_base_fee_and_gas_per_pubdata;
 #[cfg(test)]
 use zksync_types::H256;

--- a/core/node/via_state_keeper/src/metrics.rs
+++ b/core/node/via_state_keeper/src/metrics.rs
@@ -9,7 +9,7 @@ use vise::{
     Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, LatencyObserver,
     Metrics,
 };
-use zksync_mempool::MempoolStore;
+use via_mempool::MempoolStore;
 use zksync_multivm::interface::{
     DeduplicatedWritesMetrics, VmExecutionResultAndLogs, VmRevertReason,
 };

--- a/core/node/via_state_keeper/src/types.rs
+++ b/core/node/via_state_keeper/src/types.rs
@@ -3,8 +3,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use via_mempool::{L2TxFilter, MempoolInfo, MempoolStore};
 use zksync_dal::{Connection, Core, CoreDal};
-use zksync_mempool::{L2TxFilter, MempoolInfo, MempoolStore};
 use zksync_multivm::interface::{VmExecutionMetrics, VmExecutionResultAndLogs};
 use zksync_types::{block::BlockGasCount, Address, Nonce, PriorityOpId, Transaction};
 
@@ -66,7 +66,7 @@ impl MempoolGuard {
     }
 
     #[cfg(test)]
-    pub fn stats(&self) -> zksync_mempool::MempoolStats {
+    pub fn stats(&self) -> via_mempool::MempoolStats {
         self.0
             .lock()
             .expect("failed to acquire mempool lock")


### PR DESCRIPTION
## What ❔

- Add VIA mempool, with the new priority id validation. The new implementation assume that the next priority ID should be greater than the previous one and it could be not sequential.
- Update the VIA state keeper to use the new VIA mempool implementation.

## Why ❔
- The Zksync mempool implementation assume that the priority Id is sequential, which is not the case for the VIA.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
