### PR TITLE
feat: add script to create a gov tx to transfer utxo from bridge

### DIFF
--- a/docs/via_guides/upgrade.md
+++ b/docs/via_guides/upgrade.md
@@ -341,3 +341,70 @@ via token deposit --amount 10 --receiver-l2-address 0x36615Cf349d7F6344891B1e7CA
 
 8. Withdraw 1 BTC.
 9. The verifier and coordinator process the batch and sequencer finalize the batch.
+
+## Transfer the UTXOs from the old bridge address to the governance wallet
+
+1. Get the UTXOs you want to transfer, then create a file `utxos.json`. Each utxo should has a `txid`, `vout` and
+   `value`
+
+```json
+[
+  {
+    "txid": "1a32c75a5b859ebe799cc00a0d4389633204f5ac607965dba2878a2de627dc8f",
+    "vout": 1,
+    "value": 100000000
+  }
+  ...
+]
+```
+
+```sh
+curl --user rpcuser:rpcpassword \
+  --data-binary '{
+    "jsonrpc": "1.0",
+    "id": "scan_utxo",
+    "method": "scantxoutset",
+    "params": [
+      "start",
+      [
+        { "desc": "addr(bcrt1pfk264lnycy2v48h3we2jajyg7kyuvha9yfkd4qmxfrgywz3meyhqhdhmj8)", "range": 1000 }
+      ]
+    ]
+  }' \
+  -H 'content-type: text/plain;' \
+  http://127.0.0.1:18443/
+```
+
+2. Create a new tx
+
+```sh
+cargo run \
+    --example transfer_utxos_from_bridge -- \
+    --from-address bcrt1pfk264lnycy2v48h3we2jajyg7kyuvha9yfkd4qmxfrgywz3meyhqhdhmj8 \
+    --to-address bcrt1q92gkfme6k9dkpagrkwt76etkaq29hvf02w5m38f6shs4ddpw7hzqp347zm \
+    --action prepare
+```
+
+2. The signer 1 sign
+
+```sh
+cargo run --example transfer_utxos_from_bridge -- --action sign --private-key cQnW8oDqEME4gxJHC4MC9HvJECcF7Ju8oanWdjWLGxDbkfWo7vZa
+```
+
+3. The signer 2 sign
+
+```sh
+cargo run --example transfer_utxos_from_bridge -- --action sign --private-key cVJYEHTzmfdRPoX6fL3vRnZVmqy4D1sWaT5WL9U25oZhQktoeHgo
+```
+
+2. Finalise the tx
+
+```sh
+cargo run --example transfer_utxos_from_bridge -- --action finalize
+```
+
+2. Broadcast the transaction
+
+```sh
+cargo run --example transfer_utxos_from_bridge -- --action broadcast
+```

--- a/docs/via_guides/upgrade.md
+++ b/docs/via_guides/upgrade.md
@@ -344,19 +344,17 @@ via token deposit --amount 10 --receiver-l2-address 0x36615Cf349d7F6344891B1e7CA
 
 ## Transfer the UTXOs from the old bridge address to the governance wallet
 
-1. Get the UTXOs you want to transfer, then create a file `utxos.json`. Each utxo should has a `txid`, `vout` and
-   `value`
+1. Sent UTXO to the bridge wallet
 
-```json
-[
-  {
-    "txid": "1a32c75a5b859ebe799cc00a0d4389633204f5ac607965dba2878a2de627dc8f",
-    "vout": 1,
-    "value": 100000000
-  }
-  ...
-]
+```sh
+curl --user rpcuser:rpcpassword \
+     --data-binary '{"jsonrpc":"1.0","id":"sendbtc","method":"sendtoaddress","params":["bcrt1pfk264lnycy2v48h3we2jajyg7kyuvha9yfkd4qmxfrgywz3meyhqhdhmj8", 1]}' \
+     -H 'content-type: text/plain;' \
+     http://127.0.0.1:18443/wallet/Alice
 ```
+
+2. List the UTXOs you want to transfer, then create a file `utxos.json`. Each utxo should has a `txid`, `vout` and
+   `value`
 
 ```sh
 curl --user rpcuser:rpcpassword \
@@ -373,6 +371,17 @@ curl --user rpcuser:rpcpassword \
   }' \
   -H 'content-type: text/plain;' \
   http://127.0.0.1:18443/
