### PR TITLE
fix(security): zeroize signer secret key material

### DIFF
--- a/core/lib/via_btc_client/Cargo.toml
+++ b/core/lib/via_btc_client/Cargo.toml
@@ -37,6 +37,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 bincode = "1.3"
 musig2 = "0.2.0"
+zeroize = "1"
 
 
 [dev-dependencies]

--- a/core/lib/via_btc_client/src/signer/mod.rs
+++ b/core/lib/via_btc_client/src/signer/mod.rs
@@ -12,15 +12,15 @@ use crate::{
     traits::BitcoinSigner,
     types::{BitcoinError, BitcoinSignerResult},
 };
+use zeroize::Zeroizing;
 
 /// KeyManager handles the creation and management of Bitcoin keys and addresses.
 /// It provides functionality for signing transactions using both ECDSA and Schnorr signatures.
 #[derive(Clone)]
 pub struct KeyManager {
     secp: Secp256k1<All>,
-    sk: SecretKey,
+    sk: Zeroizing<[u8; 32]>,
     address: Address,
-    keypair: Keypair,
     internal_key: UntweakedPublicKey,
     script_pubkey: ScriptBuf,
 }
@@ -62,9 +62,8 @@ impl KeyManager {
 
         Ok(Self {
             secp,
-            sk,
+            sk: Zeroizing::new(sk.secret_bytes()),
             address,
-            keypair,
             internal_key,
             script_pubkey,
         })
@@ -84,9 +83,8 @@ impl Default for KeyManager {
 
         Self {
             secp,
-            sk: sk.inner,
+            sk: Zeroizing::new(sk.inner.secret_bytes()),
             address,
-            keypair,
             internal_key,
             script_pubkey,
         }
@@ -112,17 +110,24 @@ impl BitcoinSigner for KeyManager {
     }
 
     fn sign_ecdsa(&self, msg: Message) -> BitcoinSignerResult<ECDSASignature> {
-        let signature = self.secp.sign_ecdsa(&msg, &self.sk);
+        let sk = SecretKey::from_slice(self.sk.as_ref())
+            .map_err(|e| BitcoinError::SigningError(format!("Invalid cached secret key: {}", e)))?;
+        let signature = self.secp.sign_ecdsa(&msg, &sk);
         Ok(signature)
     }
 
     fn sign_schnorr(&self, msg: Message) -> BitcoinSignerResult<SchnorrSignature> {
-        let signature = self.secp.sign_schnorr_no_aux_rand(&msg, &self.keypair);
+        let sk = SecretKey::from_slice(self.sk.as_ref())
+            .map_err(|e| BitcoinError::SigningError(format!("Invalid cached secret key: {}", e)))?;
+        let keypair = Keypair::from_secret_key(&self.secp, &sk);
+        let signature = self.secp.sign_schnorr_no_aux_rand(&msg, &keypair);
         Ok(signature)
     }
 
     fn get_public_key(&self) -> PublicKey {
-        self.sk.public_key(&self.secp)
+        SecretKey::from_slice(self.sk.as_ref())
+            .map(|sk| sk.public_key(&self.secp))
+            .expect("KeyManager secret key must be valid")
     }
 }
 

--- a/core/lib/via_btc_client/src/signer/mod.rs
+++ b/core/lib/via_btc_client/src/signer/mod.rs
@@ -52,7 +52,7 @@ impl KeyManager {
         let public_key = sk.public_key(&secp);
         let pk = bitcoin::PublicKey::new(public_key);
         let wpkh = pk.wpubkey_hash().map_err(|_e| {
-            BitcoinError::UncompressedPublicKeyError("key is compressed".to_string())
+            BitcoinError::UncompressedPublicKeyError("public key is uncompressed".to_string())
         })?;
 
         let compressed_pk = CompressedPublicKey::from_private_key(&secp, &private_key)
@@ -84,7 +84,7 @@ impl Default for KeyManager {
         let keypair = Keypair::from_secret_key(&secp, &sk.inner);
         let compressed_pk = CompressedPublicKey::from_private_key(&secp, &sk)
             .expect("Failed to generate compressed public key");
-        let address = Address::p2wpkh(&compressed_pk, Network::Testnet);
+        let address = Address::p2wpkh(&compressed_pk, Network::Regtest);
         let internal_key = keypair.x_only_public_key().0;
         let script_pubkey = address.script_pubkey();
         let public_key = sk.inner.public_key(&secp);

--- a/core/lib/via_btc_client/src/signer/mod.rs
+++ b/core/lib/via_btc_client/src/signer/mod.rs
@@ -20,6 +20,7 @@ use zeroize::Zeroizing;
 pub struct KeyManager {
     secp: Secp256k1<All>,
     sk: Zeroizing<[u8; 32]>,
+    public_key: PublicKey,
     address: Address,
     internal_key: UntweakedPublicKey,
     script_pubkey: ScriptBuf,
@@ -49,7 +50,8 @@ impl KeyManager {
 
         let sk = private_key.inner;
 
-        let pk = bitcoin::PublicKey::new(sk.public_key(&secp));
+        let public_key = sk.public_key(&secp);
+        let pk = bitcoin::PublicKey::new(public_key);
         let wpkh = pk.wpubkey_hash().map_err(|_e| {
             BitcoinError::UncompressedPublicKeyError("key is compressed".to_string())
         })?;
@@ -68,6 +70,7 @@ impl KeyManager {
         Ok(Self {
             secp,
             sk: Zeroizing::new(sk.secret_bytes()),
+            public_key,
             address,
             internal_key,
             script_pubkey,
@@ -85,10 +88,12 @@ impl Default for KeyManager {
         let address = Address::p2wpkh(&compressed_pk, Network::Testnet);
         let internal_key = keypair.x_only_public_key().0;
         let script_pubkey = address.script_pubkey();
+        let public_key = sk.inner.public_key(&secp);
 
         Self {
             secp,
             sk: Zeroizing::new(sk.inner.secret_bytes()),
+            public_key,
             address,
             internal_key,
             script_pubkey,
@@ -128,9 +133,7 @@ impl BitcoinSigner for KeyManager {
     }
 
     fn get_public_key(&self) -> PublicKey {
-        self.signing_secret_key()
-            .map(|sk| sk.public_key(&self.secp))
-            .expect("KeyManager secret key must be valid")
+        self.public_key
     }
 }
 

--- a/core/lib/via_btc_client/src/signer/mod.rs
+++ b/core/lib/via_btc_client/src/signer/mod.rs
@@ -16,7 +16,6 @@ use zeroize::Zeroizing;
 
 /// KeyManager handles the creation and management of Bitcoin keys and addresses.
 /// It provides functionality for signing transactions using both ECDSA and Schnorr signatures.
-#[derive(Clone)]
 pub struct KeyManager {
     secp: Secp256k1<All>,
     sk: Zeroizing<[u8; 32]>,

--- a/core/lib/via_btc_client/src/signer/mod.rs
+++ b/core/lib/via_btc_client/src/signer/mod.rs
@@ -26,6 +26,11 @@ pub struct KeyManager {
 }
 
 impl KeyManager {
+    fn signing_secret_key(&self) -> BitcoinSignerResult<SecretKey> {
+        SecretKey::from_slice(self.sk.as_ref())
+            .map_err(|e| BitcoinError::SigningError(format!("Invalid cached secret key: {}", e)))
+    }
+
     /// Creates a new KeyManager instance from a WIF-encoded private key and network.
     ///
     /// # Arguments
@@ -110,22 +115,20 @@ impl BitcoinSigner for KeyManager {
     }
 
     fn sign_ecdsa(&self, msg: Message) -> BitcoinSignerResult<ECDSASignature> {
-        let sk = SecretKey::from_slice(self.sk.as_ref())
-            .map_err(|e| BitcoinError::SigningError(format!("Invalid cached secret key: {}", e)))?;
+        let sk = self.signing_secret_key()?;
         let signature = self.secp.sign_ecdsa(&msg, &sk);
         Ok(signature)
     }
 
     fn sign_schnorr(&self, msg: Message) -> BitcoinSignerResult<SchnorrSignature> {
-        let sk = SecretKey::from_slice(self.sk.as_ref())
-            .map_err(|e| BitcoinError::SigningError(format!("Invalid cached secret key: {}", e)))?;
+        let sk = self.signing_secret_key()?;
         let keypair = Keypair::from_secret_key(&self.secp, &sk);
         let signature = self.secp.sign_schnorr_no_aux_rand(&msg, &keypair);
         Ok(signature)
     }
 
     fn get_public_key(&self) -> PublicKey {
-        SecretKey::from_slice(self.sk.as_ref())
+        self.signing_secret_key()
             .map(|sk| sk.public_key(&self.secp))
             .expect("KeyManager secret key must be valid")
     }

--- a/via_verifier/lib/via_musig2/Cargo.toml
+++ b/via_verifier/lib/via_musig2/Cargo.toml
@@ -33,6 +33,7 @@ axum = "0.6"
 uuid = { version = "1.3", features = ["v4"] }
 hyper = { version = "0.14", features = ["full"] }
 base64 = "0.21"
+zeroize = "1"
 
 byteorder = "1.4"
 bincode = "1.3"

--- a/via_verifier/lib/via_musig2/examples/coordinator.rs
+++ b/via_verifier/lib/via_musig2/examples/coordinator.rs
@@ -29,6 +29,7 @@ use via_test_utils::utils::generate_return_data_per_outputs;
 use via_verifier_types::{transaction::UnsignedBridgeTx, withdrawal::WithdrawalRequest};
 use zksync_config::configs::via_btc_client::ViaBtcClientConfig;
 use zksync_types::Address as EVMAddress;
+use zeroize::Zeroizing;
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -97,7 +98,12 @@ async fn main() -> anyhow::Result<()> {
     let other_pubkey_2 = PublicKey::from_secret_key(&secp, &SecretKey::new(&mut rng));
 
     let all_pubkeys = vec![public_key, other_pubkey_1, other_pubkey_2];
-    let coordinator_signer = Signer::new(secret_key, 0, all_pubkeys.clone(), None)?;
+    let coordinator_signer = Signer::new(
+        Zeroizing::new(secret_key.secret_bytes()),
+        0,
+        all_pubkeys.clone(),
+        None,
+    )?;
 
     let state = AppState {
         signer: Arc::new(RwLock::new(coordinator_signer)),
@@ -124,11 +130,21 @@ async fn main() -> anyhow::Result<()> {
     // Each verifier has their own keys:
     let mut rng = thread_rng();
     let verifier1_sk = SecretKey::new(&mut rng);
-    let verifier1_signer = Signer::new(verifier1_sk, 1, all_pubkeys.clone(), None)?;
+    let verifier1_signer = Signer::new(
+        Zeroizing::new(verifier1_sk.secret_bytes()),
+        1,
+        all_pubkeys.clone(),
+        None,
+    )?;
 
     let mut rng = thread_rng();
     let verifier2_sk = SecretKey::new(&mut rng);
-    let verifier2_signer = Signer::new(verifier2_sk, 2, all_pubkeys, None)?;
+    let verifier2_signer = Signer::new(
+        Zeroizing::new(verifier2_sk.secret_bytes()),
+        2,
+        all_pubkeys,
+        None,
+    )?;
 
     // Spawn tasks for verifier polling
     let verifier1_task = tokio::spawn(run_verifier_polling(

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -134,7 +134,7 @@ impl Signer {
     }
 
     fn signing_secret_key(&self) -> Result<SecretKey, MusigError> {
-        SecretKey::from_byte_array(self.secret_key.as_ref())
+        SecretKey::from_slice(self.secret_key.as_ref())
             .map_err(|e| MusigError::Musig2Error(format!("Invalid signer secret key bytes: {}", e)))
     }
 
@@ -277,9 +277,8 @@ pub fn get_signer(
     verifiers_pub_keys_str: Vec<String>,
 ) -> anyhow::Result<Signer> {
     let private_key = PrivateKey::from_wif(private_key_wif)?;
-    let secret_key =
-        secp256k1_musig2::SecretKey::from_byte_array(&private_key.inner.secret_bytes())
-            .with_context(|| "Error to compute the coordinator sk")?;
+    let secret_key = secp256k1_musig2::SecretKey::from_slice(&private_key.inner.secret_bytes())
+        .with_context(|| "Error to compute the coordinator sk")?;
     let secp = secp256k1_musig2::Secp256k1::new();
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 
@@ -305,9 +304,8 @@ pub fn get_signer_with_merkle_root(
     merkle_root: Option<TapNodeHash>,
 ) -> anyhow::Result<Signer> {
     let private_key = PrivateKey::from_wif(private_key_wif)?;
-    let secret_key =
-        secp256k1_musig2::SecretKey::from_byte_array(&private_key.inner.secret_bytes())
-            .with_context(|| "Error to compute the coordinator sk")?;
+    let secret_key = secp256k1_musig2::SecretKey::from_slice(&private_key.inner.secret_bytes())
+        .with_context(|| "Error to compute the coordinator sk")?;
     let secp = secp256k1_musig2::Secp256k1::new();
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
 

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -8,6 +8,7 @@ use musig2::{
 };
 use rand::{rngs::OsRng, Rng};
 use secp256k1_musig2::{PublicKey, Secp256k1, SecretKey};
+use zeroize::Zeroizing;
 
 use crate::constants::TAPROOT_TWEAK_SCALAR_RANGE_ERR;
 pub mod constants;
@@ -47,7 +48,7 @@ impl std::error::Error for MusigError {}
 
 /// Represents a single signer in the MuSig2 protocol
 pub struct Signer {
-    secret_key: SecretKey,
+    secret_key: Zeroizing<[u8; 32]>,
     public_key: PublicKey,
     signer_index: usize,
     key_agg_ctx: KeyAggContext,
@@ -120,7 +121,7 @@ impl Signer {
             .map_err(|e| MusigError::Musig2Error(format!("Failed to apply tweak: {}", e)))?;
 
         Ok(Self {
-            secret_key,
+            secret_key: Zeroizing::new(secret_key.secret_bytes()),
             public_key,
             signer_index,
             key_agg_ctx: musig_key_agg_cache,
@@ -130,6 +131,11 @@ impl Signer {
             nonce_submitted: false,
             partial_sig_submitted: false,
         })
+    }
+
+    fn signing_secret_key(&self) -> Result<SecretKey, MusigError> {
+        SecretKey::from_byte_array(self.secret_key.as_ref())
+            .map_err(|e| MusigError::Musig2Error(format!("Invalid signer secret key bytes: {}", e)))
     }
 
     /// Get the aggregated public key for all signers
@@ -143,12 +149,14 @@ impl Signer {
 
         let msg_array = message.as_slice();
 
+        let secret_key = self.signing_secret_key()?;
+
         let first_round = FirstRound::new(
             self.key_agg_ctx.clone(),
             OsRng.gen::<[u8; 32]>(),
             self.signer_index,
             SecNonceSpices::new()
-                .with_seckey(self.secret_key)
+                .with_seckey(secret_key)
                 .with_message(&msg_array),
         )
         .map_err(|e| MusigError::Musig2Error(e.to_string()))?;
@@ -184,8 +192,10 @@ impl Signer {
             .take()
             .ok_or_else(|| MusigError::InvalidState("First round not initialized".into()))?;
 
+        let secret_key = self.signing_secret_key()?;
+
         let second_round = first_round
-            .finalize(self.secret_key, msg_array)
+            .finalize(secret_key, msg_array)
             .map_err(|e| MusigError::Musig2Error(e.to_string()))?;
 
         let partial_sig = second_round.our_signature();

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -277,7 +277,8 @@ pub fn get_signer(
     verifiers_pub_keys_str: Vec<String>,
 ) -> anyhow::Result<Signer> {
     let private_key = PrivateKey::from_wif(private_key_wif)?;
-    let secret_key = secp256k1_musig2::SecretKey::from_slice(&private_key.inner.secret_bytes())
+    let secret_key_bytes = Zeroizing::new(private_key.inner.secret_bytes());
+    let secret_key = secp256k1_musig2::SecretKey::from_slice(secret_key_bytes.as_ref())
         .with_context(|| "Error to compute the coordinator sk")?;
     let secp = secp256k1_musig2::Secp256k1::new();
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);
@@ -304,7 +305,8 @@ pub fn get_signer_with_merkle_root(
     merkle_root: Option<TapNodeHash>,
 ) -> anyhow::Result<Signer> {
     let private_key = PrivateKey::from_wif(private_key_wif)?;
-    let secret_key = secp256k1_musig2::SecretKey::from_slice(&private_key.inner.secret_bytes())
+    let secret_key_bytes = Zeroizing::new(private_key.inner.secret_bytes());
+    let secret_key = secp256k1_musig2::SecretKey::from_slice(secret_key_bytes.as_ref())
         .with_context(|| "Error to compute the coordinator sk")?;
     let secp = secp256k1_musig2::Secp256k1::new();
     let public_key = PublicKey::from_secret_key(&secp, &secret_key);

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -75,13 +75,15 @@ impl fmt::Debug for Signer {
 impl Signer {
     /// Create a new signer with the given secret key and index
     pub fn new(
-        secret_key: SecretKey,
+        secret_key: Zeroizing<[u8; 32]>,
         signer_index: usize,
         all_pubkeys: Vec<PublicKey>,
         merkle_root: Option<TapNodeHash>,
     ) -> Result<Self, MusigError> {
         let secp = Secp256k1::new();
-        let public_key = PublicKey::from_secret_key(&secp, &secret_key);
+        let secret_key_ref = SecretKey::from_slice(secret_key.as_ref())
+            .map_err(|e| MusigError::Musig2Error(format!("Invalid signer secret key bytes: {}", e)))?;
+        let public_key = PublicKey::from_secret_key(&secp, &secret_key_ref);
 
         // Verify that signer_index is valid and matches the public key
         if signer_index >= all_pubkeys.len() {
@@ -121,7 +123,7 @@ impl Signer {
             .map_err(|e| MusigError::Musig2Error(format!("Failed to apply tweak: {}", e)))?;
 
         Ok(Self {
-            secret_key: Zeroizing::new(secret_key.secret_bytes()),
+            secret_key,
             public_key,
             signer_index,
             key_agg_ctx: musig_key_agg_cache,
@@ -295,7 +297,12 @@ pub fn get_signer(
         }
     }
 
-    let signer = Signer::new(secret_key, signer_index, all_pubkeys.clone(), None)?;
+    let signer = Signer::new(
+        Zeroizing::new(secret_key.secret_bytes()),
+        signer_index,
+        all_pubkeys.clone(),
+        None,
+    )?;
     Ok(signer)
 }
 
@@ -323,7 +330,12 @@ pub fn get_signer_with_merkle_root(
         }
     }
 
-    let signer = Signer::new(secret_key, signer_index, all_pubkeys.clone(), merkle_root)?;
+    let signer = Signer::new(
+        Zeroizing::new(secret_key.secret_bytes()),
+        signer_index,
+        all_pubkeys.clone(),
+        merkle_root,
+    )?;
     Ok(signer)
 }
 
@@ -361,8 +373,18 @@ mod tests {
 
         let pubkeys = vec![public_key_1, public_key_2];
 
-        let mut signer1 = Signer::new(secret_key_1, 0, pubkeys.clone(), None)?;
-        let mut signer2 = Signer::new(secret_key_2, 1, pubkeys, None)?;
+        let mut signer1 = Signer::new(
+            Zeroizing::new(secret_key_1.secret_bytes()),
+            0,
+            pubkeys.clone(),
+            None,
+        )?;
+        let mut signer2 = Signer::new(
+            Zeroizing::new(secret_key_2.secret_bytes()),
+            1,
+            pubkeys,
+            None,
+        )?;
 
         // Generate and exchange nonces
         let message = b"test message".to_vec();

--- a/via_verifier/lib/via_musig2/src/lib.rs
+++ b/via_verifier/lib/via_musig2/src/lib.rs
@@ -297,12 +297,7 @@ pub fn get_signer(
         }
     }
 
-    let signer = Signer::new(
-        Zeroizing::new(secret_key.secret_bytes()),
-        signer_index,
-        all_pubkeys.clone(),
-        None,
-    )?;
+    let signer = Signer::new(secret_key_bytes, signer_index, all_pubkeys, None)?;
     Ok(signer)
 }
 
@@ -330,12 +325,7 @@ pub fn get_signer_with_merkle_root(
         }
     }
 
-    let signer = Signer::new(
-        Zeroizing::new(secret_key.secret_bytes()),
-        signer_index,
-        all_pubkeys.clone(),
-        merkle_root,
-    )?;
+    let signer = Signer::new(secret_key_bytes, signer_index, all_pubkeys, merkle_root)?;
     Ok(signer)
 }
 


### PR DESCRIPTION
﻿## Summary
This addresses issue #337 by moving signer secret storage to zeroizing byte buffers and reconstructing ephemeral `SecretKey` values only when needed for signing.

## Changes
- `core/lib/via_btc_client`
  - add `zeroize` dependency
  - store `KeyManager` secret key as `Zeroizing<[u8; 32]>`
  - derive ephemeral `SecretKey` / `Keypair` for signing operations
- `via_verifier/lib/via_musig2`
  - add `zeroize` dependency
  - store `Signer` secret key as `Zeroizing<[u8; 32]>`
  - reconstruct ephemeral `SecretKey` when creating nonce / partial signature

## Why
- reduces lingering in-memory exposure of long-lived private key material
- removes explicit long-lived `Keypair` / `SecretKey` retention where not strictly necessary

Closes #337.
