### PR TITLE
fix: mark the upgrade as processed using atomic tx

### DIFF
--- a/via_verifier/lib/verifier_dal/src/via_protocol_versions_dal.rs
+++ b/via_verifier/lib/verifier_dal/src/via_protocol_versions_dal.rs
@@ -266,7 +266,7 @@ impl ViaProtocolVersionsDal<'_, '_> {
             "#,
             upgrade_tx_hash
         )
-        .instrument("get_in_progress_upgrade_tx_hash")
+        .instrument("mark_upgrade_as_executed")
         .fetch_optional(self.storage)
         .await?;
         Ok(())


### PR DESCRIPTION
## What ❔

- Fix the zk verifier logic to update the database using an ACID transaction.

## Why ❔
We encountered a bug on the devnet during the protocol upgrade from v26 to v27. The issue occurred because the upgrade transaction status was updated in the verifier database before completing zk verification. If an error occurred immediately after, the verifier would, in the next iteration, assume the batch was invalid since it could not find the upgrade transaction.
The fix improved the following:
- Moving the upgrade transaction status update after the zk verification is successfully completed.
- Performing the update within a database transaction (ACID) to ensure atomicity and prevent inconsistencies.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
