### PR TITLE
fix: increase the target blocks when estimate fee

### DIFF
--- a/core/lib/via_btc_client/src/inscriber/mod.rs
+++ b/core/lib/via_btc_client/src/inscriber/mod.rs
@@ -36,7 +36,7 @@ mod script_builder;
 pub mod test_utils;
 
 const CTX_REQUIRED_CONFIRMATIONS: u32 = 1;
-const FEE_RATE_CONF_TARGET: u16 = 1;
+const FEE_RATE_CONF_TARGET: u16 = 10;
 
 const COMMIT_TX_CHANGE_OUTPUT_INDEX: u32 = 0;
 const COMMIT_TX_TAPSCRIPT_OUTPUT_INDEX: u32 = 1;


### PR DESCRIPTION
## What ❔

Increase the target blocks when estimate the fees to avoid node errors like "Insufficient data or no feerate found"

## Why ❔

The node returns "Insufficient data or no feerate found" when the target block to include the transaction is too small on testnet.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
