### PR TITLE
Fix/via verifier sync logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11726,6 +11726,7 @@ dependencies = [
  "via_btc_client",
  "via_musig2",
  "via_verifier_dal",
+ "via_verifier_state",
  "via_verifier_types",
  "via_withdrawal_client",
  "vise",
@@ -11766,6 +11767,32 @@ dependencies = [
  "via_verifier_dal",
  "zksync_config",
  "zksync_dal",
+ "zksync_types",
+]
+
+[[package]]
+name = "via_verifier_state"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "serde",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "via_btc_client",
+ "via_da_client",
+ "via_verification",
+ "via_verifier_dal",
+ "via_verifier_types",
+ "vise",
+ "zksync_config",
+ "zksync_da_client",
+ "zksync_dal",
+ "zksync_prover_interface",
+ "zksync_shared_metrics",
  "zksync_types",
 ]
 
@@ -11841,6 +11868,7 @@ dependencies = [
  "via_da_client",
  "via_verification",
  "via_verifier_dal",
+ "via_verifier_state",
  "via_verifier_types",
  "vise",
  "zksync_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ members = [
     "via_verifier/node/via_reorg_detector",
     "via_verifier/node/via_verifier_storage_init",
     "via_verifier/node/via_block_reverter",
+    "via_verifier/lib/via_state",
 
     # VIA Indexer
     "via_indexer/lib/via_indexer_dal",
@@ -127,9 +128,7 @@ members = [
 ]
 resolver = "2"
 
-exclude = [
-    "via-core-ext"
-]
+exclude = ["via-core-ext"]
 
 # for `perf` profiling
 [profile.perf]
@@ -389,6 +388,7 @@ via_verifier_btc_sender = { version = "0.1.0", path = "via_verifier/node/via_btc
 via_verifier_reorg_detector = { version = "0.1.0", path = "via_verifier/node/via_reorg_detector" }
 via_verifier_storage_init = { version = "0.1.0", path = "via_verifier/node/via_verifier_storage_init" }
 via_verifier_block_reverter = { version = "0.1.0", path = "via_verifier/node/via_block_reverter" }
+via_verifier_state = { version = "0.1.0", path = "via_verifier/lib/via_state" }
 
 # VIA indexer
 via_indexer = { version = "0.1.0", path = "via_indexer/node/indexer" }

--- a/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
+++ b/core/node/node_framework/src/implementations/layers/via_verifier/verifier.rs
@@ -5,7 +5,7 @@ use zksync_config::{
     configs::{
         via_bridge::ViaBridgeConfig, via_btc_client::ViaBtcClientConfig, via_wallets::ViaWallet,
     },
-    ViaVerifierConfig,
+    ViaBtcWatchConfig, ViaVerifierConfig,
 };
 
 use crate::{
@@ -27,6 +27,7 @@ pub struct ViaWithdrawalVerifierLayer {
     via_bridge_config: ViaBridgeConfig,
     via_btc_client: ViaBtcClientConfig,
     verifier_config: ViaVerifierConfig,
+    btc_watch_config: ViaBtcWatchConfig,
     wallet: ViaWallet,
 }
 
@@ -51,12 +52,14 @@ impl ViaWithdrawalVerifierLayer {
         via_bridge_config: ViaBridgeConfig,
         via_btc_client: ViaBtcClientConfig,
         verifier_config: ViaVerifierConfig,
+        btc_watch_config: ViaBtcWatchConfig,
         wallet: ViaWallet,
     ) -> Self {
         Self {
             via_bridge_config,
             via_btc_client,
             verifier_config,
+            btc_watch_config,
             wallet,
         }
     }
@@ -75,8 +78,11 @@ impl WiringLayer for ViaWithdrawalVerifierLayer {
         let master_pool = input.master_pool.get().await?;
         let query_client_l22 = input.query_client_l2.0;
 
-        let withdrawal_client =
-            WithdrawalClient::new(input.da_client.0, self.via_btc_client.network(), query_client_l22);
+        let withdrawal_client = WithdrawalClient::new(
+            input.da_client.0,
+            self.via_btc_client.network(),
+            query_client_l22,
+        );
 
         let btc_client = input.btc_client_resource.verifier.unwrap();
 
@@ -87,6 +93,7 @@ impl WiringLayer for ViaWithdrawalVerifierLayer {
             btc_client,
             withdrawal_client,
             self.via_bridge_config,
+            self.btc_watch_config,
         )
         .context("Error to init the via withdrawal verifier")?;
 

--- a/core/node/node_framework/src/implementations/layers/via_zk_verification.rs
+++ b/core/node/node_framework/src/implementations/layers/via_zk_verification.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use via_zk_verifier::ViaVerifier;
-use zksync_config::{configs::via_bridge::ViaBridgeConfig, ViaVerifierConfig};
+use zksync_config::{configs::via_bridge::ViaBridgeConfig, ViaBtcWatchConfig, ViaVerifierConfig};
 
 use crate::{
     implementations::resources::{
         da_client::DAClientResource,
         pools::{PoolResource, VerifierPool},
+        via_btc_client::BtcClientResource,
         via_btc_indexer::BtcIndexerResource,
     },
     service::StopReceiver,
@@ -18,6 +19,7 @@ use crate::{
 pub struct ViaBtcProofVerificationLayer {
     via_bridge_config: ViaBridgeConfig,
     verifier_config: ViaVerifierConfig,
+    btc_watch_config: ViaBtcWatchConfig,
 }
 
 #[derive(Debug, FromContext)]
@@ -25,6 +27,7 @@ pub struct ViaBtcProofVerificationLayer {
 pub struct ProofVerificationInput {
     pub master_pool: PoolResource<VerifierPool>,
     pub da_client: DAClientResource,
+    pub btc_client_resource: BtcClientResource,
     pub btc_indexer_resource: BtcIndexerResource,
 }
 
@@ -36,10 +39,15 @@ pub struct ProofVerificationOutput {
 }
 
 impl ViaBtcProofVerificationLayer {
-    pub fn new(verifier_config: ViaVerifierConfig, via_bridge_config: ViaBridgeConfig) -> Self {
+    pub fn new(
+        verifier_config: ViaVerifierConfig,
+        via_bridge_config: ViaBridgeConfig,
+        btc_watch_config: ViaBtcWatchConfig,
+    ) -> Self {
         Self {
             verifier_config,
             via_bridge_config,
+            btc_watch_config,
         }
     }
 }
@@ -56,12 +64,16 @@ impl WiringLayer for ViaBtcProofVerificationLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         let main_pool = input.master_pool.get().await?;
 
+        let btc_client = input.btc_client_resource.verifier.unwrap();
+
         let via_proof_verification = ViaVerifier::new(
             self.verifier_config,
             input.btc_indexer_resource.0.as_ref().clone(),
             main_pool,
             input.da_client.0,
+            btc_client,
             self.via_bridge_config.zk_agreement_threshold,
+            self.btc_watch_config,
         )
         .await
         .map_err(WiringError::internal)?;

--- a/via_verifier/bin/verifier_server/src/node_builder.rs
+++ b/via_verifier/bin/verifier_server/src/node_builder.rs
@@ -148,6 +148,7 @@ impl ViaNodeBuilder {
             self.configs.via_bridge_config.clone(),
             self.configs.via_btc_client_config.clone(),
             self.configs.via_verifier_config.clone(),
+            self.configs.via_btc_watch_config.clone(),
             wallet,
         ));
         Ok(self)
@@ -157,6 +158,7 @@ impl ViaNodeBuilder {
         self.node.add_layer(ViaBtcProofVerificationLayer::new(
             self.configs.via_verifier_config.clone(),
             self.configs.via_bridge_config.clone(),
+            self.configs.via_btc_watch_config.clone(),
         ));
         Ok(self)
     }

--- a/via_verifier/lib/via_state/Cargo.toml
+++ b/via_verifier/lib/via_state/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "via_verifier_state"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+vise.workspace = true
+via_btc_client.workspace = true
+zksync_shared_metrics.workspace = true
+zksync_dal.workspace = true
+zksync_types.workspace = true
+zksync_config.workspace = true
+zksync_da_client.workspace = true
+zksync_prover_interface.workspace = true
+via_da_client.workspace = true
+via_verifier_types.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+bincode.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+sqlx.workspace = true
+serde.workspace = true
+via_verification.workspace = true
+via_verifier_dal.workspace = true

--- a/via_verifier/lib/via_state/src/lib.rs
+++ b/via_verifier/lib/via_state/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod sync;

--- a/via_verifier/lib/via_state/src/sync.rs
+++ b/via_verifier/lib/via_state/src/sync.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use via_btc_client::traits::BitcoinOps;
+use via_verifier_dal::{Verifier, VerifierDal};
+use zksync_config::ViaBtcWatchConfig;
+use zksync_dal::ConnectionPool;
+
+#[derive(Debug, Clone)]
+pub struct ViaState {
+    pool: ConnectionPool<Verifier>,
+    btc_client: Arc<dyn BitcoinOps>,
+    via_btc_watch_config: ViaBtcWatchConfig,
+}
+
+impl ViaState {
+    pub fn new(
+        pool: ConnectionPool<Verifier>,
+        btc_client: Arc<dyn BitcoinOps>,
+        via_btc_watch_config: ViaBtcWatchConfig,
+    ) -> Self {
+        Self {
+            pool,
+            btc_client,
+            via_btc_watch_config,
+        }
+    }
+
+    /// Check if the btc_watch is in sync with the current Bitcoin node
+    pub async fn is_sync_in_progress(&self) -> anyhow::Result<bool> {
+        let last_indexed_l1_block_number = self
+            .pool
+            .connection_tagged("verifier task")
+            .await?
+            .via_indexer_dal()
+            .get_last_processed_l1_block("via_btc_watch")
+            .await?;
+        let current_l1_block_number = self.btc_client.fetch_block_height().await?;
+
+        Ok(
+            current_l1_block_number - self.via_btc_watch_config.block_confirmations
+                > last_indexed_l1_block_number,
+        )
+    }
+
+    /// Check if there is a reorg in progress
+    pub async fn is_reorg_in_progress(&self) -> anyhow::Result<bool> {
+        let is_reorg = self
+            .pool
+            .connection()
+            .await?
+            .via_l1_block_dal()
+            .has_reorg_in_progress()
+            .await?
+            .is_some();
+
+        Ok(is_reorg)
+    }
+}

--- a/via_verifier/node/via_verifier_coordinator/Cargo.toml
+++ b/via_verifier/node/via_verifier_coordinator/Cargo.toml
@@ -19,6 +19,7 @@ via_musig2.workspace = true
 reqwest.workspace = true
 via_withdrawal_client.workspace = true
 via_verifier_types.workspace = true
+via_verifier_state.workspace = true
 
 anyhow.workspace = true
 axum.workspace = true

--- a/via_verifier/node/via_zk_verifier/Cargo.toml
+++ b/via_verifier/node/via_zk_verifier/Cargo.toml
@@ -33,5 +33,6 @@ serde.workspace = true
 
 via_verification.workspace = true
 via_verifier_dal.workspace = true
+via_verifier_state.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## What ❔
- Create a common lib that returns the synchronization state of the verifier, in_sync with L1 and if reorg in progress.
- Refactor the code to use the verifier_state lib.
- Block  the zk verification if the verifier is not in sync

## Why ❔
This resolves issues that occur during a reorganization, where old batches are re-indexed. Such cases could cause the verifier to start verifying those old batches (probably invalid in some cases), even though a new batch with the same number will be indexed in the upcoming blocks.
Now, the verifier will wait to get in sync with the Bitcoin chain before start the ZK verification.

Also this PR includes small refactoring to reduce code duplication.

## Checklist
- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
