### PR TITLE
Feat: Change the gov wallet to multisig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ bootstrap-dev:
 		--private-key cVZduZu265sWeAqFYygoDEE1FZ7wV9rpW5qdqjRkUehjaUMWLT1R \
 		--start-block 1 \
 		--verifiers-pub-keys 03d8e2443ef58aa80fb6256bf3b94d2ecf9117f19cb17661ec60ad35fd84ff4a8b,02043f839b8ecd9ffd79f26ec7d05750555cd0d1e0777cfc84a29b7e38e6324662 \
-		--governance-address bcrt1qx2lk0unukm80qmepjp49hwf9z6xnz0s73k9j56 \
+		--governance-address bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm \
 		--bridge-address bcrt1p3s7m76wp5seprjy4gdxuxrr8pjgd47q5s8lu9vefxmp0my2p4t9qh6s8kq \
 		--sequencer-address bcrt1qx2lk0unukm80qmepjp49hwf9z6xnz0s73k9j56
 

--- a/core/lib/config/src/configs/via_verifier.rs
+++ b/core/lib/config/src/configs/via_verifier.rs
@@ -50,7 +50,7 @@ impl ViaVerifierConfig {
 
     pub fn max_tx_weight(&self) -> u64 {
         // Reserve 20000 weight units below Bitcoin's standard limit as a safety buffer
-        // to account for witness data variations, signature size differences, and 
+        // to account for witness data variations, signature size differences, and
         // potential rounding errors during transaction construction, ensuring we stay
         // well within node acceptance limits
         self.max_tx_weight

--- a/core/lib/types/src/via_protocol_upgrade.rs
+++ b/core/lib/types/src/via_protocol_upgrade.rs
@@ -1,23 +1,101 @@
-use zksync_basic_types::H256;
+use zksync_basic_types::{protocol_version::ProtocolSemanticVersion, H256};
 use zksync_contracts::deployer_contract;
+use zksync_system_constants::{CONTRACT_DEPLOYER_ADDRESS, CONTRACT_FORCE_DEPLOYER_ADDRESS};
 
-use crate::{ethabi::Token, Address, U256};
+use crate::{
+    abi::L2CanonicalTransaction,
+    ethabi::Token,
+    helpers::unix_timestamp_ms,
+    protocol_upgrade::{ProtocolUpgradeTx, ProtocolUpgradeTxCommonData},
+    Address, Execute, PROTOCOL_UPGRADE_TX_TYPE, U256,
+};
 
-pub fn get_calldata(system_contracts: Vec<(Address, H256)>) -> anyhow::Result<Vec<u8>> {
-    let encoded_deployments: Vec<_> = system_contracts
-        .into_iter()
-        .map(|(address, bytecode_hash)| {
-            Token::Tuple(vec![
-                Token::FixedBytes(bytecode_hash.as_bytes().to_vec()),
-                Token::Address(address),
-                Token::Bool(false),
-                Token::Uint(U256::zero()),
-                Token::Bytes(vec![]),
-            ])
-        })
-        .collect();
+const GAS_LIMIT: u64 = 72_000_000;
+const GAS_PER_PUB_DATA_BYTE_LIMIT: u64 = 800;
 
-    Ok(deployer_contract()
-        .function("forceDeployOnAddresses")?
-        .encode_input(&[Token::Array(encoded_deployments)])?)
+#[derive(Debug, Clone)]
+pub struct ViaProtocolUpgrade {}
+
+impl ViaProtocolUpgrade {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn create_protocol_upgrade_tx(
+        &self,
+        version: ProtocolSemanticVersion,
+        system_contracts: Vec<(Address, H256)>,
+    ) -> anyhow::Result<ProtocolUpgradeTx> {
+        let canonical_tx_hash =
+            self.get_canonical_tx_hash(version.clone(), system_contracts.clone())?;
+
+        let tx = ProtocolUpgradeTx {
+            execute: Execute {
+                contract_address: CONTRACT_DEPLOYER_ADDRESS,
+                calldata: self.get_calldata(system_contracts)?,
+                value: U256::zero(),
+                factory_deps: vec![],
+            },
+            common_data: ProtocolUpgradeTxCommonData {
+                sender: CONTRACT_FORCE_DEPLOYER_ADDRESS,
+                upgrade_id: version.minor,
+                max_fee_per_gas: U256::zero(),
+                gas_limit: U256::from(GAS_LIMIT),
+                gas_per_pubdata_limit: U256::from(GAS_PER_PUB_DATA_BYTE_LIMIT),
+                eth_block: 0,
+                canonical_tx_hash,
+                to_mint: U256::zero(),
+                refund_recipient: Address::zero(),
+            },
+            received_timestamp_ms: unix_timestamp_ms(),
+        };
+
+        Ok(tx)
+    }
+
+    pub fn get_canonical_tx_hash(
+        &self,
+        version: ProtocolSemanticVersion,
+        system_contracts: Vec<(Address, H256)>,
+    ) -> anyhow::Result<H256> {
+        let l2_transaction = L2CanonicalTransaction {
+            tx_type: PROTOCOL_UPGRADE_TX_TYPE.into(),
+            from: U256::from_big_endian(&CONTRACT_FORCE_DEPLOYER_ADDRESS.0),
+            to: U256::from_big_endian(&CONTRACT_DEPLOYER_ADDRESS.0),
+            gas_limit: U256::from(GAS_LIMIT),
+            gas_per_pubdata_byte_limit: U256::from(GAS_PER_PUB_DATA_BYTE_LIMIT),
+            max_fee_per_gas: U256::zero(),
+            max_priority_fee_per_gas: U256::zero(),
+            paymaster: U256::zero(),
+            nonce: U256::from(version.minor as u64),
+            value: U256::zero(),
+            reserved: [U256::zero(), U256::zero(), U256::zero(), U256::zero()],
+            data: self.get_calldata(system_contracts.clone())?,
+            signature: vec![],
+            factory_deps: vec![],
+            paymaster_input: vec![],
+            reserved_dynamic: vec![],
+        };
+
+        Ok(l2_transaction.hash())
+    }
+
+    fn get_calldata(&self, system_contracts: Vec<(Address, H256)>) -> anyhow::Result<Vec<u8>> {
+        let encoded_deployments: Vec<_> = system_contracts
+            .into_iter()
+            .map(|(address, bytecode_hash)| {
+                Token::Tuple(vec![
+                    Token::FixedBytes(bytecode_hash.as_bytes().to_vec()),
+                    Token::Address(address),
+                    Token::Bool(false),
+                    Token::Uint(U256::zero()),
+                    Token::Bytes(vec![]),
+                ])
+            })
+            .collect();
+
+        Ok(deployer_contract()
+            .function("forceDeployOnAddresses")?
+            .encode_input(&[Token::Array(encoded_deployments)])?)
+    }
 }

--- a/core/lib/types/src/via_protocol_upgrade.rs
+++ b/core/lib/types/src/via_protocol_upgrade.rs
@@ -13,21 +13,16 @@ use crate::{
 const GAS_LIMIT: u64 = 72_000_000;
 const GAS_PER_PUB_DATA_BYTE_LIMIT: u64 = 800;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ViaProtocolUpgrade {}
 
 impl ViaProtocolUpgrade {
-    pub fn new() -> Self {
-        Self {}
-    }
-
     pub fn create_protocol_upgrade_tx(
         &self,
         version: ProtocolSemanticVersion,
         system_contracts: Vec<(Address, H256)>,
     ) -> anyhow::Result<ProtocolUpgradeTx> {
-        let canonical_tx_hash =
-            self.get_canonical_tx_hash(version.clone(), system_contracts.clone())?;
+        let canonical_tx_hash = self.get_canonical_tx_hash(version, system_contracts.clone())?;
 
         let tx = ProtocolUpgradeTx {
             execute: Execute {

--- a/core/lib/via_btc_client/Cargo.toml
+++ b/core/lib/via_btc_client/Cargo.toml
@@ -83,3 +83,7 @@ path = "examples/deposit_opreturn.rs"
 [[example]]
 name = "upgrade_system_contracts"
 path = "examples/upgrade_system_contracts.rs"
+
+[[example]]
+name = "upgrade_inscription_parsing"
+path = "examples/upgrade_inscription_parsing.rs"

--- a/core/lib/via_btc_client/examples/upgrade_inscription_parsing.rs
+++ b/core/lib/via_btc_client/examples/upgrade_inscription_parsing.rs
@@ -1,0 +1,54 @@
+use std::{env, str::FromStr, sync::Arc};
+
+use anyhow::{Context, Result};
+use bitcoin::Txid;
+use tracing::info;
+use via_btc_client::{
+    client::BitcoinClient,
+    indexer::MessageParser,
+    inscriber::Inscriber,
+    traits::BitcoinOps,
+    types::{
+        BitcoinNetwork, InscriptionMessage, NodeAuth, TransactionWithMetadata,
+        ValidatorAttestationInput, Vote,
+    },
+};
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
+
+const RPC_URL: &str = "http://0.0.0.0:18443";
+const RPC_USERNAME: &str = "rpcuser";
+const RPC_PASSWORD: &str = "rpcpassword";
+const NETWORK: BitcoinNetwork = BitcoinNetwork::Regtest;
+const TIMEOUT: u64 = 5;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let auth = NodeAuth::UserPass(RPC_USERNAME.to_string(), RPC_PASSWORD.to_string());
+    let config = ViaBtcClientConfig {
+        network: NETWORK.to_string(),
+        external_apis: vec![],
+        fee_strategies: vec![],
+        use_rpc_for_fee_rate: None,
+    };
+
+    let client = Arc::new(BitcoinClient::new(RPC_URL, auth, config)?);
+
+    let txid = Txid::from_str("ca3d433c31b5e427b062d60acd3a0b5f8db6793c1aa0c3fab97eec015c72c0f6")?;
+    let mut parser = MessageParser::new(NETWORK);
+    let tx = client.get_transaction(&txid).await?;
+    let data = parser.parse_protocol_upgrade_transaction(
+        &TransactionWithMetadata {
+            tx,
+            output_vout: None,
+            tx_index: 0,
+        },
+        0,
+    );
+    println!("{:?}", data);
+
+    Ok(())
+}

--- a/core/lib/via_btc_client/examples/upgrade_system_contracts.rs
+++ b/core/lib/via_btc_client/examples/upgrade_system_contracts.rs
@@ -6,7 +6,7 @@ use via_btc_client::{
     client::BitcoinClient,
     indexer::MessageParser,
     inscriber::Inscriber,
-    types::{BitcoinNetwork, InscriptionMessage, NodeAuth, SystemContractUpgradeInput},
+    types::{BitcoinNetwork, InscriptionMessage, NodeAuth, SystemContractUpgradeProposalInput},
 };
 use zksync_basic_types::H256;
 use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
     .await?;
 
     // System contracts Upgrade message
-    let input = SystemContractUpgradeInput {
+    let input = SystemContractUpgradeProposalInput {
         version,
         bootloader_code_hash,
         default_account_code_hash,
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
         system_contracts,
     };
     let system_contract_upgrade_info = inscriber
-        .inscribe(InscriptionMessage::SystemContractUpgrade(input))
+        .inscribe(InscriptionMessage::SystemContractUpgradeProposal(input))
         .await?;
     info!(
         "System contract upgrade info tx sent: {:?}",

--- a/core/lib/via_btc_client/src/indexer/mod.rs
+++ b/core/lib/via_btc_client/src/indexer/mod.rs
@@ -486,13 +486,11 @@ impl BitcoinInscriptionIndexer {
                     .require_network(network)
                     .unwrap();
 
-                if &governance_address == p2wpkh_address {
-                    state.bridge_address = Some(bridge_address);
-                    state.starting_block_number = sb.input.start_block_height;
-                    state.bootloader_hash = Some(sb.input.bootloader_hash);
-                    state.abstract_account_hash = Some(sb.input.abstract_account_hash);
-                    state.proposed_governance = Some(governance_address);
-                }
+                state.bridge_address = Some(bridge_address);
+                state.starting_block_number = sb.input.start_block_height;
+                state.bootloader_hash = Some(sb.input.bootloader_hash);
+                state.abstract_account_hash = Some(sb.input.abstract_account_hash);
+                state.proposed_governance = Some(governance_address);
             }
             FullInscriptionMessage::ProposeSequencer(ps) => {
                 debug!("Processing ProposeSequencer message");
@@ -500,15 +498,13 @@ impl BitcoinInscriptionIndexer {
                     .common
                     .p2wpkh_address
                     .expect("ProposeSequencer message must have a p2wpkh address");
-                if state.proposed_governance == Some(p2wpkh_address) {
-                    let sequencer_address = ps
-                        .input
-                        .sequencer_new_p2wpkh_address
-                        .require_network(network)
-                        .unwrap();
-                    state.proposed_sequencer = Some(sequencer_address);
-                    state.proposed_sequencer_txid = Some(txid);
-                }
+                let sequencer_address = ps
+                    .input
+                    .sequencer_new_p2wpkh_address
+                    .require_network(network)
+                    .unwrap();
+                state.proposed_sequencer = Some(sequencer_address);
+                state.proposed_sequencer_txid = Some(txid);
             }
             FullInscriptionMessage::ValidatorAttestation(va) => {
                 let p2wpkh_address = va

--- a/core/lib/via_btc_client/src/indexer/mod.rs
+++ b/core/lib/via_btc_client/src/indexer/mod.rs
@@ -456,11 +456,6 @@ impl BitcoinInscriptionIndexer {
         match message {
             FullInscriptionMessage::SystemBootstrapping(sb) => {
                 debug!("Processing SystemBootstrapping message");
-                let p2wpkh_address = sb
-                    .common
-                    .p2wpkh_address
-                    .as_ref()
-                    .expect("SystemBootstrapping message must have a p2wpkh address");
 
                 // convert the verifier addresses to the correct network
                 // since the bootstrap message should run on the bootstrapping phase of sequencer
@@ -494,10 +489,6 @@ impl BitcoinInscriptionIndexer {
             }
             FullInscriptionMessage::ProposeSequencer(ps) => {
                 debug!("Processing ProposeSequencer message");
-                let p2wpkh_address = ps
-                    .common
-                    .p2wpkh_address
-                    .expect("ProposeSequencer message must have a p2wpkh address");
                 let sequencer_address = ps
                     .input
                     .sequencer_new_p2wpkh_address

--- a/core/lib/via_btc_client/src/inscriber/script_builder.rs
+++ b/core/lib/via_btc_client/src/inscriber/script_builder.rs
@@ -137,7 +137,7 @@ impl InscriptionData {
             types::InscriptionMessage::L1ToL2Message(input) => {
                 Self::build_l1_to_l2_message_script(basic_script, input)
             }
-            types::InscriptionMessage::SystemContractUpgrade(input) => {
+            types::InscriptionMessage::SystemContractUpgradeProposal(input) => {
                 Self::build_system_contract_upgrade_message_script(basic_script, input)
             }
         };
@@ -312,7 +312,7 @@ impl InscriptionData {
     )]
     fn build_system_contract_upgrade_message_script(
         basic_script: ScriptBuilder,
-        input: &types::SystemContractUpgradeInput,
+        input: &types::SystemContractUpgradeProposalInput,
     ) -> ScriptBuilder {
         debug!("Building SystemContract script");
 

--- a/core/lib/via_btc_client/src/types.rs
+++ b/core/lib/via_btc_client/src/types.rs
@@ -188,7 +188,6 @@ pub enum InscriptionMessage {
     ProposeSequencer(ProposeSequencerInput),
     L1ToL2Message(L1ToL2MessageInput),
     SystemContractUpgradeProposal(SystemContractUpgradeProposalInput),
-    SystemContractUpgrade(SystemContractUpgradeInput),
 }
 
 impl Serializable for InscriptionMessage {

--- a/core/lib/via_btc_client/src/types.rs
+++ b/core/lib/via_btc_client/src/types.rs
@@ -96,7 +96,7 @@ pub struct SystemBootstrapping {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SystemContractUpgradeInput {
+pub struct SystemContractUpgradeProposalInput {
     /// New protocol version ID.
     pub version: ProtocolSemanticVersion,
     /// New bootloader code hash.
@@ -107,6 +107,20 @@ pub struct SystemContractUpgradeInput {
     pub recursion_scheduler_level_vk_hash: H256,
     /// The L2 transaction calldata.
     pub system_contracts: Vec<(EVMAddress, H256)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SystemContractUpgradeProposal {
+    pub common: CommonFields,
+    pub input: SystemContractUpgradeProposalInput,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SystemContractUpgradeInput {
+    /// The input utxos.
+    pub inputs: Vec<OutPoint>,
+    /// The proposal tx_id.
+    pub proposal_tx_id: Txid,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -173,6 +187,7 @@ pub enum InscriptionMessage {
     SystemBootstrapping(SystemBootstrappingInput),
     ProposeSequencer(ProposeSequencerInput),
     L1ToL2Message(L1ToL2MessageInput),
+    SystemContractUpgradeProposal(SystemContractUpgradeProposalInput),
     SystemContractUpgrade(SystemContractUpgradeInput),
 }
 
@@ -209,6 +224,7 @@ pub enum FullInscriptionMessage {
     SystemBootstrapping(SystemBootstrapping),
     ProposeSequencer(ProposeSequencer),
     L1ToL2Message(L1ToL2Message),
+    SystemContractUpgradeProposal(SystemContractUpgradeProposal),
     SystemContractUpgrade(SystemContractUpgrade),
     BridgeWithdrawal(BridgeWithdrawal),
 }
@@ -238,7 +254,7 @@ lazy_static! {
         PushBytesBuf::from(b"ProofDAReferenceMessage");
     pub static ref L1_TO_L2_MSG: PushBytesBuf = PushBytesBuf::from(b"L1ToL2Message");
     pub static ref SYSTEM_CONTRACT_UPGRADE_MSG: PushBytesBuf =
-        PushBytesBuf::from(b"SystemContractUpgrade");
+        PushBytesBuf::from(b"SystemContractUpgradeProposal");
 }
 pub(crate) const VIA_INSCRIPTION_PROTOCOL: &str = "via_inscription_protocol";
 

--- a/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_btc_watch.rs
@@ -69,7 +69,7 @@ impl WiringLayer for BtcWatchLayer {
         let main_pool = input.master_pool.get().await?;
         let client = input.btc_client_resource.btc_sender.unwrap();
         let indexer = BitcoinInscriptionIndexer::new(
-            client,
+            client.clone(),
             self.via_btc_client.clone(),
             self.via_genesis_config.bootstrap_txids()?,
         )
@@ -89,6 +89,7 @@ impl WiringLayer for BtcWatchLayer {
         let btc_watch = BtcWatch::new(
             self.btc_watch_config,
             indexer,
+            client,
             main_pool,
             self.via_genesis_config.bridge_address()?,
             self.via_genesis_config.zk_agreement_threshold,

--- a/core/node/node_framework/src/implementations/layers/via_verifier_btc_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier_btc_watch.rs
@@ -70,7 +70,7 @@ impl WiringLayer for VerifierBtcWatchLayer {
         let main_pool = input.master_pool.get().await?;
         let client = input.btc_client_resource.btc_sender.unwrap();
         let indexer = BitcoinInscriptionIndexer::new(
-            client,
+            client.clone(),
             self.via_btc_client.clone(),
             self.via_genesis_config.bootstrap_txids()?,
         )
@@ -92,6 +92,7 @@ impl WiringLayer for VerifierBtcWatchLayer {
         let btc_watch = VerifierBtcWatch::new(
             self.btc_watch_config,
             indexer,
+            client,
             main_pool,
             self.via_genesis_config.zk_agreement_threshold,
         )

--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -1,11 +1,15 @@
 mod message_processors;
 mod metrics;
 
+use std::sync::Arc;
+
 use message_processors::GovernanceUpgradesEventProcessor;
 use tokio::sync::watch;
 // re-export via_btc_client types
 pub use via_btc_client::types::BitcoinNetwork;
-use via_btc_client::{indexer::BitcoinInscriptionIndexer, types::BitcoinAddress};
+use via_btc_client::{
+    client::BitcoinClient, indexer::BitcoinInscriptionIndexer, types::BitcoinAddress,
+};
 use zksync_config::{configs::via_btc_watch::L1_BLOCKS_CHUNK, ViaBtcWatchConfig};
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 
@@ -32,6 +36,7 @@ impl BtcWatch {
     pub async fn new(
         btc_watch_config: ViaBtcWatchConfig,
         indexer: BitcoinInscriptionIndexer,
+        btc_client: Arc<BitcoinClient>,
         pool: ConnectionPool<Core>,
         bridge_address: BitcoinAddress,
         zk_agreement_threshold: f64,
@@ -57,6 +62,7 @@ impl BtcWatch {
         // Only build message processors that match the actor role:
         let message_processors: Vec<Box<dyn MessageProcessor>> = vec![
             Box::new(GovernanceUpgradesEventProcessor::new(
+                btc_client,
                 protocol_semantic_version,
             )),
             Box::new(L1ToL2MessageProcessor::new(bridge_address)),

--- a/core/node/via_btc_watch/src/message_processors/governance_upgrade.rs
+++ b/core/node/via_btc_watch/src/message_processors/governance_upgrade.rs
@@ -41,7 +41,7 @@ impl GovernanceUpgradesEventProcessor {
             last_seen_protocol_version,
             btc_client,
             message_parser,
-            upgrade: ViaProtocolUpgrade::new(),
+            upgrade: ViaProtocolUpgrade::default(),
         }
     }
 }
@@ -157,14 +157,7 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
 
                 let new_version =
                     latest_version.apply_upgrade(upgrade, Some(recursion_scheduler_level_vk_hash));
-                // if new_version.version.minor == latest_semantic_version.minor {
-                //     // Only verification parameters may change if only patch is bumped.
-                //     assert_eq!(
-                //         new_version.base_system_contracts_hashes,
-                //         latest_version.base_system_contracts_hashes
-                //     );
-                //     assert!(new_version.tx.is_none());
-                // }
+
                 storage
                     .protocol_versions_dal()
                     .save_protocol_version_with_tx(&new_version)
@@ -180,41 +173,3 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         Ok(())
     }
 }
-
-// impl GovernanceUpgradesEventProcessor {
-//     fn create_l1_tx_from_message(
-//         &self,
-//         msg: &SystemContractUpgradeProposal,
-//     ) -> Result<ProtocolUpgradeTx, MessageProcessorError> {
-//         let l2_transaction = self
-//             .upgrade
-//             .get_canonical_tx_hash(msg.input.version, msg.input.system_contracts.clone())?;
-
-//         let tx = ProtocolUpgradeTx {
-//             execute: Execute {
-//                 contract_address: CONTRACT_DEPLOYER_ADDRESS,
-//                 calldata: calldata.clone(),
-//                 value: U256::zero(),
-//                 factory_deps: vec![],
-//             },
-//             common_data: ProtocolUpgradeTxCommonData {
-//                 sender: CONTRACT_FORCE_DEPLOYER_ADDRESS,
-//                 upgrade_id: msg.input.version.minor,
-//                 max_fee_per_gas: U256::zero(),
-//                 gas_limit,
-//                 gas_per_pubdata_limit: gas_per_pubdata_byte_limit,
-//                 eth_block: 0,
-//                 canonical_tx_hash: l2_transaction.hash(),
-//                 to_mint: U256::zero(),
-//                 refund_recipient: Address::zero(),
-//             },
-//             received_timestamp_ms: unix_timestamp_ms(),
-//         };
-
-//         Ok(tx)
-//     }
-// }
-
-// fn address_to_u256(address: &Address) -> U256 {
-//     U256::from_big_endian(&address.0)
-// }

--- a/core/node/via_btc_watch/src/message_processors/governance_upgrade.rs
+++ b/core/node/via_btc_watch/src/message_processors/governance_upgrade.rs
@@ -1,17 +1,16 @@
+use std::sync::Arc;
+
 use anyhow::Context as _;
 use via_btc_client::{
-    indexer::BitcoinInscriptionIndexer,
-    types::{FullInscriptionMessage, SystemContractUpgrade},
+    client::BitcoinClient,
+    indexer::{BitcoinInscriptionIndexer, MessageParser},
+    traits::BitcoinOps,
+    types::FullInscriptionMessage,
 };
 use zksync_dal::{Connection, Core, CoreDal, DalError};
 use zksync_types::{
-    abi::L2CanonicalTransaction,
-    helpers::unix_timestamp_ms,
-    protocol_upgrade::{ProtocolUpgradeTx, ProtocolUpgradeTxCommonData},
-    protocol_version::ProtocolSemanticVersion,
-    via_protocol_upgrade::get_calldata,
-    Address, Execute, ProtocolUpgrade, CONTRACT_DEPLOYER_ADDRESS, CONTRACT_FORCE_DEPLOYER_ADDRESS,
-    PROTOCOL_UPGRADE_TX_TYPE, U256,
+    protocol_version::ProtocolSemanticVersion, via_protocol_upgrade::ViaProtocolUpgrade,
+    ProtocolUpgrade,
 };
 
 use crate::{
@@ -24,12 +23,25 @@ use crate::{
 pub struct GovernanceUpgradesEventProcessor {
     /// Last protocol version seen. Used to skip events for already known upgrade proposals.
     last_seen_protocol_version: ProtocolSemanticVersion,
+    /// BTC client
+    btc_client: Arc<BitcoinClient>,
+    /// Message parser
+    message_parser: MessageParser,
+    /// upgrade proposal
+    upgrade: ViaProtocolUpgrade,
 }
 
 impl GovernanceUpgradesEventProcessor {
-    pub fn new(last_seen_protocol_version: ProtocolSemanticVersion) -> Self {
+    pub fn new(
+        btc_client: Arc<BitcoinClient>,
+        last_seen_protocol_version: ProtocolSemanticVersion,
+    ) -> Self {
+        let message_parser = MessageParser::new(btc_client.get_network());
         Self {
             last_seen_protocol_version,
+            btc_client,
+            message_parser,
+            upgrade: ViaProtocolUpgrade::new(),
         }
     }
 }
@@ -45,40 +57,75 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         for msg in msgs {
             if let FullInscriptionMessage::SystemContractUpgrade(system_contract_upgrade_msg) = &msg
             {
-                // Ignore if old version
-                if system_contract_upgrade_msg.input.version <= self.last_seen_protocol_version {
-                    tracing::info!(
-                        "Upgrade transaction with version {} already processed, skipping",
-                        system_contract_upgrade_msg.input.version
-                    );
-                    continue;
-                }
+                let proposal_tx = self
+                    .btc_client
+                    .get_transaction(&system_contract_upgrade_msg.input.proposal_tx_id)
+                    .await
+                    .map_err(|err| {
+                        MessageProcessorError::Internal(anyhow::anyhow!(
+                            "Failed to fetch protocol upgrade transaction: {}, error {}",
+                            system_contract_upgrade_msg.input.proposal_tx_id,
+                            err
+                        ))
+                    })?;
 
-                tracing::info!(
-                    "Received upgrades with versions: {:?}",
-                    system_contract_upgrade_msg.input.version
+                let messages = self.message_parser.parse_system_transaction(
+                    &proposal_tx,
+                    system_contract_upgrade_msg.common.block_height,
                 );
-                let tx = self.create_l1_tx_from_message(system_contract_upgrade_msg)?;
 
-                let upgrade = ProtocolUpgrade {
-                    version: system_contract_upgrade_msg.input.version,
-                    bootloader_code_hash: Some(
-                        system_contract_upgrade_msg.input.bootloader_code_hash,
-                    ),
-                    default_account_code_hash: Some(
-                        system_contract_upgrade_msg.input.default_account_code_hash,
-                    ),
-                    tx: Some(tx),
-                    timestamp: 0,
-                    verifier_address: None,
-                    verifier_params: None,
-                };
-                upgrades.push((
-                    upgrade,
-                    system_contract_upgrade_msg
-                        .input
-                        .recursion_scheduler_level_vk_hash,
-                ));
+                for message in messages {
+                    match message {
+                        FullInscriptionMessage::SystemContractUpgradeProposal(
+                            system_contract_upgrade_proposal_msg,
+                        ) => {
+                            // Ignore if old version
+                            if system_contract_upgrade_proposal_msg.input.version
+                                <= self.last_seen_protocol_version
+                            {
+                                tracing::info!(
+                                    "Upgrade transaction with version {} already processed, skipping",
+                                    system_contract_upgrade_proposal_msg.input.version
+                                );
+                                continue;
+                            }
+
+                            tracing::info!(
+                                "Received upgrades with versions: {:?}",
+                                system_contract_upgrade_proposal_msg.input.version
+                            );
+                            let tx = self.upgrade.create_protocol_upgrade_tx(
+                                system_contract_upgrade_proposal_msg.input.version,
+                                system_contract_upgrade_proposal_msg.input.system_contracts,
+                            )?;
+
+                            let upgrade = ProtocolUpgrade {
+                                version: system_contract_upgrade_proposal_msg.input.version,
+                                bootloader_code_hash: Some(
+                                    system_contract_upgrade_proposal_msg
+                                        .input
+                                        .bootloader_code_hash,
+                                ),
+                                default_account_code_hash: Some(
+                                    system_contract_upgrade_proposal_msg
+                                        .input
+                                        .default_account_code_hash,
+                                ),
+                                tx: Some(tx),
+                                timestamp: 0,
+                                verifier_address: None,
+                                verifier_params: None,
+                            };
+                            upgrades.push((
+                                upgrade,
+                                system_contract_upgrade_proposal_msg
+                                    .input
+                                    .recursion_scheduler_level_vk_hash,
+                            ));
+                        }
+                        _ => (),
+                    }
+                }
             }
         }
 
@@ -110,14 +157,14 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
 
                 let new_version =
                     latest_version.apply_upgrade(upgrade, Some(recursion_scheduler_level_vk_hash));
-                if new_version.version.minor == latest_semantic_version.minor {
-                    // Only verification parameters may change if only patch is bumped.
-                    assert_eq!(
-                        new_version.base_system_contracts_hashes,
-                        latest_version.base_system_contracts_hashes
-                    );
-                    assert!(new_version.tx.is_none());
-                }
+                // if new_version.version.minor == latest_semantic_version.minor {
+                //     // Only verification parameters may change if only patch is bumped.
+                //     assert_eq!(
+                //         new_version.base_system_contracts_hashes,
+                //         latest_version.base_system_contracts_hashes
+                //     );
+                //     assert!(new_version.tx.is_none());
+                // }
                 storage
                     .protocol_versions_dal()
                     .save_protocol_version_with_tx(&new_version)
@@ -134,59 +181,40 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
     }
 }
 
-impl GovernanceUpgradesEventProcessor {
-    fn create_l1_tx_from_message(
-        &self,
-        msg: &SystemContractUpgrade,
-    ) -> Result<ProtocolUpgradeTx, MessageProcessorError> {
-        let gas_limit = U256::from(72_000_000u64);
-        let gas_per_pubdata_byte_limit = U256::from(800u64);
-        let calldata = get_calldata(msg.input.system_contracts.clone())?;
+// impl GovernanceUpgradesEventProcessor {
+//     fn create_l1_tx_from_message(
+//         &self,
+//         msg: &SystemContractUpgradeProposal,
+//     ) -> Result<ProtocolUpgradeTx, MessageProcessorError> {
+//         let l2_transaction = self
+//             .upgrade
+//             .get_canonical_tx_hash(msg.input.version, msg.input.system_contracts.clone())?;
 
-        let l2_transaction = L2CanonicalTransaction {
-            tx_type: PROTOCOL_UPGRADE_TX_TYPE.into(),
-            from: address_to_u256(&CONTRACT_FORCE_DEPLOYER_ADDRESS),
-            to: address_to_u256(&CONTRACT_DEPLOYER_ADDRESS),
-            gas_limit,
-            gas_per_pubdata_byte_limit,
-            max_fee_per_gas: U256::zero(),
-            max_priority_fee_per_gas: U256::zero(),
-            paymaster: U256::zero(),
-            nonce: U256::from(msg.input.version.minor as u64),
-            value: U256::zero(),
-            reserved: [U256::zero(), U256::zero(), U256::zero(), U256::zero()],
-            data: calldata.clone(),
-            signature: vec![],
-            factory_deps: vec![],
-            paymaster_input: vec![],
-            reserved_dynamic: vec![],
-        };
+//         let tx = ProtocolUpgradeTx {
+//             execute: Execute {
+//                 contract_address: CONTRACT_DEPLOYER_ADDRESS,
+//                 calldata: calldata.clone(),
+//                 value: U256::zero(),
+//                 factory_deps: vec![],
+//             },
+//             common_data: ProtocolUpgradeTxCommonData {
+//                 sender: CONTRACT_FORCE_DEPLOYER_ADDRESS,
+//                 upgrade_id: msg.input.version.minor,
+//                 max_fee_per_gas: U256::zero(),
+//                 gas_limit,
+//                 gas_per_pubdata_limit: gas_per_pubdata_byte_limit,
+//                 eth_block: 0,
+//                 canonical_tx_hash: l2_transaction.hash(),
+//                 to_mint: U256::zero(),
+//                 refund_recipient: Address::zero(),
+//             },
+//             received_timestamp_ms: unix_timestamp_ms(),
+//         };
 
-        let tx = ProtocolUpgradeTx {
-            execute: Execute {
-                contract_address: CONTRACT_DEPLOYER_ADDRESS,
-                calldata: calldata.clone(),
-                value: U256::zero(),
-                factory_deps: vec![],
-            },
-            common_data: ProtocolUpgradeTxCommonData {
-                sender: CONTRACT_FORCE_DEPLOYER_ADDRESS,
-                upgrade_id: msg.input.version.minor,
-                max_fee_per_gas: U256::zero(),
-                gas_limit,
-                gas_per_pubdata_limit: gas_per_pubdata_byte_limit,
-                eth_block: 0,
-                canonical_tx_hash: l2_transaction.hash(),
-                to_mint: U256::zero(),
-                refund_recipient: Address::zero(),
-            },
-            received_timestamp_ms: unix_timestamp_ms(),
-        };
+//         Ok(tx)
+//     }
+// }
 
-        Ok(tx)
-    }
-}
-
-fn address_to_u256(address: &Address) -> U256 {
-    U256::from_big_endian(&address.0)
-}
+// fn address_to_u256(address: &Address) -> U256 {
+//     U256::from_big_endian(&address.0)
+// }

--- a/core/node/via_btc_watch/src/message_processors/votable.rs
+++ b/core/node/via_btc_watch/src/message_processors/votable.rs
@@ -101,20 +101,7 @@ impl MessageProcessor for VotableMessageProcessor {
                             .map_err(|e| MessageProcessorError::DatabaseError(e.to_string()))?;
                     }
                 }
-
-                // bootstrapping phase is already covered
-                FullInscriptionMessage::SystemContractUpgrade(_)
-                | FullInscriptionMessage::ProposeSequencer(_)
-                | FullInscriptionMessage::SystemBootstrapping(_) => {
-                    // do nothing
-                }
-                // Non-votable messages like L1BatchDAReference or L1ToL2Message are ignored by this processor
-                FullInscriptionMessage::L1ToL2Message(_)
-                | FullInscriptionMessage::BridgeWithdrawal(_)
-                | FullInscriptionMessage::ProofDAReference(_)
-                | FullInscriptionMessage::L1BatchDAReference(_) => {
-                    // do nothing
-                }
+                _ => (),
             }
         }
         Ok(())

--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -13,6 +13,7 @@ services:
       - -printtoconsole
       - -dustrelayfee=0.0
       - -minrelaytxfee=0
+      - -acceptnonstdtxn=1
     ports:
       - '18443:18443'  # RPC port
       - '18444:18444'  # P2P port
@@ -76,6 +77,10 @@ services:
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${VERIFIER_2_ADDRESS} 300
         echo "Sent 300 BTC to VERIFIER_2_ADDRESS: $${VERIFIER_2_ADDRESS}"
 
+        echo "GOV_ADDRESS: $${GOV_ADDRESS}"
+        bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${GOV_ADDRESS} 1
+        echo "Sent 1 BTC to GOV_ADDRESS: $${GOV_ADDRESS}"
+
         echo "VERIFIER_3_ADDRESS: $${VERIFIER_3_ADDRESS}"
         bitcoin-cli $${RPC_ARGS} -rpcwallet=Alice sendtoaddress $${VERIFIER_3_ADDRESS} 300
         echo "Sent 300 BTC to VERIFIER_3_ADDRESS: $${VERIFIER_3_ADDRESS}"
@@ -128,6 +133,7 @@ services:
       - VERIFIER_3_ADDRESS=bcrt1q23lgaa90s85jvtl6dsrkvn0g949cwjkwuyzwdm
       - BRIDGE_TEST_ADDRESS=bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg
       - BRIDGE_TEST_ADDRESS2=bcrt1pm4rre0xv8ryr9lr5lrnzx5tpyk0xr43kfw3aja68c0845vsu5wus3u40fp
+      - GOV_ADDRESS=bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm
       - VIA_LOADNEXT_TEST_ADDRESS=bcrt1q8tuqv885kehnzucdfskuw6mrhxcj7cjs4gfk5z
       - RPC_ARGS=-chain=regtest -rpcconnect=bitcoind -rpcwait -rpcuser=rpcuser -rpcpassword=rpcpassword
       - SLEEP_SECONDS=1

--- a/docs/via_guides/upgrade.md
+++ b/docs/via_guides/upgrade.md
@@ -128,7 +128,7 @@ via multisig broadcast-tx \
 ```sh
 cd via-playground && source .env.example && npx hardhat balance --address 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049 && cd ..
 ```
-4. Switch the submodule to `branch = fix/via-update-withdrawal-event`, this allows us to use the protcol version 26.
+4. Delete the submodule to `branch` key to use the `main` branch, this allows us to use the protocol version 26.
 5. Build git submodule using
 ```sh
 git submodule update --remote --recursive
@@ -161,7 +161,8 @@ yarn start l2-transaction upgrade-system-contracts --environment devnet-2 --priv
 11. Copy the `tx_id` of the proposal created in the previous step and follow this doc to create a multisig [GOV transaction](#How-to-execute-an-upgrade-proposal).
 
 12. When the Gov tx is created and minted in a block, execute another deposit 1 BTC, this because a batch can not include only an upgrade transaction.
-11. Check the database, new protocol version should be 26, the last batch should be processed with the new bootloader
+13. Deposit 1 BTC. 
+14. Check the database, new protocol version should be 26, the last batch should be processed with the new bootloader
 hash and version 26.
 ```sql
 -- You should see that the last miniblocks where processed using the version 26
@@ -170,9 +171,10 @@ select protocol_version from miniblocks order by number DESC
 -- The last batches (check number), should have different bootloader_code_hash and default_aa_code_hash.
 select number, encode(bootloader_code_hash, 'hex'), encode(default_aa_code_hash, 'hex') from l1_batches order by number DESC
 ```
-12. In another terminal starts the coordinator (by default version 26 ). You will notice that all the batches before the one includes the upgrade are processing with VK (verifying key version 25) and after upgrade VK-26
+15. In another terminal starts the coordinator (by default version 26 ). You will notice that all the batches before the one includes the upgrade are processing with VK (verifying key version 25) and after upgrade VK-26
 
-13. Start a verifier with the (change the version to 25 here)
-14. The coordinator will reject this verifier as the protocol version used is 25 and it requires 26
-15. Start the verifier and restart it with version 26. The withdrawal is processed
-16. Done
+16. Start a verifier with the (change the version to 25 [const SEQUENCER_MINOR: ProtocolVersionId = ProtocolVersionId::Version26;](https://github.com/vianetwork/via-core/blob/22bbfd3e5dae6f01a5cbecc629a748798e66cd16/via_verifier/lib/via_verifier_types/src/protocol_version.rs#L6))
+17. The coordinator will reject this verifier as the protocol version used is 25 and it requires 26
+18. Start the verifier and restart it with version 26. The withdrawal is processed
+19. Execute a withdrawal.
+20. Done :)

--- a/docs/via_guides/upgrade.md
+++ b/docs/via_guides/upgrade.md
@@ -1,0 +1,121 @@
+# VIA upgrade flow
+
+The VIA upgrade flow is split in 2 main parts:
+1. The upgrade proposal inscription.
+2. The Governance proposal execution inscription.
+
+## How to create an upgrade proposal?
+Creating a proposal can be done by any P2PKH wallet. The process should inscribe the data using the btc client inscriber ProtocolUpgradeProposal inscription.
+
+1. Build the system contracts, `cd contracts` && `yarn sc build` && `cd ..`
+2. Create a new upgrade config, `cd infrastructure/via-protocol-upgrade` and `yarn start upgrades create via-network --protocol-version <new-version>`.
+3. Publish the new system contract for <version>
+```sh
+yarn start system-contracts publish \
+    --private-key <l2-private-key> \
+    --l2rpc http://0.0.0.0:3050 \
+    --environment devnet-2 \
+    --new-protocol-version <version> \
+    --recursion-scheduler-level-vk-hash <hash> \
+    --bootloader \
+    --default-aa \
+    --system-contracts
+```
+
+4. The previous cmd created a new upgrade file at this location `etc/upgrades/1742370950-via-network` with the new system contracts we are going to deploy.
+5. When all the l1_batches are processed execute the next cmd to create an upgrade proposal.
+```sh
+yarn start l2-transaction upgrade-system-contracts --environment devnet-2 --private-key <l1-private-key>
+```
+
+## How to execute an upgrade proposal?
+Use the VIA CLI to create a multisig transaction that execute the proposal stored in `txid`.
+
+For this example we will use those wallets on regtest:
+
+```json
+{
+  "mnemonic": "what same drill eight camp market ill month inform urge february duck",
+  "privateKey": "cQnW8oDqEME4gxJHC4MC9HvJECcF7Ju8oanWdjWLGxDbkfWo7vZa",
+  "address": "bcrt1q08v0vm5w3rftefqutgtwlyslhy35ms8ftuay80",
+  "publicKey": "025b3c069378f860cc4dae864a491e0cd33cc559b9f82fc856d4dcc74d3d763241",
+  "network": "regtest"
+}
+
+{
+  "mnemonic": "beef rigid brick input hint coyote gap earn march affair tissue major",
+  "privateKey": "cVJYEHTzmfdRPoX6fL3vRnZVmqy4D1sWaT5WL9U25oZhQktoeHgo",
+  "address": "bcrt1q50xmdcwlmt8qhwczxptaq2h5cn3zchcrvqd35v",
+  "publicKey": "03c2871e18d4fb503ead90461da747b40df5e28da0fd3e067f3731f1a28da60ddf",
+  "network": "regtest"
+}
+
+{
+  "mnemonic": "fragile loyal suffer fashion about insane expose body siege brother control action",
+  "privateKey": "cPytijNj4VAnczJD5a21bboiPavYDCLmM9AW6cmjUxrDUYnJXQaf",
+  "address": "bcrt1q9l2wcyaquvvxuzxenae75q24yx4uhzhq3mrlfe",
+  "publicKey": "03445c516584d751643442bea558be2c5d77a6c3377e86fe6e78e3b992dd68ac62",
+  "network": "regtest"
+}
+```
+
+1. Compute the multisig wallet with 2 signers as minimum.
+```sh,
+via multisig compute-multisig \
+--pubkeys 025b3c069378f860cc4dae864a491e0cd33cc559b9f82fc856d4dcc74d3d763241,03c2871e18d4fb503ead90461da747b40df5e28da0fd3e067f3731f1a28da60ddf,03445c516584d751643442bea558be2c5d77a6c3377e86fe6e78e3b992dd68ac62 \
+--minimumSigners 2
+```
+A new file is created `upgrade_tx_exec.json`
+
+2. Create an unsigned upgrade transaction. Make sure to select the input you want to use and the `upgradeProposalTxId`.
+To fetch the UTXOs from regtest use this cmd
+```sh
+curl --user rpcuser:rpcpassword \
+  --data-binary '{
+    "jsonrpc": "1.0",
+    "id": "scan_utxo",
+    "method": "scantxoutset",
+    "params": [
+      "start", 
+      [
+        { "desc": "addr(bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm)", "range": 1000 }
+      ]
+    ]
+  }' \
+  -H 'content-type: text/plain;' \
+  http://127.0.0.1:18443/
+```
+
+```sh
+via multisig create-upgrade-tx \
+--inputTxId <tx_id> \
+--inputVout <vout> \
+--inputAmount <amount> \
+--upgradeProposalTxId <upgradeProposalTxId> \
+--fee 500
+```
+
+3. Sign the transaction using the signer-1 `Privatekey`.
+```sh
+via multisig sign-upgrade-tx --privateKey cQnW8oDqEME4gxJHC4MC9HvJECcF7Ju8oanWdjWLGxDbkfWo7vZa
+```
+After signing the tx send the `upgrade_tx_exec.json` to signer-2
+
+
+4. Sign the transaction using the signer-2 `Privatekey`.
+```sh
+via multisig sign-upgrade-tx --privateKey cVJYEHTzmfdRPoX6fL3vRnZVmqy4D1sWaT5WL9U25oZhQktoeHgo
+```
+
+5. The signer-2 finalize the transaction
+```sh
+via multisig finalize-upgrade-tx
+```
+
+6. The signer-2 broadcast the transaction
+```sh
+via multisig broadcast-tx \
+--rpcUrl http://0.0.0.0:18443 \
+--rpcUser rpcuser\
+--rpcPass rpcpassword
+```

--- a/docs/via_guides/upgrade.md
+++ b/docs/via_guides/upgrade.md
@@ -1,15 +1,20 @@
 # VIA upgrade flow
 
 The VIA upgrade flow is split in 2 main parts:
+
 1. The upgrade proposal inscription.
 2. The Governance proposal execution inscription.
 
-## How to create an upgrade proposal?
-Creating a proposal can be done by any P2PKH wallet. The process should inscribe the data using the btc client inscriber ProtocolUpgradeProposal inscription.
+## How to create an upgrade proposal
+
+Creating a proposal can be done by any P2PKH wallet. The process should inscribe the data using the btc client inscriber
+ProtocolUpgradeProposal inscription.
 
 1. Build the system contracts, `cd contracts` && `yarn sc build` && `cd ..`
-2. Create a new upgrade config, `cd infrastructure/via-protocol-upgrade` and `yarn start upgrades create via-network --protocol-version <new-version>`.
+2. Create a new upgrade config, `cd infrastructure/via-protocol-upgrade` and
+   `yarn start upgrades create via-network --protocol-version <new-version>`.
 3. Publish the new system contract for <version>
+
 ```sh
 yarn start system-contracts publish \
     --private-key <l2-private-key> \
@@ -22,13 +27,16 @@ yarn start system-contracts publish \
     --system-contracts
 ```
 
-4. The previous cmd created a new upgrade file at this location `etc/upgrades/1742370950-via-network` with the new system contracts we are going to deploy.
+4. The previous cmd created a new upgrade file at this location `etc/upgrades/1742370950-via-network` with the new
+   system contracts we are going to deploy.
 5. When all the l1_batches are processed execute the next cmd to create an upgrade proposal.
+
 ```sh
 yarn start l2-transaction upgrade-system-contracts --environment devnet-2 --private-key <l1-private-key>
 ```
 
-## How to execute an upgrade proposal?
+## How to execute an upgrade proposal
+
 Use the VIA CLI to create a multisig transaction that execute the proposal stored in `txid`.
 
 For this example we will use those wallets on regtest:
@@ -60,15 +68,18 @@ For this example we will use those wallets on regtest:
 ```
 
 1. Compute the multisig wallet with 2 signers as minimum.
+
 ```sh,
 via multisig compute-multisig \
 --pubkeys 025b3c069378f860cc4dae864a491e0cd33cc559b9f82fc856d4dcc74d3d763241,03c2871e18d4fb503ead90461da747b40df5e28da0fd3e067f3731f1a28da60ddf,03445c516584d751643442bea558be2c5d77a6c3377e86fe6e78e3b992dd68ac62 \
 --minimumSigners 2
 ```
+
 A new file is created `upgrade_tx_exec.json`
 
 2. Create an unsigned upgrade transaction. Make sure to select the input you want to use and the `upgradeProposalTxId`.
-To fetch the UTXOs from regtest use this cmd
+   To fetch the UTXOs from regtest use this cmd
+
 ```sh
 curl --user rpcuser:rpcpassword \
   --data-binary '{
@@ -76,7 +87,7 @@ curl --user rpcuser:rpcpassword \
     "id": "scan_utxo",
     "method": "scantxoutset",
     "params": [
-      "start", 
+      "start",
       [
         { "desc": "addr(bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm)", "range": 1000 }
       ]
@@ -96,23 +107,27 @@ via multisig create-upgrade-tx \
 ```
 
 3. Sign the transaction using the signer-1 `Privatekey`.
+
 ```sh
 via multisig sign-upgrade-tx --privateKey cQnW8oDqEME4gxJHC4MC9HvJECcF7Ju8oanWdjWLGxDbkfWo7vZa
 ```
+
 After signing the tx send the `upgrade_tx_exec.json` to signer-2
 
-
 4. Sign the transaction using the signer-2 `Privatekey`.
+
 ```sh
 via multisig sign-upgrade-tx --privateKey cVJYEHTzmfdRPoX6fL3vRnZVmqy4D1sWaT5WL9U25oZhQktoeHgo
 ```
 
 5. The signer-2 finalize the transaction
+
 ```sh
 via multisig finalize-upgrade-tx
 ```
 
 6. The signer-2 broadcast the transaction
+
 ```sh
 via multisig broadcast-tx \
 --rpcUrl http://0.0.0.0:18443 \
@@ -125,23 +140,32 @@ via multisig broadcast-tx \
 1. Start the Sequencer.
 2. Deposit 1 BTC.
 3. cd via-playground exec the following cmd, you should see ETH. as token symbol.
+
 ```sh
 cd via-playground && source .env.example && npx hardhat balance --address 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049 && cd ..
 ```
+
 4. Delete the submodule to `branch` key to use the `main` branch, this allows us to use the protocol version 26.
 5. Build git submodule using
+
 ```sh
 git submodule update --remote --recursive
 ```
+
 6. Build the system contracts
+
 ```sh
 cd contracts && yarn sc build && cd ..
 ```
+
 7. Create a new upgrade config
+
 ```sh
 cd infrastructure/via-protocol-upgrade && yarn start upgrades create via-network --protocol-version 0.26.0
 ```
-8. Publish the new system contract for version 
+
+8. Publish the new system contract for version
+
 ```sh
 yarn start system-contracts publish \
     --private-key 0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110 \
@@ -153,17 +177,24 @@ yarn start system-contracts publish \
     --default-aa \
     --system-contracts
 ```
-The above cmd created a new upgrade file at this location etc/upgrades/1742370950-via-network with the new system contracts we are going to deploy. Wait the transactions to be processed on L2 and included in L1 batches before execute the next steps.
-10. When all the l1_batches are processed execute the next cmd to send an upgrade inscription to the L1.
+
+The above cmd created a new upgrade file at this location etc/upgrades/1742370950-via-network with the new system
+contracts we are going to deploy. Wait the transactions to be processed on L2 and included in L1 batches before execute
+the next steps. 10. When all the l1_batches are processed execute the next cmd to send an upgrade inscription to the L1.
+
 ```sh
 yarn start l2-transaction upgrade-system-contracts --environment devnet-2 --private-key cVZduZu265sWeAqFYygoDEE1FZ7wV9rpW5qdqjRkUehjaUMWLT1R
 ```
-11. Copy the `tx_id` of the proposal created in the previous step and follow this doc to create a multisig [GOV transaction](#How-to-execute-an-upgrade-proposal).
 
-12. When the Gov tx is created and minted in a block, execute another deposit 1 BTC, this because a batch can not include only an upgrade transaction.
-13. Deposit 1 BTC. 
+11. Copy the `tx_id` of the proposal created in the previous step and follow this doc to create a multisig
+    [GOV transaction](#How-to-execute-an-upgrade-proposal).
+
+12. When the Gov tx is created and minted in a block, execute another deposit 1 BTC, this because a batch can not
+    include only an upgrade transaction.
+13. Deposit 1 BTC.
 14. Check the database, new protocol version should be 26, the last batch should be processed with the new bootloader
-hash and version 26.
+    hash and version 26.
+
 ```sql
 -- You should see that the last miniblocks where processed using the version 26
 select protocol_version from miniblocks order by number DESC
@@ -171,9 +202,12 @@ select protocol_version from miniblocks order by number DESC
 -- The last batches (check number), should have different bootloader_code_hash and default_aa_code_hash.
 select number, encode(bootloader_code_hash, 'hex'), encode(default_aa_code_hash, 'hex') from l1_batches order by number DESC
 ```
-15. In another terminal starts the coordinator (by default version 26 ). You will notice that all the batches before the one includes the upgrade are processing with VK (verifying key version 25) and after upgrade VK-26
 
-16. Start a verifier with the (change the version to 25 [const SEQUENCER_MINOR: ProtocolVersionId = ProtocolVersionId::Version26;](https://github.com/vianetwork/via-core/blob/22bbfd3e5dae6f01a5cbecc629a748798e66cd16/via_verifier/lib/via_verifier_types/src/protocol_version.rs#L6))
+15. In another terminal starts the coordinator (by default version 26 ). You will notice that all the batches before the
+    one includes the upgrade are processing with VK (verifying key version 25) and after upgrade VK-26
+
+16. Start a verifier with the (change the version to 25
+    [const SEQUENCER_MINOR: ProtocolVersionId = ProtocolVersionId::Version26;](https://github.com/vianetwork/via-core/blob/22bbfd3e5dae6f01a5cbecc629a748798e66cd16/via_verifier/lib/via_verifier_types/src/protocol_version.rs#L6))
 17. The coordinator will reject this verifier as the protocol version used is 25 and it requires 26
 18. Start the verifier and restart it with version 26. The withdrawal is processed
 19. Execute a withdrawal.

--- a/infrastructure/via/package.json
+++ b/infrastructure/via/package.json
@@ -23,7 +23,10 @@
     "tiny-secp256k1": "2.2.4",
     "bip39": "3.1.0",
     "@types/bip32": "2.0.4",
-    "bip32": "5.0.0-rc.0"
+    "bip32": "5.0.0-rc.0",
+    "ecpair": "2.1.0",
+    "axios": "1.10.0",
+    "bitcoin-core": "5.0.0"
   },
   "bin": {
     "via": "./build/index.js"

--- a/infrastructure/via/src/helpers.ts
+++ b/infrastructure/via/src/helpers.ts
@@ -26,7 +26,7 @@ interface Wallet {
     mnemonic: string;
     privateKey: string;
     address: string;
-    publicKey: string,
+    publicKey: string;
     network: string;
 }
 

--- a/infrastructure/via/src/index.ts
+++ b/infrastructure/via/src/index.ts
@@ -23,6 +23,7 @@ import { command as contract } from './contract';
 import { command as test } from './test/test';
 import { indexerCommand as indexer } from './indexer';
 import { command as debug } from './debug';
+import { command as multisig } from './multisig';
 import { command as enSetup } from './setup_en';
 
 const COMMANDS = [
@@ -46,6 +47,7 @@ const COMMANDS = [
     test,
     indexer,
     debug,
+    multisig,
     enSetup,
     en,
     completion(program as Command)

--- a/infrastructure/via/src/multisig.ts
+++ b/infrastructure/via/src/multisig.ts
@@ -1,0 +1,289 @@
+import { Command } from 'commander';
+import * as bitcoin from 'bitcoinjs-lib';
+import * as ecc from 'tiny-secp256k1';
+import { ECPairFactory, ECPairInterface } from 'ecpair';
+import { generateBitcoinWallet, getNetwork, readJsonFile, writeJsonFile } from './helpers';
+import { Psbt } from 'bitcoinjs-lib';
+import axios from 'axios';
+import { DEFAULT_NETWORK } from "./constants"
+
+// Initialize the elliptic curve library
+bitcoin.initEccLib(ecc);
+const ECPair = ECPairFactory(ecc);
+
+// Define a type for our UTXO input for clarity and type safety.
+interface UtxoInput {
+    txid: string;
+    vout: number;
+    amountSatoshis: number;
+}
+
+const createBitcoinWallet = async (networkStr: string = "regtest") => {
+    const wallet = await generateBitcoinWallet(networkStr);
+
+    console.log("Wallet: ", wallet);
+}
+
+// Initialise ECC (required since bitcoinjs‑lib v6)
+const compute_multisig_address = (pubkeys: Array<string>, minimumSigners: number, outDir: string, networkStr: string = "regtest") => {
+    bitcoin.initEccLib(ecc);
+
+    const network = getNetwork(networkStr);
+    const pubkeyBuffers = pubkeys.map(hex => Buffer.from(hex, 'hex'));
+
+    const p2ms = bitcoin.payments.p2ms({ m: minimumSigners, pubkeys: pubkeyBuffers, network });
+    const p2wsh = bitcoin.payments.p2wsh({ redeem: p2ms, network });
+
+    const multisig = {
+        address: p2wsh.address,
+        witnessScript: p2wsh.redeem?.output?.toString('hex'),
+        outputScript: p2wsh.output?.toString('hex'),
+    }
+    console.log("Multisig wallet", multisig)
+
+    writeJsonFile(outDir, { multisig });
+}
+
+const createUnsignedUpgradeTransaction = (
+    utxoInput: UtxoInput,
+    upgradeTxId: string,
+    fee: number,
+    outDir: string,
+    networkStr: string = "regtest",
+) => {
+    const dataFile: any = readJsonFile(outDir);
+    const network = getNetwork(networkStr);
+
+    const psbt = new Psbt({ network });
+
+    // 1. Add the multisig input to spend
+    psbt.addInput({
+        hash: Buffer.from(utxoInput.txid, 'hex').reverse(),
+        index: utxoInput.vout,
+        witnessUtxo: {
+            script: Buffer.from(dataFile.multisig.outputScript, 'hex'),
+            value: utxoInput.amountSatoshis,
+        },
+        witnessScript: Buffer.from(dataFile.multisig.witnessScript, 'hex'),
+    });
+
+    // 2. Create and add the OP_RETURN output
+    const upgradeTxIdBuffer = Buffer.from(upgradeTxId, 'hex').reverse();
+    const prefixBuffer = Buffer.from("VIA_PROTOCOL:UPGRADE", 'utf8');
+    const embed = bitcoin.payments.embed({ data: [prefixBuffer, upgradeTxIdBuffer] });
+    if (!embed.output) throw new Error("Could not create OP_RETURN script.");
+
+    psbt.addOutput({
+        script: embed.output,
+        value: 0,
+    });
+
+    // 3. Create and add the change output
+    const changeValue = utxoInput.amountSatoshis - fee;
+    if (changeValue < 0) {
+        throw new Error("Funding amount is less than the fee.");
+    }
+
+    psbt.addOutput({
+        address: dataFile.multisig.address,
+        value: changeValue,
+    });
+
+    writeJsonFile(outDir, { ...dataFile, tx: psbt.toBase64() })
+
+    console.log("Successfully created an unsigned PSBT for the upgrade transaction.");
+};
+
+/**
+ * Signs a PSBT with a given private key.
+ * This function correctly creates a Signer object that is compatible with bitcoinjs-lib's types.
+ */
+const signPsbt = (
+    wifPrivateKey: string,
+    outDir: string,
+    networkStr: string,
+) => {
+    const dataFile: any = readJsonFile(outDir);
+    const network = getNetwork(networkStr);
+
+    const keyPair: ECPairInterface = ECPair.fromWIF(wifPrivateKey, network);
+    const psbt = bitcoin.Psbt.fromBase64(dataFile.tx, { network });
+
+    const signer: bitcoin.Signer = {
+        publicKey: Buffer.from(keyPair.publicKey), // Convert Uint8Array to Buffer
+        sign: (hash: Buffer): Buffer => {
+            // Use the underlying keyPair to perform the actual signing
+            return Buffer.from(keyPair.sign(hash));
+        },
+    };
+
+    psbt.signInput(0, signer);
+
+    const validationFunction = (pubkey: Buffer, msghash: Buffer, signature: Buffer): boolean =>
+        ecc.verify(msghash, pubkey, signature);
+
+    if (!psbt.validateSignaturesOfInput(0, validationFunction)) {
+        throw new Error("Signature validation failed for the new signature.");
+    }
+
+    writeJsonFile(outDir, { ...dataFile, tx: psbt.toBase64() })
+};
+
+
+/**
+ * Finalizes a PSBT and extracts the full transaction hex.
+ */
+const finalizeAndExtractTx = (outDir: string, networkStr: string = "regtest") => {
+    const dataFile: any = readJsonFile(outDir);
+    const network = getNetwork(networkStr);
+
+    const psbt = bitcoin.Psbt.fromBase64(dataFile.tx, { network });
+    psbt.finalizeAllInputs();
+
+    const finalTx = psbt.extractTransaction();
+
+    writeJsonFile(outDir, { ...dataFile, txHex: finalTx.toHex() })
+    console.log(finalTx.toHex());
+};
+
+/**
+ * Broadcasts a raw transaction hex to the Bitcoin node via JSON-RPC with authentication.
+ */
+const broadcastTransaction = async (
+    outDir: string,
+    rpc_url: string,
+    rpc_user: string,
+    rpc_password: string
+) => {
+    try {
+        const dataFile: any = readJsonFile(outDir);
+        console.log()
+
+        const auth = Buffer.from(`${rpc_user}:${rpc_password}`).toString('base64');
+
+        const response = await axios.post(
+            rpc_url,
+            {
+                jsonrpc: '1.0',
+                id: 'broadcast',
+                method: 'sendrawtransaction',
+                params: [dataFile.txHex],
+            },
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Basic ${auth}`,
+                },
+            }
+        );
+
+        if (response.data.error) {
+            throw new Error(`RPC Error: ${response.data.error.message}`);
+        }
+
+        writeJsonFile(outDir, { ...dataFile, txid: response.data.result })
+
+        console.log("Txid:", response.data.result)
+    } catch (error) {
+        if (axios.isAxiosError(error) && error.response) {
+            console.error('RPC Error:', error.response.data);
+            throw new Error(`Failed to broadcast transaction: ${error.response.data.error?.message || 'Unknown error'}`);
+        }
+        throw error;
+    }
+};
+
+export const command = new Command('multisig').description('Multisig helper');
+
+command
+    .command('create-wallet')
+    .description('Create a bitcoin wallet')
+    .option('--network <network>', 'network', DEFAULT_NETWORK)
+    .action((cmd: Command) =>
+        createBitcoinWallet(
+            cmd.network
+        )
+    );
+
+command
+    .command('compute-multisig')
+    .description('Compute multisig address')
+    .requiredOption('--pubkeys <pubkeys>', 'List of public keys "," separated')
+    .requiredOption('--minimumSigners <minimumSigners>', 'Minimum number of signers')
+    .option('--outDir <outDir>', 'The output dir', './upgrade_tx_exec.json')
+    .option('--network <network>', 'network', DEFAULT_NETWORK)
+    .action((cmd: Command) =>
+        compute_multisig_address(
+            cmd.pubkeys.split(","),
+            Number(cmd.minimumSigners),
+            cmd.outDir,
+            cmd.network
+        )
+    );
+
+command
+    .command('create-upgrade-tx')
+    .description('Create an unsigned multisig upgrade transaction')
+    .requiredOption('--inputTxId <inputTxId>', 'The input txid used to pay fee')
+    .requiredOption('--inputVout <inputVout>', 'The input vout used to pay fee')
+    .requiredOption('--inputAmount <inputAmount>', 'The input amount used to pay fee')
+    .requiredOption('--upgradeProposalTxId <upgradeProposalTxId>', 'The multisig witness script')
+    .requiredOption('--fee <fee>', 'The transaction fee')
+    .option('--outDir <outDir>', 'The output dir', './upgrade_tx_exec.json')
+    .option('--network <network>', 'network', DEFAULT_NETWORK)
+    .action((cmd: Command) =>
+        createUnsignedUpgradeTransaction(
+            {
+                txid: cmd.inputTxId,
+                amountSatoshis: Number(cmd.inputAmount),
+                vout: Number(cmd.inputVout),
+            },
+            cmd.upgradeProposalTxId,
+            Number(cmd.fee),
+            cmd.outDir,
+            cmd.network
+        )
+    );
+
+command
+    .command('sign-upgrade-tx')
+    .description('Sign and upgrade transaction')
+    .requiredOption('--privateKey <privateKey>', 'The signer private key')
+    .option('--outDir <outDir>', 'The output dir', './upgrade_tx_exec.json')
+    .option('--network <network>', 'network', DEFAULT_NETWORK)
+    .action((cmd: Command) =>
+        signPsbt(
+            cmd.privateKey,
+            cmd.outDir,
+            cmd.network
+        )
+    );
+
+command
+    .command('finalize-upgrade-tx')
+    .description('finalize the upgrade transaction')
+    .option('--outDir <outDir>', 'The output dir', './upgrade_tx_exec.json')
+    .option('--network <network>', 'network', DEFAULT_NETWORK)
+    .action((cmd: Command) =>
+        finalizeAndExtractTx(
+            cmd.outDir,
+            cmd.network
+        )
+    );
+
+command
+    .command('broadcast-tx')
+    .description('broadcast finalized transaction')
+    .requiredOption('--rpcUrl <rpcUrl>', 'The rpc url')
+    .requiredOption('--rpcUser <rpcUser>', 'The rpc user')
+    .requiredOption('--rpcPass <rpcPass>', 'The rpc password')
+    .option('--outDir <outDir>', 'The output dir', './upgrade_tx_exec.json')
+    .option('--network <network>', 'network', DEFAULT_NETWORK)
+    .action((cmd: Command) =>
+        broadcastTransaction(
+            cmd.outDir,
+            cmd.rpcUrl,
+            cmd.rpcUser,
+            cmd.rpcPass,
+        )
+    );

--- a/via_verifier/node/via_btc_watch/src/message_processors/governance_upgrade.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/governance_upgrade.rs
@@ -32,7 +32,7 @@ impl GovernanceUpgradesEventProcessor {
         Self {
             btc_client,
             message_parser,
-            upgrade: ViaProtocolUpgrade::new(),
+            upgrade: ViaProtocolUpgrade::default(),
         }
     }
 }

--- a/via_verifier/node/via_btc_watch/src/message_processors/governance_upgrade.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/governance_upgrade.rs
@@ -1,13 +1,14 @@
+use std::sync::Arc;
+
 use via_btc_client::{
-    indexer::BitcoinInscriptionIndexer,
-    types::{FullInscriptionMessage, SystemContractUpgrade},
+    client::BitcoinClient,
+    indexer::{BitcoinInscriptionIndexer, MessageParser},
+    traits::BitcoinOps,
+    types::FullInscriptionMessage,
 };
 use via_verifier_dal::{Connection, DalError, Verifier, VerifierDal};
 use via_verifier_types::protocol_version::get_sequencer_version;
-use zksync_types::{
-    abi::L2CanonicalTransaction, via_protocol_upgrade::get_calldata, CONTRACT_DEPLOYER_ADDRESS,
-    CONTRACT_FORCE_DEPLOYER_ADDRESS, H256, PROTOCOL_UPGRADE_TX_TYPE, U256,
-};
+use zksync_types::via_protocol_upgrade::ViaProtocolUpgrade;
 
 use crate::{
     message_processors::{MessageProcessor, MessageProcessorError},
@@ -16,11 +17,23 @@ use crate::{
 
 /// Listens to operation events coming from the governance contract and saves new protocol upgrade proposals to the database.
 #[derive(Debug)]
-pub struct GovernanceUpgradesEventProcessor {}
+pub struct GovernanceUpgradesEventProcessor {
+    /// BTC client
+    btc_client: Arc<BitcoinClient>,
+    /// Message parser
+    message_parser: MessageParser,
+    /// upgrade proposal
+    upgrade: ViaProtocolUpgrade,
+}
 
 impl GovernanceUpgradesEventProcessor {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(btc_client: Arc<BitcoinClient>) -> Self {
+        let message_parser = MessageParser::new(btc_client.get_network());
+        Self {
+            btc_client,
+            message_parser,
+            upgrade: ViaProtocolUpgrade::new(),
+        }
     }
 }
 #[async_trait::async_trait]
@@ -35,33 +48,67 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         for msg in msgs {
             if let FullInscriptionMessage::SystemContractUpgrade(system_contract_upgrade_msg) = &msg
             {
-                // Ignore if old version but not if same version. The verifier should refresh the protocol version when the
-                // in case where the Sequencer revert an upgrade.
-                if system_contract_upgrade_msg.input.version < get_sequencer_version() {
-                    tracing::info!(
-                        "Upgrade transaction with version {} already processed, skipping",
-                        system_contract_upgrade_msg.input.version
-                    );
-                    continue;
+                let proposal_tx = self
+                    .btc_client
+                    .get_transaction(&system_contract_upgrade_msg.input.proposal_tx_id)
+                    .await
+                    .map_err(|err| {
+                        MessageProcessorError::Internal(anyhow::anyhow!(
+                            "Failed to fetch protocol upgrade transaction: {}, error {}",
+                            system_contract_upgrade_msg.input.proposal_tx_id,
+                            err
+                        ))
+                    })?;
+
+                let messages = self.message_parser.parse_system_transaction(
+                    &proposal_tx,
+                    system_contract_upgrade_msg.common.block_height,
+                );
+
+                for message in messages {
+                    match message {
+                        FullInscriptionMessage::SystemContractUpgradeProposal(
+                            system_contract_upgrade_proposal_msg,
+                        ) => {
+                            if system_contract_upgrade_proposal_msg.input.version
+                                < get_sequencer_version()
+                            {
+                                tracing::info!(
+                                    "Upgrade transaction with version {} already processed, skipping",
+                                    system_contract_upgrade_proposal_msg.input.version
+                                );
+                                continue;
+                            }
+
+                            tracing::info!(
+                                "Received upgrades with versions: {:?}",
+                                system_contract_upgrade_proposal_msg.input.version
+                            );
+
+                            let hash = self.upgrade.get_canonical_tx_hash(
+                                system_contract_upgrade_proposal_msg.input.version,
+                                system_contract_upgrade_proposal_msg.input.system_contracts,
+                            )?;
+
+                            let upgrade = (
+                                system_contract_upgrade_proposal_msg.input.version,
+                                system_contract_upgrade_proposal_msg
+                                    .input
+                                    .bootloader_code_hash,
+                                system_contract_upgrade_proposal_msg
+                                    .input
+                                    .default_account_code_hash,
+                                hash,
+                                system_contract_upgrade_proposal_msg
+                                    .input
+                                    .recursion_scheduler_level_vk_hash,
+                            );
+
+                            upgrades.push(upgrade);
+                        }
+                        _ => (),
+                    }
                 }
-
-                tracing::info!(
-                    "Received upgrades with versions: {:?}",
-                    system_contract_upgrade_msg.input.version
-                );
-                let hash = self.get_canonical_tx_hash(system_contract_upgrade_msg)?;
-
-                let upgrade = (
-                    system_contract_upgrade_msg.input.version,
-                    system_contract_upgrade_msg.input.bootloader_code_hash,
-                    system_contract_upgrade_msg.input.default_account_code_hash,
-                    hash,
-                    system_contract_upgrade_msg
-                        .input
-                        .recursion_scheduler_level_vk_hash,
-                );
-
-                upgrades.push(upgrade);
             }
         }
 
@@ -88,37 +135,5 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
                 .map_err(DalError::generalize)?;
         }
         Ok(())
-    }
-}
-
-impl GovernanceUpgradesEventProcessor {
-    fn get_canonical_tx_hash(
-        &self,
-        msg: &SystemContractUpgrade,
-    ) -> Result<H256, MessageProcessorError> {
-        let gas_limit = U256::from(72_000_000u64);
-        let gas_per_pubdata_byte_limit = U256::from(800u64);
-        let calldata = get_calldata(msg.input.system_contracts.clone())?;
-
-        let l2_transaction = L2CanonicalTransaction {
-            tx_type: PROTOCOL_UPGRADE_TX_TYPE.into(),
-            from: U256::from_big_endian(&CONTRACT_FORCE_DEPLOYER_ADDRESS.0),
-            to: U256::from_big_endian(&CONTRACT_DEPLOYER_ADDRESS.0),
-            gas_limit,
-            gas_per_pubdata_byte_limit,
-            max_fee_per_gas: U256::zero(),
-            max_priority_fee_per_gas: U256::zero(),
-            paymaster: U256::zero(),
-            nonce: U256::from(msg.input.version.minor as u64),
-            value: U256::zero(),
-            reserved: [U256::zero(), U256::zero(), U256::zero(), U256::zero()],
-            data: calldata.clone(),
-            signature: vec![],
-            factory_deps: vec![],
-            paymaster_input: vec![],
-            reserved_dynamic: vec![],
-        };
-
-        Ok(l2_transaction.hash())
     }
 }

--- a/via_verifier/node/via_btc_watch/src/message_processors/verifier.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/verifier.rs
@@ -168,18 +168,7 @@ impl MessageProcessor for VerifierMessageProcessor {
                         }
                     }
                 }
-                // bootstrapping phase is already covered
-                FullInscriptionMessage::SystemContractUpgrade(_)
-                | FullInscriptionMessage::ProposeSequencer(_)
-                | FullInscriptionMessage::SystemBootstrapping(_) => {
-                    // do nothing
-                }
-                // Non-votable messages like L1BatchDAReference or L1ToL2Message are ignored by this processor
-                FullInscriptionMessage::L1ToL2Message(_)
-                | FullInscriptionMessage::BridgeWithdrawal(_)
-                | FullInscriptionMessage::L1BatchDAReference(_) => {
-                    // do nothing
-                }
+                _ => (),
             }
         }
         Ok(())

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,6 +3133,13 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@uphold/request-logger@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@uphold/request-logger/-/request-logger-2.0.0.tgz#c585c0bdb94210198945c6597e4fe23d6e63e084"
+  integrity sha512-UvGS+v87C7VTtQDcFHDLfvfl1zaZaLSwSmAnV35Ne7CzAVvotmZqt9lAIoNpMpaoRpdjVIcnUDwPSeIeA//EoQ==
+  dependencies:
+    uuid "^3.0.1"
+
 JSONStream@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"
@@ -3546,6 +3553,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
+axios@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
+  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -3738,6 +3754,19 @@ bip39@3.1.0:
   integrity sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==
   dependencies:
     "@noble/hashes" "^1.2.0"
+
+bitcoin-core@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bitcoin-core/-/bitcoin-core-5.0.0.tgz#6ae38e457814f55ee37c5fa6a5b33c48d9ca8f2d"
+  integrity sha512-XqHsD5LjtshN8yWzRrq2kof57e1eXCGDx3i5+sFKBRi9MktSlXOR4SRLyXLkfzfBmPEs5q/76RotQJuaWg75DQ==
+  dependencies:
+    "@uphold/request-logger" "^2.0.0"
+    debugnyan "^1.0.0"
+    json-bigint "^1.0.0"
+    lodash "^4.0.0"
+    request "^2.53.0"
+    semver "^5.1.0"
+    standard-error "^1.1.0"
 
 bitcoinjs-lib@6.1.7:
   version "6.1.7"
@@ -3988,6 +4017,16 @@ buildcheck@~0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.6.tgz#89aa6e417cfd1e2196e3f8fe915eb709d2fe4238"
   integrity sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==
+
+bunyan@^1.8.1:
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.19.3"
+    mv "~2"
+    safe-json-stringify "~1"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -4590,6 +4629,14 @@ debug@^4.3.2, debug@^4.3.3, debug@^4.3.5:
   dependencies:
     ms "^2.1.3"
 
+debugnyan@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/debugnyan/-/debugnyan-1.0.0.tgz#90386d5ebc2c63588f17f272be5c2a93b7665d83"
+  integrity sha512-dTvKxcLZCammDLFYi31NRVr5g6vjJ33uf1wcdbIPPxPxxnJ9/xj00Mh/YQkhFMw/VGavaG5KpjSC+4o9r/JjRg==
+  dependencies:
+    bunyan "^1.8.1"
+    debug "^2.2.0"
+
 decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
@@ -4795,6 +4842,13 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -4814,6 +4868,15 @@ ecdsa-sig-formatter@1.0.11:
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
+
+ecpair@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ecpair/-/ecpair-2.1.0.tgz#673f826b1d80d5eb091b8e2010c6b588e8d2cb45"
+  integrity sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==
+  dependencies:
+    randombytes "^2.1.0"
+    typeforce "^1.18.0"
+    wif "^2.0.6"
 
 electron-to-chromium@^1.4.668:
   version "1.4.731"
@@ -6174,6 +6237,17 @@ glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -7837,7 +7911,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8184,7 +8258,7 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@0.5.x, mkdirp@^0.5.1:
+mkdirp@0.5.x, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -8300,6 +8374,11 @@ mocha@^9.0.2:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+moment@^2.19.3:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 moo@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
@@ -8325,6 +8404,20 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==
 
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.14.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.0.tgz#24aa4ddffcc37613a2d2935b97683c1ec96093c6"
+  integrity sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==
+
 nan@^2.17.0, nan@^2.18.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
@@ -8349,6 +8442,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==
 
 nearley@^2.20.1:
   version "2.20.1"
@@ -9340,7 +9438,7 @@ req-from@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
-request@^2.85.0:
+request@^2.53.0, request@^2.85.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -9466,6 +9564,13 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==
+  dependencies:
+    glob "^6.0.1"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -9542,6 +9647,11 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
+
 safe-regex-test@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.3.tgz#a5b4c0f06e0ab50ea2c395c14d8371232924c377"
@@ -9600,7 +9710,7 @@ semaphore-async-await@^1.5.1:
   resolved "https://registry.yarnpkg.com/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz#857bef5e3644601ca4b9570b87e9df5ca12974fa"
   integrity sha512-b/ptP11hETwYWpeilHXXQiV5UJNJl7ZWWooKRE5eBIYWoom6dZ0SluCIdCtKycsMtZgKWE01/qAw6jblw1YVhg==
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -10015,6 +10125,11 @@ stacktrace-parser@^0.1.10:
   integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
   dependencies:
     type-fest "^0.7.1"
+
+standard-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/standard-error/-/standard-error-1.1.0.tgz#23e5168fa1c0820189e5812701a79058510d0d34"
+  integrity sha512-4v7qzU7oLJfMI5EltUSHCaaOd65J6S4BqKRWgzMi4EYaE5fvNabPxmAPGdxpGXqrcWjhDGI/H09CIdEuUOUeXg==
 
 statuses@2.0.1:
   version "2.0.1"
@@ -10726,7 +10841,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typeforce@^1.11.3, typeforce@^1.11.5:
+typeforce@^1.11.3, typeforce@^1.11.5, typeforce@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
@@ -10875,7 +10990,7 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
## What ❔

- Change the upgrade gov wallet to multi-sig wallet.
- Added sub command to VIA cli called `multisig`, it allows the governance signers to build a transaction.
- Updated the indexer to index the upgrade execute inscription.
- Documented the VIA upgrade process.

## Why ❔

This PR contains the implementation of the proposed [solution 1](https://www.notion.so/txfusion/Improved-Upgrade-Proposal-Mechanism-2088978a806480b99639ceb773cd1d53). It change the gov address to multisig.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
