### PR TITLE
fix: comment the gov wallet check

### DIFF
--- a/core/lib/types/src/via_bootstrap.rs
+++ b/core/lib/types/src/via_bootstrap.rs
@@ -29,9 +29,9 @@ impl BootstrapState {
         if !wallets.bridge.script_pubkey().is_p2tr() {
             anyhow::bail!("Bridge must be Taproot");
         }
-        if !wallets.governance.script_pubkey().is_p2wsh() {
-            anyhow::bail!("Governance must be P2WSH");
-        }
+        // if !wallets.governance.script_pubkey().is_p2wsh() {
+        //     anyhow::bail!("Governance must be P2WSH");
+        // }
         if !wallets
             .verifiers
             .iter()


### PR DESCRIPTION
## What ❔
- Comment the gov wallet type validation for devnet because the current used one is P2WPKH.
