### PR TITLE
build: build only required binaries in container for each via component

### DIFF
--- a/core/lib/config/src/configs/via_verifier.rs
+++ b/core/lib/config/src/configs/via_verifier.rs
@@ -50,7 +50,7 @@ impl ViaVerifierConfig {
 
     pub fn max_tx_weight(&self) -> u64 {
         // Reserve 20000 weight units below Bitcoin's standard limit as a safety buffer
-        // to account for witness data variations, signature size differences, and 
+        // to account for witness data variations, signature size differences, and
         // potential rounding errors during transaction construction, ensuring we stay
         // well within node acceptance limits
         self.max_tx_weight

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/via
 COPY . .
 
 RUN apt-get update && apt-get install -y protobuf-compiler git && rm -rf /var/lib/apt/lists/*
-RUN cargo build --release #--features=rocksdb/io-uring <-- investigate what is this
+RUN cargo build --release --bin via_server --bin via_block_reverter_cli --bin merkle_tree_consistency_checker
 
 FROM debian:bookworm-slim
 
@@ -20,7 +20,7 @@ EXPOSE 3031
 EXPOSE 3030
 
 COPY --from=builder /usr/src/via/target/release/via_server /usr/bin
-COPY --from=builder /usr/src/via/target/release/block_reverter /usr/bin
+COPY --from=builder /usr/src/via/target/release/via_block_reverter_cli /usr/bin
 COPY --from=builder /usr/src/via/target/release/merkle_tree_consistency_checker /usr/bin
 COPY contracts/system-contracts/bootloader/build/artifacts/ /contracts/system-contracts/bootloader/build/artifacts/
 COPY contracts/system-contracts/contracts-preprocessed/artifacts/ /contracts/system-contracts/contracts-preprocessed/artifacts/

--- a/docker/via-l1-indexer/Dockerfile
+++ b/docker/via-l1-indexer/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/via
 COPY . .
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
-RUN cargo build --release
+RUN cargo build --release --bin via_indexer_bin
 
 FROM debian:bookworm-slim
 

--- a/docker/via-verifier/Dockerfile
+++ b/docker/via-verifier/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/via
 COPY . .
 
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
-RUN cargo build --release
+RUN cargo build --release --bin via_verifier
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
## What ❔

- Improve the container build by building only required binaries instead all of binaries.