### PR TITLE
Feat/via system wallet message processor

### DIFF
--- a/core/lib/via_btc_client/src/inscriber/mod.rs
+++ b/core/lib/via_btc_client/src/inscriber/mod.rs
@@ -814,6 +814,11 @@ impl Inscriber {
     pub async fn get_client(&self) -> &dyn BitcoinOps {
         &*self.client
     }
+
+    #[instrument(skip(self), target = "bitcoin_inscriber")]
+    pub fn inscriber_address(&self) -> anyhow::Result<Address> {
+        Ok(self.signer.get_p2wpkh_address()?)
+    }
 }
 
 #[cfg(test)]

--- a/core/lib/via_btc_client/src/types.rs
+++ b/core/lib/via_btc_client/src/types.rs
@@ -90,6 +90,57 @@ pub struct SystemBootstrappingInput {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct UpdateSequencer {
+    pub common: CommonFields,
+    pub input: UpdateSequencerInput,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UpdateSequencerInput {
+    /// The input utxos.
+    pub inputs: Vec<OutPoint>,
+    pub address: BitcoinAddress<NetworkUnchecked>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpdateGovernance {
+    pub common: CommonFields,
+    pub input: UpdateGovernanceInput,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UpdateGovernanceInput {
+    /// The input utxos.
+    pub inputs: Vec<OutPoint>,
+    pub address: BitcoinAddress<NetworkUnchecked>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpdateBridge {
+    pub common: CommonFields,
+    pub input: UpdateBridgeInput,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UpdateBridgeInput {
+    /// The input utxos.
+    pub inputs: Vec<OutPoint>,
+    pub proposal_tx_id: Txid,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpdateBridgeProposal {
+    pub common: CommonFields,
+    pub input: UpdateBridgeProposalInput,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UpdateBridgeProposalInput {
+    pub bridge_musig2_address: BitcoinAddress<NetworkUnchecked>,
+    pub verifier_p2wpkh_addresses: Vec<BitcoinAddress<NetworkUnchecked>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct SystemBootstrapping {
     pub common: CommonFields,
     pub input: SystemBootstrappingInput,
@@ -188,6 +239,7 @@ pub enum InscriptionMessage {
     ProposeSequencer(ProposeSequencerInput),
     L1ToL2Message(L1ToL2MessageInput),
     SystemContractUpgradeProposal(SystemContractUpgradeProposalInput),
+    UpdateBridgeProposal(UpdateBridgeProposalInput),
 }
 
 impl Serializable for InscriptionMessage {
@@ -224,8 +276,40 @@ pub enum FullInscriptionMessage {
     ProposeSequencer(ProposeSequencer),
     L1ToL2Message(L1ToL2Message),
     SystemContractUpgradeProposal(SystemContractUpgradeProposal),
-    SystemContractUpgrade(SystemContractUpgrade),
     BridgeWithdrawal(BridgeWithdrawal),
+    UpdateBridgeProposal(UpdateBridgeProposal),
+    UpdateGovernance(UpdateGovernance),
+    UpdateSequencer(UpdateSequencer),
+    SystemContractUpgrade(SystemContractUpgrade),
+    UpdateBridge(UpdateBridge),
+}
+
+impl FullInscriptionMessage {
+    /// Return a numeric sort key that reflects the enum declaration order
+    fn order_key(&self) -> usize {
+        match self {
+            FullInscriptionMessage::L1BatchDAReference(_) => 0,
+            FullInscriptionMessage::ProofDAReference(_) => 1,
+            FullInscriptionMessage::ValidatorAttestation(_) => 2,
+            FullInscriptionMessage::SystemBootstrapping(_) => 3,
+            FullInscriptionMessage::ProposeSequencer(_) => 4,
+            FullInscriptionMessage::L1ToL2Message(_) => 5,
+            FullInscriptionMessage::SystemContractUpgradeProposal(_) => 6,
+            FullInscriptionMessage::BridgeWithdrawal(_) => 7,
+            FullInscriptionMessage::UpdateBridgeProposal(_) => 8,
+
+            // System inscriptions must be ordered to ensure the indexer always uses the latest wallet state.
+            FullInscriptionMessage::UpdateGovernance(_) => 9,
+            FullInscriptionMessage::UpdateSequencer(_) => 10,
+            FullInscriptionMessage::SystemContractUpgrade(_) => 11,
+            FullInscriptionMessage::UpdateBridge(_) => 12,
+        }
+    }
+
+    pub fn sort_messages(mut msgs: Vec<FullInscriptionMessage>) -> Vec<FullInscriptionMessage> {
+        msgs.sort_by_key(|msg| msg.order_key());
+        msgs
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -254,6 +338,7 @@ lazy_static! {
     pub static ref L1_TO_L2_MSG: PushBytesBuf = PushBytesBuf::from(b"L1ToL2Message");
     pub static ref SYSTEM_CONTRACT_UPGRADE_MSG: PushBytesBuf =
         PushBytesBuf::from(b"SystemContractUpgradeProposal");
+    pub static ref UPGRADE_BRIDGE_MSG: PushBytesBuf = PushBytesBuf::from(b"UpgradeBridgeProposal");
 }
 pub(crate) const VIA_INSCRIPTION_PROTOCOL: &str = "via_inscription_protocol";
 

--- a/core/lib/via_test_utils/Cargo.toml
+++ b/core/lib/via_test_utils/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+bitcoin = { version = "0.32.2", features = ["serde"] }
 via_btc_client.workspace = true
 zksync_types.workspace = true
 zksync_config.workspace = true

--- a/core/lib/via_test_utils/src/utils.rs
+++ b/core/lib/via_test_utils/src/utils.rs
@@ -1,9 +1,16 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
+use bitcoin::{
+    address::NetworkUnchecked,
+    key::rand,
+    script::PushBytesBuf,
+    secp256k1::{self, SecretKey},
+    CompressedPublicKey, PrivateKey,
+};
 use tokio::time::sleep;
 use via_btc_client::{
     client::BitcoinClient,
-    indexer::{BitcoinInscriptionIndexer, BootstrapState, MessageParser},
+    indexer::{BitcoinInscriptionIndexer, MessageParser},
     inscriber::Inscriber,
     traits::BitcoinOps,
     types::{
@@ -12,12 +19,16 @@ use via_btc_client::{
             hex::{Case, DisplayHex},
             Hash,
         },
-        BitcoinTxid, FullInscriptionMessage, InscriptionMessage, L1BatchDAReferenceInput, NodeAuth,
-        ProofDAReferenceInput, Vote,
+        BitcoinTxid, CommonFields, FullInscriptionMessage, InscriptionMessage,
+        L1BatchDAReferenceInput, NodeAuth, ProofDAReferenceInput, UpdateBridge, UpdateBridgeInput,
+        UpdateBridgeProposalInput, UpdateGovernance, UpdateGovernanceInput, UpdateSequencer,
+        UpdateSequencerInput,
     },
 };
 use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
-use zksync_types::{BitcoinNetwork, L1BatchNumber, H256};
+use zksync_types::{
+    via_bootstrap::BootstrapState, via_wallet::SystemWallets, BitcoinNetwork, L1BatchNumber, H256,
+};
 
 const RPC_URL: &str = "http://0.0.0.0:18443";
 const RPC_USERNAME: &str = "rpcuser";
@@ -69,35 +80,126 @@ pub fn test_verifier_add_2() -> BitcoinAddress {
         .assume_checked()
 }
 
+/// Verifier 3 address
+pub fn test_verifier_add_3() -> BitcoinAddress {
+    BitcoinAddress::from_str(&"bcrt1q23lgaa90s85jvtl6dsrkvn0g949cwjkwuyzwdm")
+        .unwrap()
+        .assume_checked()
+}
+
+pub fn test_wallets() -> SystemWallets {
+    let (proposed_sequencer, _) = test_sequencer_wallet();
+    SystemWallets {
+        sequencer: proposed_sequencer,
+        bridge: BitcoinAddress::from_str(
+            &"bcrt1p3s7m76wp5seprjy4gdxuxrr8pjgd47q5s8lu9vefxmp0my2p4t9qh6s8kq",
+        )
+        .unwrap()
+        .assume_checked(),
+        governance: BitcoinAddress::from_str(
+            &"bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm",
+        )
+        .unwrap()
+        .assume_checked(),
+        verifiers: vec![
+            test_verifier_add_1(),
+            test_verifier_add_2(),
+            test_verifier_add_3(),
+        ],
+    }
+}
+
 pub fn bootstrap_state_mock() -> BootstrapState {
     let mut sequencer_votes = HashMap::new();
-    sequencer_votes.insert(test_verifier_add_1(), Vote::Ok);
-    sequencer_votes.insert(test_verifier_add_2(), Vote::Ok);
+    sequencer_votes.insert(test_verifier_add_1(), true);
+    sequencer_votes.insert(test_verifier_add_2(), true);
 
-    let (proposed_sequencer, _) = test_sequencer_wallet();
     BootstrapState {
-        verifier_addresses: vec![test_verifier_add_1(), test_verifier_add_2()],
-        proposed_sequencer: Some(proposed_sequencer),
-        proposed_sequencer_txid: Some(BitcoinTxid::all_zeros()),
+        wallets: Some(test_wallets()),
+        sequencer_proposal_tx_id: Some(BitcoinTxid::all_zeros()),
+        bootstrap_tx_id: Some(BitcoinTxid::all_zeros()),
         sequencer_votes,
-        bridge_address: Some(
-            BitcoinAddress::from_str(
-                &"bcrt1p3s7m76wp5seprjy4gdxuxrr8pjgd47q5s8lu9vefxmp0my2p4t9qh6s8kq",
-            )
-            .unwrap()
-            .assume_checked(),
-        ),
         starting_block_number: 1,
         bootloader_hash: Some(H256::zero()),
         abstract_account_hash: Some(H256::zero()),
-        proposed_governance: Some(
-            BitcoinAddress::from_str(
-                &"bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm",
-            )
-            .unwrap()
-            .assume_checked(),
-        ),
     }
+}
+
+/// Create a update sequencer address inscription
+pub fn create_update_sequencer_inscription(address: BitcoinAddress) -> FullInscriptionMessage {
+    FullInscriptionMessage::UpdateSequencer(UpdateSequencer {
+        common: CommonFields {
+            schnorr_signature: bitcoin::taproot::Signature::from_slice(&[0; 64])
+                .ok()
+                .unwrap(),
+            encoded_public_key: PushBytesBuf::new(),
+            block_height: 0,
+            tx_id: BitcoinTxid::all_zeros(),
+            p2wpkh_address: None,
+            tx_index: None,
+            output_vout: None,
+        },
+        input: UpdateSequencerInput {
+            address: address.as_unchecked().clone(),
+        },
+    })
+}
+
+/// Create a update governance address inscription
+pub fn create_update_governance_inscription(address: BitcoinAddress) -> FullInscriptionMessage {
+    FullInscriptionMessage::UpdateGovernance(UpdateGovernance {
+        common: CommonFields {
+            schnorr_signature: bitcoin::taproot::Signature::from_slice(&[0; 64])
+                .ok()
+                .unwrap(),
+            encoded_public_key: PushBytesBuf::new(),
+            block_height: 0,
+            tx_id: BitcoinTxid::all_zeros(),
+            p2wpkh_address: None,
+            tx_index: None,
+            output_vout: None,
+        },
+        input: UpdateGovernanceInput {
+            address: address.as_unchecked().clone(),
+        },
+    })
+}
+
+/// Create a update bridge address inscription
+pub async fn create_update_bridge_inscription(
+    new_bridge: BitcoinAddress,
+    new_verifiers: Vec<BitcoinAddress>,
+) -> anyhow::Result<FullInscriptionMessage> {
+    let mut inscriber = test_sequencer_inscriber().await?;
+
+    sleep(Duration::from_millis(500)).await;
+
+    let input = UpdateBridgeProposalInput {
+        bridge_musig2_address: new_bridge.as_unchecked().clone(),
+        verifier_p2wpkh_addresses: new_verifiers
+            .iter()
+            .map(|address| address.as_unchecked().clone())
+            .collect::<Vec<BitcoinAddress<NetworkUnchecked>>>(),
+    };
+
+    let result = inscriber
+        .inscribe(InscriptionMessage::UpdateBridgeProposal(input))
+        .await?;
+
+    Ok(FullInscriptionMessage::UpdateBridge(UpdateBridge {
+        common: CommonFields {
+            schnorr_signature: bitcoin::taproot::Signature::from_slice(&[0; 64]).unwrap(),
+            encoded_public_key: PushBytesBuf::new(),
+            block_height: 0,
+            tx_id: BitcoinTxid::all_zeros(),
+            p2wpkh_address: None,
+            tx_index: None,
+            output_vout: None,
+        },
+        input: UpdateBridgeInput {
+            proposal_tx_id: result.final_reveal_tx.txid,
+        },
+    }))
 }
 
 /// Returns the inscriptions and the last block hash
@@ -156,15 +258,26 @@ pub async fn create_chained_inscriptions(
     Ok((msgs, prev_l1_batch_hash))
 }
 
-pub async fn test_create_indexer() -> anyhow::Result<BitcoinInscriptionIndexer> {
-    let bootstrap_state = bootstrap_state_mock();
+pub fn test_create_indexer() -> BitcoinInscriptionIndexer {
+    BitcoinInscriptionIndexer::new(Arc::new(test_bitcoin_client()), Arc::new(test_wallets()))
+}
 
-    let client = test_bitcoin_client();
-    let parser = MessageParser::new(BitcoinNetwork::Regtest);
+pub fn random_bitcoin_wallet() -> (PrivateKey, BitcoinAddress) {
+    // Initialize secp256k1 context
+    let secp = secp256k1::Secp256k1::new();
 
-    Ok(BitcoinInscriptionIndexer::create_indexer(
-        bootstrap_state,
-        Arc::new(client.clone()),
-        parser.clone(),
-    )?)
+    // Generate a random secret key
+    let secret_key = SecretKey::new(&mut rand::thread_rng());
+
+    // Wrap it into a Bitcoin private key
+    let private_key = PrivateKey {
+        compressed: true,
+        network: NETWORK.into(),
+        inner: secret_key.clone(),
+    };
+
+    let cpk = CompressedPublicKey::from_private_key(&secp, &private_key).unwrap();
+    let address = BitcoinAddress::p2wpkh(&cpk, NETWORK);
+
+    (private_key, address)
 }

--- a/core/node/via_btc_watch/Cargo.toml
+++ b/core/node/via_btc_watch/Cargo.toml
@@ -28,3 +28,4 @@ tracing.workspace = true
 sqlx.workspace = true
 
 [dev-dependencies]
+via_test_utils.workspace = true

--- a/core/node/via_btc_watch/src/message_processors/governance_upgrade.rs
+++ b/core/node/via_btc_watch/src/message_processors/governance_upgrade.rs
@@ -52,7 +52,7 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         storage: &mut Connection<'_, Core>,
         msgs: Vec<FullInscriptionMessage>,
         _: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         let mut upgrades = Vec::new();
         for msg in msgs {
             if let FullInscriptionMessage::SystemContractUpgrade(system_contract_upgrade_msg) = &msg
@@ -130,7 +130,7 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         }
 
         let Some(last_upgrade) = upgrades.last() else {
-            return Ok(());
+            return Ok(false);
         };
 
         let last_version = last_upgrade.0.version;
@@ -170,6 +170,6 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         }
         self.last_seen_protocol_version = last_version;
 
-        Ok(())
+        Ok(true)
     }
 }

--- a/core/node/via_btc_watch/src/message_processors/l1_to_l2.rs
+++ b/core/node/via_btc_watch/src/message_processors/l1_to_l2.rs
@@ -31,7 +31,7 @@ impl MessageProcessor for L1ToL2MessageProcessor {
         storage: &mut Connection<'_, Core>,
         msgs: Vec<FullInscriptionMessage>,
         _: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         let mut priority_ops = Vec::new();
         for msg in msgs {
             if let FullInscriptionMessage::L1ToL2Message(l1_to_l2_msg) = msg {
@@ -67,7 +67,7 @@ impl MessageProcessor for L1ToL2MessageProcessor {
         }
 
         if priority_ops.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         for (new_op, txid) in priority_ops {
@@ -80,7 +80,7 @@ impl MessageProcessor for L1ToL2MessageProcessor {
                 .map_err(|e| MessageProcessorError::DatabaseError(e.to_string()))?;
         }
 
-        Ok(())
+        Ok(true)
     }
 }
 

--- a/core/node/via_btc_watch/src/message_processors/system_wallet.rs
+++ b/core/node/via_btc_watch/src/message_processors/system_wallet.rs
@@ -1,0 +1,271 @@
+use std::sync::Arc;
+
+use via_btc_client::{
+    client::BitcoinClient,
+    indexer::{BitcoinInscriptionIndexer, MessageParser},
+    traits::BitcoinOps,
+    types::{
+        BitcoinAddress, FullInscriptionMessage, UpdateBridge, UpdateGovernance, UpdateSequencer,
+    },
+};
+use zksync_dal::{Connection, Core, CoreDal};
+use zksync_types::via_wallet::{SystemWallets, SystemWalletsDetails, WalletInfo, WalletRole};
+
+use crate::message_processors::{MessageProcessor, MessageProcessorError};
+
+#[derive(Debug)]
+pub struct SystemWalletProcessor {
+    /// BTC client
+    btc_client: Arc<BitcoinClient>,
+}
+
+impl SystemWalletProcessor {
+    pub fn new(btc_client: Arc<BitcoinClient>) -> Self {
+        Self { btc_client }
+    }
+}
+
+#[async_trait::async_trait]
+impl MessageProcessor for SystemWalletProcessor {
+    async fn process_messages(
+        &mut self,
+        storage: &mut Connection<'_, Core>,
+        msgs: Vec<FullInscriptionMessage>,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        let mut wallets_updated = false;
+
+        let msgs = FullInscriptionMessage::sort_messages(msgs);
+
+        for msg in msgs {
+            match msg {
+                FullInscriptionMessage::UpdateGovernance(msg) => {
+                    let updated = self.handle_update_governance(storage, msg, indexer).await?;
+                    // Make sure to not override the wallets_updated if "wallets_updated" it's already true.
+                    if updated {
+                        wallets_updated = updated;
+                    }
+                }
+                FullInscriptionMessage::UpdateSequencer(msg) => {
+                    let updated = self.handle_update_sequencer(storage, msg, indexer).await?;
+                    if updated {
+                        wallets_updated = updated;
+                    }
+                }
+                FullInscriptionMessage::UpdateBridge(msg) => {
+                    let updated = self
+                        .handle_update_bridge_proposal(storage, msg, indexer)
+                        .await?;
+                    if updated {
+                        wallets_updated = updated;
+                    }
+                }
+
+                _ => {}
+            }
+        }
+        Ok(wallets_updated)
+    }
+}
+
+impl SystemWalletProcessor {
+    async fn handle_update_bridge_proposal(
+        &self,
+        storage: &mut Connection<'_, Core>,
+        update_bridge_msg: UpdateBridge,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        let proposal_tx_id = update_bridge_msg.input.proposal_tx_id;
+
+        let proposal_tx = self
+            .btc_client
+            .get_transaction(&proposal_tx_id)
+            .await
+            .map_err(|err| {
+                MessageProcessorError::Internal(anyhow::anyhow!(
+                    "Failed to fetch update bridge proposal transaction: {}, error {}",
+                    proposal_tx_id,
+                    err
+                ))
+            })?;
+
+        let mut message_parser = MessageParser::new(self.btc_client.get_network());
+
+        let messages = message_parser
+            .parse_system_transaction(&proposal_tx, update_bridge_msg.common.block_height);
+
+        for message in messages {
+            match message {
+                FullInscriptionMessage::UpdateBridgeProposal(update_bridge_msg) => {
+                    let system_wallets_map =
+                        match storage.via_wallet_dal().get_system_wallets_raw().await? {
+                            Some(map) => map,
+                            None => Default::default(),
+                        };
+
+                    let system_wallets = SystemWallets::try_from(system_wallets_map)?;
+
+                    let new_bridge_address = match update_bridge_msg
+                        .input
+                        .bridge_musig2_address
+                        .require_network(self.btc_client.get_network())
+                    {
+                        Ok(address) => address,
+                        Err(err) => {
+                            tracing::error!("Failed to parse bridge address: {}", err);
+                            return Ok(false);
+                        }
+                    };
+
+                    // Skip if bridge already registered
+                    if system_wallets.bridge == new_bridge_address {
+                        tracing::info!("Bridge wallet already exists, skipping");
+                        return Ok(false);
+                    }
+
+                    let mut wallets_details = SystemWalletsDetails::default();
+
+                    wallets_details.0.insert(
+                        WalletRole::Bridge,
+                        WalletInfo {
+                            addresses: vec![new_bridge_address.clone()],
+                            txid: update_bridge_msg.common.tx_id.clone(),
+                        },
+                    );
+
+                    let verifier_addresses = update_bridge_msg
+                        .input
+                        .verifier_p2wpkh_addresses
+                        .iter()
+                        .map(|addr| addr.clone().assume_checked())
+                        .collect::<Vec<BitcoinAddress>>();
+
+                    wallets_details.0.insert(
+                        WalletRole::Verifier,
+                        WalletInfo {
+                            addresses: verifier_addresses.clone(),
+                            txid: update_bridge_msg.common.tx_id.clone(),
+                        },
+                    );
+
+                    storage
+                        .via_wallet_dal()
+                        .insert_wallets(&wallets_details)
+                        .await?;
+
+                    indexer.update_system_wallets(
+                        None,
+                        Some(new_bridge_address),
+                        Some(verifier_addresses),
+                        None,
+                    );
+
+                    tracing::info!("New bridge address updated: {:?}", &wallets_details);
+
+                    return Ok(true);
+                }
+                _ => return Ok(false),
+            }
+        }
+        Ok(false)
+    }
+
+    async fn handle_update_sequencer(
+        &self,
+        storage: &mut Connection<'_, Core>,
+        update_sequencer_msg: UpdateSequencer,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        tracing::info!("Received UpdateSequencer message");
+        let system_wallets_map = match storage
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await
+            .unwrap()
+        {
+            Some(map) => map,
+            None => Default::default(),
+        };
+
+        let system_wallets = SystemWallets::try_from(system_wallets_map)?;
+
+        let new_sequencer_address = update_sequencer_msg.input.address.assume_checked();
+
+        // Skip if sequencer already registered
+        if system_wallets.sequencer == new_sequencer_address {
+            tracing::info!("Sequencer wallet already exists, skipping");
+            return Ok(false);
+        }
+
+        let mut wallets_details = SystemWalletsDetails::default();
+
+        wallets_details.0.insert(
+            WalletRole::Sequencer,
+            WalletInfo {
+                addresses: vec![new_sequencer_address.clone()],
+                txid: update_sequencer_msg.common.tx_id.clone(),
+            },
+        );
+
+        storage
+            .via_wallet_dal()
+            .insert_wallets(&wallets_details)
+            .await?;
+
+        indexer.update_system_wallets(Some(new_sequencer_address), None, None, None);
+
+        tracing::info!("New sequencer address updated: {:?}", &wallets_details);
+
+        Ok(true)
+    }
+
+    async fn handle_update_governance(
+        &self,
+        storage: &mut Connection<'_, Core>,
+        update_governance_msg: UpdateGovernance,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        tracing::info!("Received UpdateGovernance message");
+
+        let system_wallets_map = match storage
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await
+            .unwrap()
+        {
+            Some(map) => map,
+            None => Default::default(),
+        };
+
+        let system_wallets = SystemWallets::try_from(system_wallets_map)?;
+
+        let new_governance_address = update_governance_msg.input.address.assume_checked();
+
+        // Skip if sequencer already registered
+        if system_wallets.governance == new_governance_address {
+            tracing::info!("Sequencer wallet already exists, skipping");
+            return Ok(false);
+        }
+
+        let mut wallets_details = SystemWalletsDetails::default();
+
+        wallets_details.0.insert(
+            WalletRole::Gov,
+            WalletInfo {
+                addresses: vec![new_governance_address.clone()],
+                txid: update_governance_msg.common.tx_id.clone(),
+            },
+        );
+
+        storage
+            .via_wallet_dal()
+            .insert_wallets(&wallets_details)
+            .await?;
+
+        indexer.update_system_wallets(None, None, None, Some(new_governance_address));
+
+        tracing::info!("New governance address updated: {:?}", &wallets_details);
+
+        Ok(true)
+    }
+}

--- a/core/node/via_btc_watch/src/message_processors/votable.rs
+++ b/core/node/via_btc_watch/src/message_processors/votable.rs
@@ -24,7 +24,7 @@ impl MessageProcessor for VotableMessageProcessor {
         storage: &mut Connection<'_, Core>,
         msgs: Vec<FullInscriptionMessage>,
         indexer: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         for msg in msgs {
             match msg {
                 ref f @ FullInscriptionMessage::ValidatorAttestation(ref attestation_msg) => {
@@ -104,6 +104,6 @@ impl MessageProcessor for VotableMessageProcessor {
                 _ => (),
             }
         }
-        Ok(())
+        Ok(true)
     }
 }

--- a/core/node/via_btc_watch/src/test/mod.rs
+++ b/core/node/via_btc_watch/src/test/mod.rs
@@ -1,0 +1,1 @@
+mod system_wallets;

--- a/core/node/via_btc_watch/src/test/system_wallets.rs
+++ b/core/node/via_btc_watch/src/test/system_wallets.rs
@@ -1,0 +1,286 @@
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use via_btc_client::types::BitcoinAddress;
+    use via_test_utils::utils::{
+        create_update_bridge_inscription, create_update_governance_inscription,
+        create_update_sequencer_inscription, random_bitcoin_wallet, test_bitcoin_client,
+        test_create_indexer, test_wallets,
+    };
+    use zksync_dal::{ConnectionPool, Core, CoreDal};
+    use zksync_types::via_wallet::{SystemWallets, SystemWalletsDetails};
+
+    use crate::{message_processors::SystemWalletProcessor, MessageProcessor};
+
+    #[tokio::test]
+    async fn test_update_sequencer_wallet() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_sequencer_address = random_bitcoin_wallet().1;
+        let msg = create_update_sequencer_inscription(new_sequencer_address.clone());
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.sequencer, new_sequencer_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_governance_wallet() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_governance_address = random_bitcoin_wallet().1;
+        let msg = create_update_governance_inscription(new_governance_address.clone());
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.governance, new_governance_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_bridge_wallet_with_4_new_verifiers_when_old_3() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_bridge_address = BitcoinAddress::from_str(
+            &"bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg",
+        )?
+        .assume_checked();
+
+        let new_verifier_1 = random_bitcoin_wallet().1;
+        let new_verifier_2 = random_bitcoin_wallet().1;
+        let new_verifier_3 = random_bitcoin_wallet().1;
+        let new_verifier_4 = random_bitcoin_wallet().1;
+
+        let new_verifiers = vec![
+            new_verifier_1,
+            new_verifier_2,
+            new_verifier_3,
+            new_verifier_4,
+        ];
+
+        let msg =
+            create_update_bridge_inscription(new_bridge_address.clone(), new_verifiers.clone())
+                .await?;
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.bridge, new_bridge_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_bridge_wallet_with_2_new_verifiers_when_old_3() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_bridge_address = BitcoinAddress::from_str(
+            &"bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg",
+        )?
+        .assume_checked();
+
+        let new_verifier_1 = random_bitcoin_wallet().1;
+        let new_verifier_2 = random_bitcoin_wallet().1;
+
+        let new_verifiers = vec![new_verifier_1, new_verifier_2];
+
+        let msg =
+            create_update_bridge_inscription(new_bridge_address.clone(), new_verifiers.clone())
+                .await?;
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.bridge, new_bridge_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_governance_bridge_wallet_and_sequencer() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+
+        let new_governance_address = random_bitcoin_wallet().1;
+        let gov_msg = create_update_governance_inscription(new_governance_address.clone());
+
+        let new_sequencer_address = random_bitcoin_wallet().1;
+        let sequencer_msg = create_update_sequencer_inscription(new_sequencer_address.clone());
+
+        let new_bridge_address = BitcoinAddress::from_str(
+            &"bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg",
+        )?
+        .assume_checked();
+
+        let new_verifier_1 = random_bitcoin_wallet().1;
+        let new_verifier_2 = random_bitcoin_wallet().1;
+        let new_verifier_3 = random_bitcoin_wallet().1;
+        let new_verifier_4 = random_bitcoin_wallet().1;
+
+        let new_verifiers = vec![
+            new_verifier_1,
+            new_verifier_2,
+            new_verifier_3,
+            new_verifier_4,
+        ];
+
+        let bridge_msg =
+            create_update_bridge_inscription(new_bridge_address.clone(), new_verifiers.clone())
+                .await?;
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(
+                &mut pool.connection().await?,
+                vec![bridge_msg, sequencer_msg, gov_msg],
+                &mut indexer,
+            )
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.bridge, new_bridge_address);
+        assert_eq!(new_wallets.sequencer, new_sequencer_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+}

--- a/via_verifier/node/via_btc_watch/src/message_processors/governance_upgrade.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/governance_upgrade.rs
@@ -43,7 +43,7 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
         storage: &mut Connection<'_, Verifier>,
         msgs: Vec<FullInscriptionMessage>,
         _: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         let mut upgrades = Vec::new();
         for msg in msgs {
             if let FullInscriptionMessage::SystemContractUpgrade(system_contract_upgrade_msg) = &msg
@@ -134,6 +134,6 @@ impl MessageProcessor for GovernanceUpgradesEventProcessor {
                 .await
                 .map_err(DalError::generalize)?;
         }
-        Ok(())
+        Ok(true)
     }
 }

--- a/via_verifier/node/via_btc_watch/src/message_processors/l1_to_l2.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/l1_to_l2.rs
@@ -38,7 +38,7 @@ impl MessageProcessor for L1ToL2MessageProcessor {
         storage: &mut Connection<'_, Verifier>,
         msgs: Vec<FullInscriptionMessage>,
         _: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         let mut priority_ops = Vec::new();
 
         for msg in msgs {
@@ -75,7 +75,7 @@ impl MessageProcessor for L1ToL2MessageProcessor {
         }
 
         if priority_ops.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         for new_op in priority_ops {
@@ -93,7 +93,7 @@ impl MessageProcessor for L1ToL2MessageProcessor {
                 .map_err(|e| MessageProcessorError::DatabaseError(e.to_string()))?;
         }
 
-        Ok(())
+        Ok(true)
     }
 }
 

--- a/via_verifier/node/via_btc_watch/src/message_processors/mod.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use governance_upgrade::GovernanceUpgradesEventProcessor;
 pub(crate) use l1_to_l2::L1ToL2MessageProcessor;
+pub(crate) use system_wallet::SystemWalletProcessor;
 pub(crate) use verifier::VerifierMessageProcessor;
 use via_btc_client::{
     indexer::BitcoinInscriptionIndexer,
@@ -11,6 +12,7 @@ use zksync_types::H256;
 
 mod governance_upgrade;
 mod l1_to_l2;
+mod system_wallet;
 mod verifier;
 mod withdrawal;
 
@@ -43,7 +45,7 @@ pub(super) trait MessageProcessor: 'static + std::fmt::Debug + Send + Sync {
         storage: &mut Connection<'_, Verifier>,
         msgs: Vec<FullInscriptionMessage>,
         indexer: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError>;
+    ) -> Result<bool, MessageProcessorError>;
 }
 
 pub(crate) fn convert_txid_to_h256(txid: BitcoinTxid) -> H256 {

--- a/via_verifier/node/via_btc_watch/src/message_processors/system_wallet.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/system_wallet.rs
@@ -1,0 +1,272 @@
+use std::sync::Arc;
+
+use via_btc_client::{
+    client::BitcoinClient,
+    indexer::{BitcoinInscriptionIndexer, MessageParser},
+    traits::BitcoinOps,
+    types::{
+        BitcoinAddress, FullInscriptionMessage, UpdateBridge, UpdateGovernance, UpdateSequencer,
+    },
+};
+use via_verifier_dal::{Connection, Verifier, VerifierDal};
+use zksync_types::via_wallet::{SystemWallets, SystemWalletsDetails, WalletInfo, WalletRole};
+
+use crate::message_processors::{MessageProcessor, MessageProcessorError};
+
+#[derive(Debug)]
+pub struct SystemWalletProcessor {
+    /// BTC client
+    btc_client: Arc<BitcoinClient>,
+}
+
+impl SystemWalletProcessor {
+    pub fn new(btc_client: Arc<BitcoinClient>) -> Self {
+        Self { btc_client }
+    }
+}
+
+#[async_trait::async_trait]
+impl MessageProcessor for SystemWalletProcessor {
+    async fn process_messages(
+        &mut self,
+        storage: &mut Connection<'_, Verifier>,
+        msgs: Vec<FullInscriptionMessage>,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        let mut wallets_updated = false;
+
+        let msgs = FullInscriptionMessage::sort_messages(msgs);
+
+        for msg in msgs {
+            match msg {
+                FullInscriptionMessage::UpdateGovernance(msg) => {
+                    let updated = self.handle_update_governance(storage, msg, indexer).await?;
+                    // Make sure to not override the wallets_updated if "wallets_updated" it's already true.
+                    if updated {
+                        wallets_updated = updated;
+                    }
+                }
+                FullInscriptionMessage::UpdateSequencer(msg) => {
+                    let updated = self.handle_update_sequencer(storage, msg, indexer).await?;
+                    if updated {
+                        wallets_updated = updated;
+                    }
+                }
+                FullInscriptionMessage::UpdateBridge(msg) => {
+                    let updated = self
+                        .handle_update_bridge_proposal(storage, msg, indexer)
+                        .await?;
+                    if updated {
+                        wallets_updated = updated;
+                    }
+                }
+
+                _ => {}
+            }
+        }
+        Ok(wallets_updated)
+    }
+}
+
+impl SystemWalletProcessor {
+    async fn handle_update_bridge_proposal(
+        &self,
+        storage: &mut Connection<'_, Verifier>,
+        update_bridge_msg: UpdateBridge,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        let proposal_tx_id = update_bridge_msg.input.proposal_tx_id;
+
+        let proposal_tx = self
+            .btc_client
+            .get_transaction(&proposal_tx_id)
+            .await
+            .map_err(|err| {
+                MessageProcessorError::Internal(anyhow::anyhow!(
+                    "Failed to fetch update bridge proposal transaction: {}, error {}",
+                    proposal_tx_id,
+                    err
+                ))
+            })?;
+
+        let mut message_parser = MessageParser::new(self.btc_client.get_network());
+
+        let messages = message_parser
+            .parse_system_transaction(&proposal_tx, update_bridge_msg.common.block_height);
+
+        for message in messages {
+            match message {
+                FullInscriptionMessage::UpdateBridgeProposal(update_bridge_msg) => {
+                    let system_wallets_map =
+                        match storage.via_wallet_dal().get_system_wallets_raw().await? {
+                            Some(map) => map,
+                            None => Default::default(),
+                        };
+
+                    let system_wallets = SystemWallets::try_from(system_wallets_map)?;
+
+                    let new_bridge_address = match update_bridge_msg
+                        .input
+                        .bridge_musig2_address
+                        .require_network(self.btc_client.get_network())
+                    {
+                        Ok(address) => address,
+                        Err(err) => {
+                            tracing::error!("Failed to parse bridge address: {}", err);
+                            return Ok(false);
+                        }
+                    };
+
+                    // Skip if bridge already registered
+                    if system_wallets.bridge == new_bridge_address {
+                        tracing::info!("Bridge wallet already exists, skipping");
+                        return Ok(false);
+                    }
+
+                    let mut wallets_details = SystemWalletsDetails::default();
+
+                    wallets_details.0.insert(
+                        WalletRole::Bridge,
+                        WalletInfo {
+                            addresses: vec![new_bridge_address.clone()],
+                            txid: update_bridge_msg.common.tx_id.clone(),
+                        },
+                    );
+
+                    let verifier_addresses = update_bridge_msg
+                        .input
+                        .verifier_p2wpkh_addresses
+                        .iter()
+                        .map(|addr| addr.clone().assume_checked())
+                        .collect::<Vec<BitcoinAddress>>();
+
+                    wallets_details.0.insert(
+                        WalletRole::Verifier,
+                        WalletInfo {
+                            addresses: verifier_addresses.clone(),
+                            txid: update_bridge_msg.common.tx_id.clone(),
+                        },
+                    );
+
+                    storage
+                        .via_wallet_dal()
+                        .insert_wallets(&wallets_details)
+                        .await?;
+
+                    indexer.update_system_wallets(
+                        None,
+                        Some(new_bridge_address),
+                        Some(verifier_addresses),
+                        None,
+                    );
+
+                    tracing::info!("New bridge address updated: {:?}", &wallets_details);
+
+                    return Ok(true);
+                }
+                _ => return Ok(false),
+            }
+        }
+        Ok(false)
+    }
+
+    async fn handle_update_sequencer(
+        &self,
+        storage: &mut Connection<'_, Verifier>,
+        update_sequencer_msg: UpdateSequencer,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        tracing::info!("Received UpdateSequencer message");
+
+        let system_wallets_map = match storage
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await
+            .unwrap()
+        {
+            Some(map) => map,
+            None => Default::default(),
+        };
+
+        let system_wallets = SystemWallets::try_from(system_wallets_map)?;
+
+        let new_sequencer_address = update_sequencer_msg.input.address.assume_checked();
+
+        // Skip if sequencer already registered
+        if system_wallets.sequencer == new_sequencer_address {
+            tracing::info!("Sequencer wallet already exists, skipping");
+            return Ok(false);
+        }
+
+        let mut wallets_details = SystemWalletsDetails::default();
+
+        wallets_details.0.insert(
+            WalletRole::Sequencer,
+            WalletInfo {
+                addresses: vec![new_sequencer_address.clone()],
+                txid: update_sequencer_msg.common.tx_id.clone(),
+            },
+        );
+
+        storage
+            .via_wallet_dal()
+            .insert_wallets(&wallets_details)
+            .await?;
+
+        indexer.update_system_wallets(Some(new_sequencer_address), None, None, None);
+
+        tracing::info!("New sequencer address updated: {:?}", &wallets_details);
+
+        Ok(true)
+    }
+
+    async fn handle_update_governance(
+        &self,
+        storage: &mut Connection<'_, Verifier>,
+        update_governance_msg: UpdateGovernance,
+        indexer: &mut BitcoinInscriptionIndexer,
+    ) -> Result<bool, MessageProcessorError> {
+        tracing::info!("Received UpdateGovernance message");
+
+        let system_wallets_map = match storage
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await
+            .unwrap()
+        {
+            Some(map) => map,
+            None => Default::default(),
+        };
+
+        let system_wallets = SystemWallets::try_from(system_wallets_map)?;
+
+        let new_governance_address = update_governance_msg.input.address.assume_checked();
+
+        // Skip if sequencer already registered
+        if system_wallets.governance == new_governance_address {
+            tracing::info!("Sequencer wallet already exists, skipping");
+            return Ok(false);
+        }
+
+        let mut wallets_details = SystemWalletsDetails::default();
+
+        wallets_details.0.insert(
+            WalletRole::Gov,
+            WalletInfo {
+                addresses: vec![new_governance_address.clone()],
+                txid: update_governance_msg.common.tx_id.clone(),
+            },
+        );
+
+        storage
+            .via_wallet_dal()
+            .insert_wallets(&wallets_details)
+            .await?;
+
+        indexer.update_system_wallets(None, None, None, Some(new_governance_address));
+
+        tracing::info!("New governance address updated: {:?}", &wallets_details);
+
+        Ok(true)
+    }
+}

--- a/via_verifier/node/via_btc_watch/src/message_processors/verifier.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/verifier.rs
@@ -24,7 +24,7 @@ impl MessageProcessor for VerifierMessageProcessor {
         storage: &mut Connection<'_, Verifier>,
         msgs: Vec<FullInscriptionMessage>,
         indexer: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         for msg in msgs {
             match msg {
                 FullInscriptionMessage::ProofDAReference(ref proof_msg) => {
@@ -202,6 +202,6 @@ impl MessageProcessor for VerifierMessageProcessor {
                 _ => (),
             }
         }
-        Ok(())
+        Ok(false)
     }
 }

--- a/via_verifier/node/via_btc_watch/src/message_processors/withdrawal.rs
+++ b/via_verifier/node/via_btc_watch/src/message_processors/withdrawal.rs
@@ -24,7 +24,7 @@ impl MessageProcessor for WithdrawalProcessor {
         storage: &mut Connection<'_, Verifier>,
         msgs: Vec<FullInscriptionMessage>,
         _: &mut BitcoinInscriptionIndexer,
-    ) -> Result<(), MessageProcessorError> {
+    ) -> Result<bool, MessageProcessorError> {
         for msg in msgs {
             if let FullInscriptionMessage::BridgeWithdrawal(withdrawal_msg) = msg {
                 tracing::info!("Processing withdrawal bridge transaction...");
@@ -62,7 +62,7 @@ impl MessageProcessor for WithdrawalProcessor {
                             "Withdrawal already processed for batch {}. Skipping.",
                             l1_batch_number
                         );
-                        return Ok(());
+                        continue;
                     }
 
                     return Err(MessageProcessorError::SyncError(format!(
@@ -90,6 +90,6 @@ impl MessageProcessor for WithdrawalProcessor {
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 }

--- a/via_verifier/node/via_btc_watch/src/test/mod.rs
+++ b/via_verifier/node/via_btc_watch/src/test/mod.rs
@@ -1,2 +1,2 @@
-#[cfg(test)]
+mod system_wallets;
 mod verifier;

--- a/via_verifier/node/via_btc_watch/src/test/system_wallets.rs
+++ b/via_verifier/node/via_btc_watch/src/test/system_wallets.rs
@@ -1,0 +1,286 @@
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use via_btc_client::types::BitcoinAddress;
+    use via_test_utils::utils::{
+        create_update_bridge_inscription, create_update_governance_inscription,
+        create_update_sequencer_inscription, random_bitcoin_wallet, test_bitcoin_client,
+        test_create_indexer, test_wallets,
+    };
+    use via_verifier_dal::{ConnectionPool, Verifier, VerifierDal};
+    use zksync_types::via_wallet::{SystemWallets, SystemWalletsDetails};
+
+    use crate::{message_processors::SystemWalletProcessor, MessageProcessor};
+
+    #[tokio::test]
+    async fn test_update_sequencer_wallet() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Verifier>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_sequencer_address = random_bitcoin_wallet().1;
+        let msg = create_update_sequencer_inscription(new_sequencer_address.clone());
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.sequencer, new_sequencer_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_governance_wallet() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Verifier>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_governance_address = random_bitcoin_wallet().1;
+        let msg = create_update_governance_inscription(new_governance_address.clone());
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.governance, new_governance_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_bridge_wallet_with_4_new_verifiers_when_old_3() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Verifier>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_bridge_address = BitcoinAddress::from_str(
+            &"bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg",
+        )?
+        .assume_checked();
+
+        let new_verifier_1 = random_bitcoin_wallet().1;
+        let new_verifier_2 = random_bitcoin_wallet().1;
+        let new_verifier_3 = random_bitcoin_wallet().1;
+        let new_verifier_4 = random_bitcoin_wallet().1;
+
+        let new_verifiers = vec![
+            new_verifier_1,
+            new_verifier_2,
+            new_verifier_3,
+            new_verifier_4,
+        ];
+
+        let msg =
+            create_update_bridge_inscription(new_bridge_address.clone(), new_verifiers.clone())
+                .await?;
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.bridge, new_bridge_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_bridge_wallet_with_2_new_verifiers_when_old_3() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Verifier>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+        let new_bridge_address = BitcoinAddress::from_str(
+            &"bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg",
+        )?
+        .assume_checked();
+
+        let new_verifier_1 = random_bitcoin_wallet().1;
+        let new_verifier_2 = random_bitcoin_wallet().1;
+
+        let new_verifiers = vec![new_verifier_1, new_verifier_2];
+
+        let msg =
+            create_update_bridge_inscription(new_bridge_address.clone(), new_verifiers.clone())
+                .await?;
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(&mut pool.connection().await?, vec![msg], &mut indexer)
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.bridge, new_bridge_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_governance_bridge_wallet_and_sequencer() -> anyhow::Result<()> {
+        let pool = ConnectionPool::<Verifier>::test_pool().await;
+        let mut indexer = test_create_indexer();
+
+        let system_wallet_map = SystemWalletsDetails::try_from(test_wallets())?;
+        pool.connection()
+            .await?
+            .via_wallet_dal()
+            .insert_wallets(&system_wallet_map)
+            .await?;
+
+        let mut processor = SystemWalletProcessor::new(Arc::new(test_bitcoin_client()));
+
+        let new_governance_address = random_bitcoin_wallet().1;
+        let gov_msg = create_update_governance_inscription(new_governance_address.clone());
+
+        let new_sequencer_address = random_bitcoin_wallet().1;
+        let sequencer_msg = create_update_sequencer_inscription(new_sequencer_address.clone());
+
+        let new_bridge_address = BitcoinAddress::from_str(
+            &"bcrt1pcx974cg2w66cqhx67zadf85t8k4sd2wp68l8x8agd3aj4tuegsgsz97amg",
+        )?
+        .assume_checked();
+
+        let new_verifier_1 = random_bitcoin_wallet().1;
+        let new_verifier_2 = random_bitcoin_wallet().1;
+        let new_verifier_3 = random_bitcoin_wallet().1;
+        let new_verifier_4 = random_bitcoin_wallet().1;
+
+        let new_verifiers = vec![
+            new_verifier_1,
+            new_verifier_2,
+            new_verifier_3,
+            new_verifier_4,
+        ];
+
+        let bridge_msg =
+            create_update_bridge_inscription(new_bridge_address.clone(), new_verifiers.clone())
+                .await?;
+
+        let old_wallets = indexer.get_state();
+
+        processor
+            .process_messages(
+                &mut pool.connection().await?,
+                vec![bridge_msg, sequencer_msg, gov_msg],
+                &mut indexer,
+            )
+            .await?;
+
+        let new_wallets = indexer.get_state();
+
+        assert_ne!(new_wallets, old_wallets);
+        assert_eq!(new_wallets.bridge, new_bridge_address);
+        assert_eq!(new_wallets.sequencer, new_sequencer_address);
+
+        let system_wallets_db_map = pool
+            .connection()
+            .await?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await?
+            .unwrap();
+
+        let system_wallets_db = Arc::new(SystemWallets::try_from(system_wallets_db_map.clone())?);
+
+        assert_eq!(system_wallets_db, new_wallets);
+
+        Ok(())
+    }
+}

--- a/via_verifier/node/via_btc_watch/src/test/verifier.rs
+++ b/via_verifier/node/via_btc_watch/src/test/verifier.rs
@@ -1,18 +1,17 @@
 #[cfg(test)]
 mod tests {
+    use via_test_utils::utils::{
+        create_chained_inscriptions, test_create_indexer, test_verifier_add_1, test_verifier_add_2,
+    };
     use via_verifier_dal::{ConnectionPool, Verifier, VerifierDal};
     use zksync_types::H256;
 
     use crate::{message_processors::VerifierMessageProcessor, MessageProcessor};
 
-    use via_test_utils::utils::{
-        create_chained_inscriptions, test_create_indexer, test_verifier_add_1, test_verifier_add_2,
-    };
-
     #[tokio::test]
     async fn test_insert_first_batch() -> anyhow::Result<()> {
         let pool = ConnectionPool::<Verifier>::test_pool().await;
-        let mut indexer = test_create_indexer().await?;
+        let mut indexer = test_create_indexer();
         let start = 1;
         let end = 1;
 
@@ -46,7 +45,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_two_times_first_batch() -> anyhow::Result<()> {
         let pool = ConnectionPool::<Verifier>::test_pool().await;
-        let mut indexer = test_create_indexer().await?;
+        let mut indexer = test_create_indexer();
         let start = 1;
         let end = 1;
 
@@ -84,7 +83,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_multiple_batches() -> anyhow::Result<()> {
         let pool = ConnectionPool::<Verifier>::test_pool().await;
-        let mut indexer = test_create_indexer().await?;
+        let mut indexer = test_create_indexer();
 
         let mut processor = VerifierMessageProcessor::new(1.0);
         let start = 1;
@@ -121,7 +120,7 @@ mod tests {
     #[tokio::test]
     async fn test_should_fail_to_insert_batch_with_invalid_prev_batch_hash() -> anyhow::Result<()> {
         let pool = ConnectionPool::<Verifier>::test_pool().await;
-        let mut indexer = test_create_indexer().await?;
+        let mut indexer = test_create_indexer();
         let mut processor = VerifierMessageProcessor::new(1.0);
         let start = 1;
         let end = 2;
@@ -303,7 +302,7 @@ mod tests {
     #[tokio::test]
     async fn test_should_not_insert_batch_zero() -> anyhow::Result<()> {
         let pool = ConnectionPool::<Verifier>::test_pool().await;
-        let mut indexer = test_create_indexer().await?;
+        let mut indexer = test_create_indexer();
         let start = 0;
         let end = 0;
 
@@ -332,7 +331,7 @@ mod tests {
     ) -> anyhow::Result<()> {
         let pool = ConnectionPool::<Verifier>::test_pool().await;
 
-        let mut indexer = test_create_indexer().await?;
+        let mut indexer = test_create_indexer();
         let mut processor = VerifierMessageProcessor::new(1.0);
         let start = 1;
         let end = 2;


### PR DESCRIPTION
## What ❔

- Add system wallets message processor to index and store the update wallets.
- Add e2e tests to system wallets message.

## Why ❔

Before this PR, updating system wallets was not possible. When the sequencer wallet was updated, the verifier network stopped processing batches because it was not notified of the change.
With this PR, the verifier network is now aware whenever a system address is updated and can react accordingly.

## Checklist
- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
