### PR TITLE
fix: via prepare calldata

### DIFF
--- a/core/lib/types/src/via_protocol_upgrade.rs
+++ b/core/lib/types/src/via_protocol_upgrade.rs
@@ -103,3 +103,77 @@ impl ViaProtocolUpgrade {
         Ok(calldata)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex::FromHex;
+    use zksync_basic_types::{Address, H256};
+    use zksync_contracts::deployer_contract;
+
+    #[test]
+    fn test_get_calldata_encoding() {
+        let upgrader = ViaProtocolUpgrade {};
+
+        // Example inputs
+        let addr = Address::from_slice(
+            &<[u8; 20]>::from_hex("1111111111111111111111111111111111111111").unwrap(),
+        );
+        let bytecode_hash = H256::from_slice(
+            &<[u8; 32]>::from_hex(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
+            .unwrap(),
+        );
+
+        let calldata = upgrader
+            .get_calldata(vec![(addr, bytecode_hash)])
+            .expect("calldata should encode");
+
+        // First 4 bytes = selector
+        let selector =
+            &keccak256(b"forceDeployOnAddresses((bytes32,address,bool,uint256,bytes)[])")[0..4];
+        assert_eq!(&calldata[0..4], selector);
+
+        // Optionally print out to compare with Solidity's abi.encodeWithSelector
+        println!("Calldata hex: 0x{}", hex::encode(&calldata));
+
+        // Minimal check: length should be > selector (ABI data present)
+        assert!(calldata.len() > 4);
+    }
+
+    #[test]
+    fn test_calldata_matches_contract_encoding() {
+        let upgrader = ViaProtocolUpgrade {};
+
+        let addr = Address::repeat_byte(0x11);
+        let bytecode_hash = H256::repeat_byte(0xaa);
+
+        // New way: manual encoding
+        let new_calldata = upgrader
+            .get_calldata(vec![(addr, bytecode_hash)])
+            .expect("manual calldata");
+
+        // Old way: via ABI contract binding
+        let encoded_deployments = vec![Token::Tuple(vec![
+            Token::FixedBytes(bytecode_hash.as_bytes().to_vec()),
+            Token::Address(addr),
+            Token::Bool(false),
+            Token::Uint(U256::zero()),
+            Token::Bytes(vec![]),
+        ])];
+
+        let old_calldata = deployer_contract()
+            .function("forceDeployOnAddresses")
+            .unwrap()
+            .encode_input(&[Token::Array(encoded_deployments)])
+            .unwrap();
+
+        // Compare full byte equality
+        assert_eq!(
+            hex::encode(&new_calldata),
+            hex::encode(&old_calldata),
+            "manual encoding does not match deployer_contract encoding"
+        );
+    }
+}


### PR DESCRIPTION
## What ❔

- Remove loading the system contract to prepare the upgrade tx calldata.

## Why ❔
- This code is shared by the verifier and the sequencer. In thecase of the verifier, the system contracts are not built with the binary which throw an error on prod.

```shell
2025-08-18T14:52:21.072450Z  INFO via_verifier_btc_watch::message_processors::governance_upgrade: Received upgrades with versions: ProtocolSemanticVersion { minor: Version27, patch: VersionPatch(0) }
2025-08-18T14:52:21.074909Z  INFO zksync_utils::env: locate_workspace() failed. You are using an already compiled version
thread 'tokio-runtime-worker' panicked at core/lib/contracts/src/lib.rs:107:9:
Failed to load contract from "contracts/system-contracts/artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json"
stack backtrace:
   0:     0x55a0f390e03d - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h4ba39a43d3e87adf
   1:     0x55a0f393da4b - core::fmt::write::h948fa78229aa764e
   2:     0x55a0f3909343 - std::io::Write::write_fmt::h60b4ed4b4cde96a3
   3:     0x55a0f390f502 - std::panicking::default_hook::{{closure}}::h326e80fe334527f5
   4:     0x55a0f390f16e - std::panicking::default_hook::h154dcec67b5cc2b3
   5:     0x55a0f390fdff - std::panicking::rust_panic_with_hook::haa0d1f76c5d6487e
   6:     0x55a0f390fae7 - std::panicking::begin_panic_handler::{{closure}}::h8e01df9f228549a9
   7:     0x55a0f390e529 - std::sys::backtrace::__rust_end_short_backtrace::h173dbc6039c4534b
   8:     0x55a0f390f774 - rust_begin_unwind
   9:     0x55a0f393aa43 - core::panicking::panic_fmt::h8b93d4e6dcb57d25
  10:     0x55a0f2ff9da8 - zksync_contracts::load_sys_contract::h8dc786b6f232375c
  11:     0x55a0f2ff9f16 - zksync_contracts::deployer_contract::ha73a4e22cd779724
  12:     0x55a0f2ff36c2 - zksync_types::via_protocol_upgrade::ViaProtocolUpgrade::get_calldataalldata::hbf0210426043c8e4
  13:     0x55a0f2ff33c3 - zksync_types::via_protocol_upgrade::ViaProtocolUpgrade::get_canonical_tx_hash::h25f5a64fc3e47763
  14:     0x55a0f280060b - <via_verifier_btc_watch::message_processors::governance_upgrade::GovernanceUpgradesEventProcessor as via_verifier_btc_watch::message_processors::MessageProcessor>::process_messages::{{closure}}::haa4670a15473ac46
  15:     0x55a0f22f0306 - via_verifier_btc_watch::VerifierBtcWatch::run::{{closure}}::h96672d6ca9c8a147
  16:     0x55a0f2342024 - zksync_node_framework::implementations::layers::via_verifier_btc_watch::<impl zksync_node_framework::task::Task for via_verifier_btc_watch::VerifierBtcWatch>::run::{{closure}}::h2abc445bdaa0868f
  17:     0x55a0f24713c9 - <dyn zksync_node_framework::task::Task>::run_internal::{{closure}}::h4c7b570b87498840
  18:     0x55a0f243eff6 - tokio::runtime::task::core::Core<T,S>::poll::h3999d35390ce922e
  19:     0x55a0f23ccd01 - tokio::runtime::task::harness::Harness<T,S>::poll::h2a8998abb5199a48
  20:     0x55a0f373db61 - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::ha3f4fd82c6bb883f
  21:     0x55a0f373c8e2 - tokio::runtime::scheduler::multi_thread::worker::Context::run::h3e72df079580d0c8
  22:     0x55a0f3733396 - tokio::runtime::context::scoped::Scoped<T>::set::h1082d5f55e5172e1
  23:     0x55a0f373700e - tokio::runtime::context::runtime::enter_runtime::h77d657932868574a
  24:     0x55a0f373c40a - tokio::runtime::scheduler::multi_thread::worker::run::h747048773a05fd83
  25:     0x55a0f3741267 - <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::ha6403daab111a966
  26:     0x55a0f374fe73 - tokio::runtime::task::core::Core<T,S>::poll::hab41086ae3c31f7c
  27:     0x55a0f372cf04 - tokio::runtime::task::harness::Harness<T,S>::poll::h7e4915961aa9539e
  28:     0x55a0f3747de2 - tokio::runtime::blocking::pool::Inner::run::h05c0c9ccdc8be91d
  29:     0x55a0f3730cbe - std::sys::backtrace::__rust_begin_short_backtrace::hf139c5a0de755de5
  30:     0x55a0f374d5a2 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h6b5b15e025fb07d1
  31:     0x55a0f3914b0b - std::sys::pal::unix::thread::Thread::new::thread_start::hd2564588fac3af04
  32:     0x7bb20f2fc1f5 - <unknown>
  33:     0x7bb20f37c89c - <unknown>
  34:                0x0 - <unknown>
2025-08-18T14:52:21.095727Z ERROR zksync_node_framework::service: Task verifier_btc_watch panicked: Failed to load contract from "contracts/system-contracts/artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json"
2025-08-18T14:52:21.095745Z  INFO zksync_node_framework::service: One of the task has exited, shutting down the node
2025-08-18T14:52:21.095915Z  INFO via_verifier_btc_sender::btc_inscription_manager: Stop signal received, btc_sender is shutting down
2025-08-18T14:52:21.095983Z  INFO via_verifier_coordinator::coordinator::api: Stop signal received, coordinator server is shutting down
2025-08-18T14:52:21.096056Z  INFO via_verifier_coordinator::coordinator::api: coordinator handler server shut down
2025-08-18T14:52:21.096070Z  INFO zksync_circuit_breaker: received a stop signal; circuit breaker is shut down
2025-08-18T14:52:21.096086Z  INFO zksync_node_api_server::healthcheck: Stop signal received, healthcheck server is shutting down
2025-08-18T14:52:21.096124Z  INFO zksync_node_api_server::healthcheck: Healthcheck server shut down
2025-08-18T14:52:21.096384Z DEBUG zksync_health_check: Changed health of `prometheus_exporter` from {"status":"ready"} to {"status":"shut_down"}
2025-08-18T14:52:21.097971Z  INFO NamedFuture{name=via_verifier_storage_initializer}: zksync_node_framework::implementations::layers::via_verifier_storage_init: Verifier storage initialization task completed
2025-08-18T14:52:21.154557Z  INFO via_verifier_btc_sender::btc_vote_inscription: Stop signal received, Verifier btc_sender_inscription is shutting down
2025-08-18T14:52:21.156612Z  INFO via_zk_verifier: Stop signal received, via_zk_verifier is shutting down
2025-08-18T14:52:21.158937Z  INFO via_verifier_coordinator::verifier: Stop signal received, verifier withdrawal is shutting down
2025-08-18T14:52:21.160227Z  INFO zksync_node_framework::service: Task sigint_handler finished
2025-08-18T14:52:21.160250Z  INFO zksync_node_framework::service: Task healthcheck_server finished
2025-08-18T14:52:21.160256Z  INFO zksync_node_framework::service: Task circuit_breaker_checker finished
2025-08-18T14:52:21.160260Z  INFO zksync_node_framework::service: Task prometheus_exporter finished
2025-08-18T14:52:21.160264Z  INFO zksync_node_framework::service: Task via_vote_inscription finished
2025-08-18T14:52:21.160268Z  INFO zksync_node_framework::service: Task via_btc_inscription_manager finished
2025-08-18T14:52:21.160271Z  INFO zksync_node_framework::service: Task oneshot_runner finished
2025-08-18T14:52:21.160275Z  INFO zksync_node_framework::service: Task via_proof_verification finished
2025-08-18T14:52:21.160279Z  INFO zksync_node_framework::service: Task via_coordinator_api finished
2025-08-18T14:52:21.160282Z  INFO zksync_node_framework::service: Task via_withdrawal_verifier finished
2025-08-18T14:52:21.160288Z  INFO zksync_node_framework::service: Exiting the service
Error: One or more tasks failed: [TaskPanicked(TaskId("verifier_btc_watch"), "Failed to load contract from \"contracts/system-contracts/artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json\"")]

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: via_verifier::main
   2: std::sys::backtrace::__rust_begin_short_backtrace
   3: std::rt::lang_start::{{closure}}
   4: std::rt::lang_start_internal
   5: main
   6: <unknown>
   7: __libc_start_main
   8: _start
```

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
