### PR TITLE
docs: annotate Mailbox deprecations and replacements

### DIFF
--- a/docs/src/guides/advanced/02_deposits.md
+++ b/docs/src/guides/advanced/02_deposits.md
@@ -103,8 +103,11 @@ Input: 0xeb672419000000000000000000000000618263ce921f7dd5f4f40c29f6c524aaf97b9bb
 ```
 
 The deposit command has called the contract on address `0xa6B` (which is exactly the `CONTRACTS_DIAMOND_PROXY_ADDR` from
-`deployL1.log`), and it has called the method `0xeb672419` - which is the `requestL2Transaction` from
-[Mailbox.sol](https://github.com/matter-labs/era-contracts/blob/f06a58360a2b8e7129f64413998767ac169d1efd/ethereum/contracts/zksync/facets/Mailbox.sol#L220)
+`deployL1.log`), and it has called the method `0xeb672419` - which is the legacy `requestL2Transaction` from
+[Mailbox.sol](https://github.com/matter-labs/era-contracts/blob/f06a58360a2b8e7129f64413998767ac169d1efd/ethereum/contracts/zksync/facets/Mailbox.sol#L220).
+
+Deprecation note: `requestL2Transaction` is deprecated. New integrations should use
+`Bridgehub.requestL2TransactionDirect`.
 
 #### Quick note on our L1 contracts
 

--- a/docs/src/guides/advanced/03_withdrawals.md
+++ b/docs/src/guides/advanced/03_withdrawals.md
@@ -139,8 +139,10 @@ about the withdrawal.
 
 ### Final step - finalizing withdrawal
 
-Now we're ready to actually claim our ETH on L1. We do this by calling a `finalizeEthWithdrawal` function on the
-DiamondProxy contract (Mailbox.sol to be exact).
+Now we're ready to actually claim our ETH on L1.
+
+Historically this was done by calling `finalizeEthWithdrawal` on the DiamondProxy (Mailbox). Deprecation note:
+`finalizeEthWithdrawal` is deprecated; new integrations should use `L1Nullifier.finalizeDeposit`.
 
 To prove that we actually can withdraw the money, we have to say in which L2 block the withdrawal happened, and provide
 the merkle proof from our withdrawal log, to the root that is stored in the L1 contract.

--- a/docs/src/specs/l1_l2_communication/l1_to_l2.md
+++ b/docs/src/specs/l1_l2_communication/l1_to_l2.md
@@ -18,10 +18,15 @@ between system and user logs.
 
 ### Initiation
 
-A new priority operation can be appended by calling the
-[requestL2Transaction](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/contracts/ethereum/contracts/zksync/facets/Mailbox.sol#L236)
-method on L1. This method will perform several checks for the transaction, making sure that it is processable and
-provides enough fee to compensate the operator for this transaction. Then, this transaction will be
+Historically, a new priority operation was appended by calling
+[`requestL2Transaction`](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/contracts/ethereum/contracts/zksync/facets/Mailbox.sol#L236)
+on Mailbox.
+
+Deprecation note: `requestL2Transaction` is deprecated. New integrations should use
+`Bridgehub.requestL2TransactionDirect`.
+
+This flow performs several checks for the transaction, making sure that it is processable and provides enough fee to
+compensate the operator. Then, this transaction is
 [appended](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/contracts/ethereum/contracts/zksync/facets/Mailbox.sol#L369C1-L369C1)
 to the priority queue.
 

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -101,9 +101,12 @@ applying address aliasing leaves room for future EVM compatibility.
 
 The L1 -> L2 communication is also used for bridging ether. The user should include a `msg.value` when initiating a
 transaction request on the L1 contract. Before executing a transaction on L2, the specified address will be credited
-with the funds. To withdraw funds user should call `withdraw` function on the `L2EtherToken` system contracts. This will
-burn the funds on L2, allowing the user to reclaim them through the `finalizeEthWithdrawal` function on the
-`MailboxFacet`.
+with the funds. To withdraw funds user should call `withdraw` function on the `L2EtherToken` system contracts.
+
+Deprecation note: `finalizeEthWithdrawal` on `MailboxFacet` is deprecated. The replacement flow is
+`L1Nullifier.finalizeDeposit`.
+
+This will burn the funds on L2, allowing the user to reclaim them on L1 through the finalize flow.
 
 More about L1->L2 operations can be found
 [here](https://github.com/code-423n4/2023-10-zksync/blob/main/docs/Smart%20contract%20Section/Handling%20L1→L2%20ops%20on%20zkSync.md).


### PR DESCRIPTION
## Summary
Add explicit deprecation notes in docs for the two Mailbox methods announced in discussion #1147.

## Changes
Updated docs to clearly mark legacy method references and point to replacements:
- `requestL2Transaction` -> `Bridgehub.requestL2TransactionDirect`
- `finalizeEthWithdrawal` -> `L1Nullifier.finalizeDeposit`

Files:
- `docs/src/specs/l1_l2_communication/l1_to_l2.md`
- `docs/src/specs/l1_smart_contracts.md`
- `docs/src/guides/advanced/02_deposits.md`
- `docs/src/guides/advanced/03_withdrawals.md`

## Notes
This PR is docs-only and keeps the existing historical explanations while adding migration guidance.

## Linked issues
- Part of #347
- Ref #348