### PR TITLE
feat(api): fetch the bridge address from db

### DIFF
--- a/core/bin/via_external_node/src/config/mod.rs
+++ b/core/bin/via_external_node/src/config/mod.rs
@@ -123,7 +123,6 @@ pub(crate) struct RemoteENConfig {
     pub base_token_addr: Address,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
     pub dummy_verifier: bool,
-    pub via_bridge_address: String,
     pub via_network: BitcoinNetwork,
 }
 
@@ -134,10 +133,6 @@ impl RemoteENConfig {
             .rpc_context("get_testnet_paymaster")
             .await?;
         let genesis = client.genesis_config().rpc_context("genesis").await.ok();
-        let via_bridge_address = client
-            .get_bridge_address()
-            .rpc_context("get_bridge_address")
-            .await?;
         let via_network = client
             .get_bitcoin_network()
             .rpc_context("get_bitcoin_network")
@@ -164,7 +159,6 @@ impl RemoteENConfig {
                 .as_ref()
                 .map(|a| a.dummy_verifier)
                 .unwrap_or_default(),
-            via_bridge_address,
             via_network,
         })
     }
@@ -186,7 +180,6 @@ impl RemoteENConfig {
             l2_shared_bridge_addr: Some(Address::repeat_byte(6)),
             l1_batch_commit_data_generator_mode: L1BatchCommitmentMode::Rollup,
             dummy_verifier: true,
-            via_bridge_address: String::new(),
             via_network: BitcoinNetwork::Regtest,
         }
     }
@@ -1369,7 +1362,6 @@ impl From<&ExternalNodeConfig> for InternalApiConfig {
             filters_disabled: config.optional.filters_disabled,
             dummy_verifier: config.remote.dummy_verifier,
             l1_batch_commit_data_generator_mode: config.remote.l1_batch_commit_data_generator_mode,
-            via_bridge_address: config.remote.via_bridge_address.clone(),
             via_network: config.remote.via_network,
         }
     }

--- a/core/bin/via_server/src/node_builder.rs
+++ b/core/bin/via_server/src/node_builder.rs
@@ -313,7 +313,6 @@ impl ViaNodeBuilder {
             response_body_size_limit: Some(rpc_config.max_response_body_size()),
             ..Default::default()
         };
-        let via_bridge_config = try_load_config!(self.configs.via_bridge_config);
         let via_btc_client_config = try_load_config!(self.configs.via_btc_client_config);
 
         self.node.add_layer(Web3ServerLayer::http(
@@ -322,7 +321,6 @@ impl ViaNodeBuilder {
                 &rpc_config,
                 &self.contracts_config,
                 &self.genesis_config,
-                Some(via_bridge_config.bridge_address),
                 Some(via_btc_client_config.network()),
             ),
             optional_config,
@@ -521,7 +519,6 @@ impl ViaNodeBuilder {
             with_extended_tracing: rpc_config.extended_api_tracing,
             ..Default::default()
         };
-        let via_bridge_config = try_load_config!(self.configs.via_bridge_config);
         let via_btc_client_config = try_load_config!(self.configs.via_btc_client_config);
 
         self.node.add_layer(Web3ServerLayer::ws(
@@ -530,7 +527,6 @@ impl ViaNodeBuilder {
                 &rpc_config,
                 &self.contracts_config,
                 &self.genesis_config,
-                Some(via_bridge_config.bridge_address),
                 Some(via_btc_client_config.network()),
             ),
             optional_config,

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/via.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/via.rs
@@ -9,7 +9,9 @@ use crate::web3::namespaces::ViaNamespace;
 #[async_trait]
 impl ViaNamespaceServer for ViaNamespace {
     async fn get_bridge_address(&self) -> RpcResult<String> {
-        Ok(self.get_bridge_address_impl())
+        self.get_bridge_address_impl()
+            .await
+            .map_err(|err| self.current_method().map_err(err))
     }
 
     async fn get_bitcoin_network(&self) -> RpcResult<Network> {

--- a/core/node/api_server/src/web3/namespaces/via.rs
+++ b/core/node/api_server/src/web3/namespaces/via.rs
@@ -1,6 +1,10 @@
+use anyhow::anyhow;
 use bitcoin::Network;
+use zksync_dal::{CoreDal, DalError};
+use zksync_types::via_wallet::SystemWallets;
+use zksync_web3_decl::error::Web3Error;
 
-use crate::web3::RpcState;
+use crate::web3::{backend_jsonrpsee::MethodTracer, RpcState};
 
 #[derive(Debug)]
 pub(crate) struct ViaNamespace {
@@ -12,8 +16,29 @@ impl ViaNamespace {
         Self { state }
     }
 
-    pub fn get_bridge_address_impl(&self) -> String {
-        self.state.api_config.via_bridge_address.clone()
+    pub(crate) fn current_method(&self) -> &MethodTracer {
+        &self.state.current_method
+    }
+
+    pub async fn get_bridge_address_impl(&self) -> Result<String, Web3Error> {
+        if let Some(system_wallets_raw) = self
+            .state
+            .connection_pool
+            .connection()
+            .await
+            .map_err(DalError::generalize)?
+            .via_wallet_dal()
+            .get_system_wallets_raw()
+            .await
+            .map_err(DalError::generalize)?
+        {
+            let system_wallets = SystemWallets::try_from(system_wallets_raw)?;
+            return Ok(system_wallets.bridge.to_string());
+        }
+
+        Err(Web3Error::InternalError(anyhow!(
+            "Bridge address not found"
+        )))
     }
 
     pub fn get_bitcoin_network_impl(&self) -> Network {

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -115,7 +115,6 @@ pub struct InternalApiConfig {
     pub dummy_verifier: bool,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
 
-    pub via_bridge_address: String,
     pub via_network: Network,
 }
 
@@ -124,11 +123,9 @@ impl InternalApiConfig {
         web3_config: &Web3JsonRpcConfig,
         contracts_config: &ContractsConfig,
         genesis_config: &GenesisConfig,
-        via_bridge_address: Option<String>,
         via_network: Option<Network>,
     ) -> Self {
         Self {
-            via_bridge_address: via_bridge_address.unwrap_or_default(),
             via_network: via_network.unwrap_or(Network::Regtest),
             l1_chain_id: genesis_config.l1_chain_id,
             l2_chain_id: genesis_config.l2_chain_id,

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -248,7 +248,6 @@ async fn test_http_server(test: impl HttpTest) {
         &web3_config,
         &contracts_config,
         &genesis,
-        Some("".into()),
         Some(bitcoin::Network::Regtest),
     );
     api_config.filters_disabled = test.filters_disabled();

--- a/core/node/api_server/src/web3/tests/ws.rs
+++ b/core/node/api_server/src/web3/tests/ws.rs
@@ -172,7 +172,6 @@ async fn test_ws_server(test: impl WsTest) {
         &web3_config,
         &contracts_config,
         &genesis_config,
-        Some("".into()),
         Some(bitcoin::Network::Regtest),
     );
     let mut storage = pool.connection().await.unwrap();


### PR DESCRIPTION
## What ❔

- Fetch the bridge address from the DB instead of read the value config file. 

## Why ❔

- Now the system wallets is managed by the relayer and the last up to date bridge address should be fetched from the DB.

<img width="893" height="238" alt="Screenshot from 2025-08-17 16-44-59" src="https://github.com/user-attachments/assets/02b0bcd9-ff98-4cba-97ce-29c1d946a4d5" />

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