+```
+
+```json
+[
+  {
+    "txid": "<txid>",
+    "vout": 1,
+    "value": 100000000
+  }
+  ...
+]
 ```
 
 2. Create a new tx

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -70,3 +70,7 @@ path = "examples/musig2_with_script_path.rs"
 [[example]]
 name = "compute_musig2"
 path = "examples/compute_musig2.rs"
+
+[[example]]
+name = "transfer_utxos_from_bridge"
+path = "examples/transfer_utxos_from_bridge.rs"

--- a/via_verifier/lib/via_musig2/examples/transfer_utxos_from_bridge.rs
+++ b/via_verifier/lib/via_musig2/examples/transfer_utxos_from_bridge.rs
@@ -1,0 +1,375 @@
+use std::{collections::HashMap, fs::File, str::FromStr};
+
+use anyhow::{anyhow, Context, Result};
+use bitcoin::{
+    absolute::LockTime,
+    consensus::{self, encode::serialize_hex},
+    hashes::Hash,
+    hex::DisplayHex,
+    secp256k1::{self, Keypair, Secp256k1, SecretKey},
+    sighash::{Prevouts, SighashCache},
+    taproot::LeafVersion,
+    transaction::Version,
+    Address, Amount, Network, OutPoint, PrivateKey, ScriptBuf, Sequence, TapLeafHash,
+    TapSighashType, Transaction, TxIn, TxOut, Txid, Witness,
+};
+use bitcoincore_rpc::Auth;
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use via_btc_client::{client::BitcoinClient, traits::BitcoinOps};
+use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    #[arg(long)]
+    private_key: Option<String>,
+
+    #[arg(long)]
+    signers_public_keys: Vec<String>,
+
+    #[arg(long, default_value = "my_wallet.json")]
+    wallet_path: String,
+
+    #[arg(long, default_value = "utxos.json")]
+    utxos_path: Option<String>,
+
+    #[arg(long)]
+    from_address: Option<String>,
+
+    #[arg(long)]
+    to_address: Option<String>,
+
+    #[arg(long, default_value = "500")]
+    fee: u64,
+
+    #[arg(long, default_value = "regtest")]
+    network: String,
+
+    #[arg(long, default_value = "gov_bridge_tx.json")]
+    output: String,
+
+    #[arg(long, default_value = "prepare")]
+    action: String,
+
+    #[arg(long, default_value = "http://0.0.0.0:18443")]
+    rpc_url: String,
+
+    #[arg(long, default_value = "rpcuser")]
+    rpc_username: String,
+
+    #[arg(long, default_value = "rpcpassword")]
+    rpc_password: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+enum Action {
+    Prepare,
+    Sign,
+    Finalize,
+    Broadcast,
+}
+
+impl Action {
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "prepare" => Ok(Action::Prepare),
+            "sign" => Ok(Action::Sign),
+            "finalize" => Ok(Action::Finalize),
+            "broadcast" => Ok(Action::Broadcast),
+            _ => Err(anyhow!("Invalid action: {s}")),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+struct UTXO {
+    txid: String,
+    vout: u32,
+    value: u64,
+}
+
+impl UTXO {
+    fn to_parts(&self, from: &Address) -> (OutPoint, TxOut) {
+        (
+            OutPoint {
+                txid: Txid::from_str(&self.txid).expect("Invalid txid format"),
+                vout: self.vout,
+            },
+            TxOut {
+                value: Amount::from_sat(self.value),
+                script_pubkey: from.script_pubkey(),
+            },
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct WalletData {
+    public_keys: Vec<String>,
+    aggregated_internal_key: String,
+    governance_script_hex: String,
+    taproot_output_key: String,
+    merkle_root: Option<String>,
+    taproot_address: String,
+    control_block: String,
+    threshold: usize,
+    total_governance_keys: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct OutputData {
+    messages: Vec<String>,
+    signatures: Option<HashMap<String, Vec<String>>>,
+    tx: String,
+    signed_tx: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    match Action::from_str(&args.action)? {
+        Action::Prepare => do_prepare(&args).await?,
+        Action::Sign => do_sign(&args)?,
+        Action::Finalize => do_finalize(&args)?,
+        Action::Broadcast => do_broadcast(&args).await?,
+    }
+    Ok(())
+}
+
+async fn do_prepare(args: &Args) -> Result<()> {
+    let wallet: WalletData = read_json(&args.wallet_path)?;
+    let network = Network::from_str(&args.network)?;
+    let from_address = Address::from_str(
+        &args
+            .from_address
+            .clone()
+            .ok_or_else(|| anyhow!("Missing from address"))?,
+    )?
+    .require_network(network.clone())?;
+    let to_address = Address::from_str(
+        &args
+            .to_address
+            .clone()
+            .ok_or(anyhow!("Missing to address"))?,
+    )?
+    .require_network(network.clone())?;
+
+    let utxos: Vec<(OutPoint, TxOut)> = read_json::<Vec<UTXO>>(
+        &args
+            .utxos_path
+            .clone()
+            .ok_or(anyhow!("Missing utxos path"))?,
+    )?
+    .into_iter()
+    .map(|u| u.to_parts(&from_address))
+    .collect();
+
+    let tx = build_tx(utxos.clone(), Amount::from_sat(args.fee), to_address);
+
+    let messages = compute_inputs_sig_hashes(
+        tx.clone(),
+        utxos.clone(),
+        ScriptBuf::from_hex(&wallet.governance_script_hex)?,
+    )
+    .await?
+    .iter()
+    .map(|m| hex::encode(m.as_ref()))
+    .collect();
+
+    let output_data = OutputData {
+        messages,
+        signatures: None,
+        tx: serialize_hex(&tx),
+        signed_tx: None,
+    };
+    write_json(&args.output, &output_data)
+}
+
+fn do_sign(args: &Args) -> Result<()> {
+    let mut output: OutputData = read_json(&args.output)?;
+    let messages = output
+        .messages
+        .iter()
+        .map(|m| {
+            let bytes = hex::decode(m)?;
+            secp256k1::Message::from_digest_slice(&bytes).map_err(|e| anyhow!(e))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let pk_wif = args
+        .private_key
+        .clone()
+        .ok_or_else(|| anyhow!("Missing private key"))?;
+    let secp = Secp256k1::new();
+    let sk = PrivateKey::from_wif(&pk_wif)?;
+    let keypair =
+        Keypair::from_secret_key(&secp, &SecretKey::from_slice(&sk.inner.secret_bytes())?);
+
+    let signer_signatures = sign_tx(keypair, messages)?
+        .iter()
+        .map(|sig| sig.to_hex_string(bitcoin::hex::Case::Lower))
+        .collect::<Vec<_>>();
+
+    output
+        .signatures
+        .get_or_insert_with(HashMap::new)
+        .insert(keypair.public_key().to_string(), signer_signatures);
+
+    write_json(&args.output, &output)
+}
+
+fn do_finalize(args: &Args) -> Result<()> {
+    let mut output: OutputData = read_json(&args.output)?;
+    let wallet: WalletData = read_json(&args.wallet_path)?;
+    let utxos: Vec<UTXO> = read_json(
+        &args
+            .utxos_path
+            .clone()
+            .ok_or(anyhow!("Missing utxos path"))?,
+    )?;
+
+    let signatures = output
+        .signatures
+        .clone()
+        .ok_or_else(|| anyhow!("Missing signatures"))?;
+
+    let witnesses = build_witnesses(
+        args.signers_public_keys.clone(),
+        utxos.len(),
+        hex::decode(&wallet.governance_script_hex)?,
+        hex::decode(&wallet.control_block)?,
+        signatures,
+    )?;
+
+    let tx: Transaction = consensus::deserialize(&hex::decode(&output.tx)?)?;
+    let signed_tx = finalize_tx(tx, witnesses)?;
+    output.signed_tx = Some(serialize_hex(&signed_tx));
+
+    write_json(&args.output, &output)
+}
+
+async fn do_broadcast(args: &Args) -> Result<()> {
+    let output: OutputData = read_json(&args.output)?;
+
+    let auth = Auth::UserPass(args.rpc_username.clone(), args.rpc_password.clone());
+    let config = ViaBtcClientConfig {
+        network: args.network.clone(),
+        external_apis: vec![],
+        fee_strategies: vec![],
+        use_rpc_for_fee_rate: None,
+    };
+
+    let btc_client = BitcoinClient::new(&args.rpc_url.clone(), auth, config).unwrap();
+    let Some(signed_tx) = output.signed_tx else {
+        anyhow::bail!("signed signature missing");
+    };
+    let txid = btc_client.broadcast_signed_transaction(&signed_tx).await?;
+
+    println!("Txid: {:?}", txid.to_string());
+    Ok(())
+}
+
+// ---------- Helpers ----------
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &str) -> Result<T> {
+    let file = File::open(path).with_context(|| format!("Opening {path}"))?;
+    Ok(serde_json::from_reader(file)?)
+}
+
+fn write_json<T: Serialize>(path: &str, value: &T) -> Result<()> {
+    let file = File::create(path).with_context(|| format!("Creating {path}"))?;
+    Ok(serde_json::to_writer_pretty(file, value)?)
+}
+
+fn build_tx(utxos: Vec<(OutPoint, TxOut)>, fee: Amount, to: Address) -> Transaction {
+    let total_amount = utxos.iter().map(|u| u.1.value).sum::<Amount>() - fee;
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: utxos
+            .into_iter()
+            .map(|(op, _)| TxIn {
+                previous_output: op,
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            })
+            .collect(),
+        output: vec![TxOut {
+            value: total_amount,
+            script_pubkey: to.script_pubkey(),
+        }],
+    }
+}
+
+async fn compute_inputs_sig_hashes(
+    tx: Transaction,
+    utxos: Vec<(OutPoint, TxOut)>,
+    multisig_script: ScriptBuf,
+) -> Result<Vec<secp256k1::Message>> {
+    let leaf_hash = TapLeafHash::from_script(&multisig_script, LeafVersion::TapScript);
+    let prevouts: Vec<_> = utxos.into_iter().map(|(_, txout)| txout).collect();
+    let mut sighash_cache = SighashCache::new(&tx);
+
+    (0..prevouts.len())
+        .map(|i| {
+            let sighash = sighash_cache.taproot_script_spend_signature_hash(
+                i,
+                &Prevouts::All(&prevouts),
+                leaf_hash,
+                TapSighashType::All,
+            )?;
+            Ok(secp256k1::Message::from_digest_slice(
+                &sighash.as_raw_hash().as_byte_array().to_vec(),
+            )?)
+        })
+        .collect()
+}
+
+fn sign_tx(kp: Keypair, messages: Vec<secp256k1::Message>) -> Result<Vec<Vec<u8>>> {
+    let secp = Secp256k1::new();
+    messages
+        .into_iter()
+        .map(|msg| {
+            let mut sig = secp.sign_schnorr(&msg, &kp).as_ref().to_vec();
+            sig.push(TapSighashType::All as u8);
+            Ok(sig)
+        })
+        .collect()
+}
+
+fn build_witnesses(
+    signers_public_keys: Vec<String>,
+    total_utxos: usize,
+    multisig_script: Vec<u8>,
+    control_block: Vec<u8>,
+    signatures_per_utxo: HashMap<String, Vec<String>>,
+) -> anyhow::Result<Vec<Witness>> {
+    (0..total_utxos)
+        .map(|utxo_idx| {
+            let mut witness = Witness::new();
+
+            for public_key in signers_public_keys.iter().rev() {
+                let sig = signatures_per_utxo
+                    .get(public_key)
+                    .and_then(|sigs| sigs.get(utxo_idx))
+                    .map(|s| hex::decode(s))
+                    .transpose()?;
+
+                witness.push(sig.unwrap_or_default());
+            }
+
+            witness.push(&multisig_script);
+            witness.push(&control_block);
+            Ok(witness)
+        })
+        .collect::<anyhow::Result<Vec<_>>>()
+}
+
+fn finalize_tx(mut tx: Transaction, witnesses: Vec<Witness>) -> Result<Transaction> {
+    for (i, wit) in witnesses.into_iter().enumerate() {
+        tx.input[i].witness = wit;
+    }
+    Ok(tx)
+}


### PR DESCRIPTION
## What ❔

- Add script that allows the governance multisig to transfer UTXOs from the bridge address using the script path spending method.
- Document the transaction creating process with an example.  

## Testing
- Follow the [docs](https://github.com/vianetwork/via-core/blob/feat/via-gov-script-transfer-utxo-from-bridge/docs/via_guides/upgrade.md#transfer-the-utxos-from-the-old-bridge-address-to-the-governance-wallet) how to transfer utxo from the bridge address to the governance wallet.

<img width="1859" height="1009" alt="Screenshot from 2025-08-11 12-36-55" src="https://github.com/user-attachments/assets/0285b84f-b5f7-46ca-9ecf-a42daa09399b" />

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
