### PR TITLE
fix(via): provide option to generate transactions directly on host

### DIFF
--- a/infrastructure/via/src/bootstrap.ts
+++ b/infrastructure/via/src/bootstrap.ts
@@ -27,7 +27,7 @@ async function updateEnvVariable(envFilePath: string, variableName: string, newV
 export async function updateBootstrapTxidsEnv(network: string) {
     let genesisTxIds = process.env.VIA_GENESIS_BOOTSTRAP_TXIDS;
 
-    if (!genesisTxIds) {
+    if (!genesisTxIds || genesisTxIds === '""') {
         const genesisDir = path.join(process.env.VIA_HOME!, `etc/env/via/genesis/${network}`);
         const files = await fs.readdir(genesisDir);
 


### PR DESCRIPTION
## What ❔

- Provide option to execute `via transaction` command directly on host  machine instead on running inside container.
- Fix the bug when updating the config file with bootstrap tx ids.