### PR TITLE
chore(deps): bump bitcoin crate version and use workspace version in …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.2"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
  "bech32 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,8 @@ axum = "0.7.5"
 backon = "0.4.4"
 bigdecimal = "0.4.5"
 bincode = "1"
+bitcoin = { version = "0.32.7", features = ["serde"] }
+bitcoincore-rpc = "0.19.0"
 blake2 = "0.10"
 chrono = "0.4"
 clap = "4.2.2"

--- a/core/lib/config/Cargo.toml
+++ b/core/lib/config/Cargo.toml
@@ -18,8 +18,8 @@ zksync_concurrency.workspace = true
 zksync_vlog = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
-bitcoin = { version = "0.32.2", features = ["serde"] }
-bitcoincore-rpc = "0.19.0"
+bitcoin.workspace = true
+bitcoincore-rpc.workspace = true
 
 url.workspace = true
 anyhow.workspace = true

--- a/core/lib/dal/Cargo.toml
+++ b/core/lib/dal/Cargo.toml
@@ -50,7 +50,7 @@ hex.workspace = true
 strum = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 chrono = { workspace = true, features = ["serde"] }
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 
 [dev-dependencies]
 zksync_test_account.workspace = true

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -21,7 +21,7 @@ zksync_protobuf.workspace = true
 zksync_crypto_primitives.workspace = true
 
 anyhow.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true, features = ["debug"] }
 num = { workspace = true, features = ["serde"] }

--- a/core/lib/via_btc_client/Cargo.toml
+++ b/core/lib/via_btc_client/Cargo.toml
@@ -23,8 +23,8 @@ async-trait.workspace = true
 lazy_static.workspace = true
 tokio.workspace = true
 futures.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
-bitcoincore-rpc = "0.19.0"
+bitcoin.workspace = true
+bitcoincore-rpc.workspace = true
 rand.workspace = true
 hex.workspace = true
 secp256k1 = "0.29.0"

--- a/core/lib/via_test_utils/Cargo.toml
+++ b/core/lib/via_test_utils/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 via_btc_client.workspace = true
 zksync_types.workspace = true
 zksync_config.workspace = true

--- a/core/lib/web3_decl/Cargo.toml
+++ b/core/lib/web3_decl/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 vise.workspace = true
 rustls.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/core/node/api_server/Cargo.toml
+++ b/core/node/api_server/Cargo.toml
@@ -53,7 +53,7 @@ tower.workspace = true
 strum = { workspace = true, features = ["derive"] }
 tower-http = { workspace = true, features = ["cors", "metrics"] }
 lru.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 
 [dev-dependencies]
 zksync_node_genesis.workspace = true

--- a/core/node/via_btc_sender/Cargo.toml
+++ b/core/node/via_btc_sender/Cargo.toml
@@ -22,7 +22,7 @@ zksync_utils.workspace = true
 zksync_l1_contract_interface.workspace = true
 zksync_types.workspace = true
 zksync_contracts.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 bincode = "1.3"
 
 tokio.workspace = true

--- a/core/node/via_consistency_checker/Cargo.toml
+++ b/core/node/via_consistency_checker/Cargo.toml
@@ -21,8 +21,8 @@ zksync_l1_contract_interface.workspace = true
 zksync_shared_metrics.workspace = true
 zksync_types.workspace = true
 via_btc_client.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
-bitcoincore-rpc = "0.19.0"
+bitcoin.workspace = true
+bitcoincore-rpc.workspace = true
 
 anyhow.workspace = true
 serde.workspace = true

--- a/core/tests/via_loadnext/Cargo.toml
+++ b/core/tests/via_loadnext/Cargo.toml
@@ -22,7 +22,7 @@ zksync_system_constants.workspace = true
 zksync_vlog.workspace = true
 via_btc_client.workspace = true
 
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 
 async-trait.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.2"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
  "bech32",

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -21,8 +21,8 @@ tracing-subscriber.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 reqwest.workspace = true
-bitcoincore-rpc = "0.19.0"
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoincore-rpc.workspace = true
+bitcoin.workspace = true
 musig2 = "0.2.0"
 secp256k1_musig2 = { package = "secp256k1", version = "0.30.0", features = [
     "rand",
@@ -45,7 +45,7 @@ via_da_clients.workspace = true
 async-trait.workspace = true
 zksync_config.workspace = true
 mockall = "0.13.0"
-bitcoincore-rpc = "0.19.0"
+bitcoincore-rpc.workspace = true
 rand = "0.8"
 clap = { workspace = true, features = ["derive"] }
 

--- a/via_verifier/lib/via_verifier_types/Cargo.toml
+++ b/via_verifier/lib/via_verifier_types/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 serde.workspace = true
 via_btc_client.workspace = true
 zksync_types.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 bincode = "1.3"
 anyhow.workspace = true
 indexmap = "2.2"

--- a/via_verifier/lib/via_withdrawal_client/Cargo.toml
+++ b/via_verifier/lib/via_withdrawal_client/Cargo.toml
@@ -23,7 +23,7 @@ tracing-subscriber.workspace = true
 via_btc_client.workspace = true
 via_da_client.workspace = true
 
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 serde.workspace = true
 via_verifier_types.workspace = true
 

--- a/via_verifier/node/via_btc_sender/Cargo.toml
+++ b/via_verifier/node/via_btc_sender/Cargo.toml
@@ -21,7 +21,7 @@ zksync_utils.workspace = true
 zksync_l1_contract_interface.workspace = true
 zksync_types.workspace = true
 zksync_contracts.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 bincode = "1.3"
 
 tokio.workspace = true

--- a/via_verifier/node/via_verifier_coordinator/Cargo.toml
+++ b/via_verifier/node/via_verifier_coordinator/Cargo.toml
@@ -28,7 +28,7 @@ tower = { workspace = true }
 tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-bitcoin = { version = "0.32.2", features = ["serde"] }
+bitcoin.workspace = true
 secp256k1_musig2 = { package = "secp256k1", version = "0.30.0", features = [
     "rand",
 ] }


### PR DESCRIPTION
## What ❔

- Update the Bitcoin version to 0.32.7 that includes Testnet4 as network type.

## Checklist
- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Code has been formatted via `zk fmt` and `zk lint`.
