### PR TITLE
build(en): remove l1 contracts in dockerfile

### DIFF
--- a/docker/via-external-node/Dockerfile
+++ b/docker/via-external-node/Dockerfile
@@ -18,7 +18,6 @@ COPY contracts/system-contracts/bootloader/build/artifacts/ /contracts/system-co
 COPY contracts/system-contracts/contracts-preprocessed/artifacts/ /contracts/system-contracts/contracts-preprocessed/artifacts/
 COPY contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/ /contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/
 COPY contracts/system-contracts/artifacts-zk /contracts/system-contracts/artifacts-zk
-COPY contracts/l1-contracts/artifacts/ /contracts/l1-contracts/artifacts/
 COPY contracts/l2-contracts/artifacts-zk/ /contracts/l2-contracts/artifacts-zk/
 COPY etc/tokens/ /etc/tokens/
 COPY etc/ERC20/ /etc/ERC20/


### PR DESCRIPTION
## What ❔

- Remove l1 contracts from via ext node image.