### PR TITLE
fix: compare reorg windows by l1 height

### DIFF
--- a/core/node/via_main_node_reorg_detector/src/lib.rs
+++ b/core/node/via_main_node_reorg_detector/src/lib.rs
@@ -199,14 +199,16 @@ impl ViaMainNodeReorgDetector {
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
 
-        let mut reorg_start_block_height_opt = None;
+        let chain_hashes = chain_blocks
+            .iter()
+            .map(|block| block.block_hash().to_string())
+            .collect::<Vec<_>>();
 
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
+        let reorg_start_block_height_opt =
+            find_reorg_start_block_in_window(start_height, &db_blocks, &chain_hashes);
+
+        if let Some(reorg_start_block_height) = reorg_start_block_height_opt {
+            tracing::warn!("Reorg detected at block {}", reorg_start_block_height);
         }
 
         if reorg_start_block_height_opt.is_none() {
@@ -312,5 +314,57 @@ impl ViaMainNodeReorgDetector {
         }
 
         Ok(false)
+    }
+}
+
+fn find_reorg_start_block_in_window(
+    start_height: i64,
+    db_blocks: &[(i64, String)],
+    chain_hashes: &[String],
+) -> Option<i64> {
+    for (db_number, db_hash) in db_blocks {
+        let Ok(chain_index) = usize::try_from(*db_number - start_height) else {
+            continue;
+        };
+        let Some(chain_hash) = chain_hashes.get(chain_index) else {
+            continue;
+        };
+
+        if chain_hash != db_hash {
+            return Some(*db_number);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_reorg_start_block_in_window;
+
+    #[test]
+    fn sparse_l1_block_window_compares_hashes_by_height() {
+        let start_height = 100_792;
+        let db_blocks = vec![(100_891, "hash-100891".to_string())];
+        let chain_hashes = (start_height..=100_891)
+            .map(|height| format!("hash-{height}"))
+            .collect::<Vec<_>>();
+
+        let reorg_start = find_reorg_start_block_in_window(start_height, &db_blocks, &chain_hashes);
+
+        assert_eq!(reorg_start, None);
+    }
+
+    #[test]
+    fn matching_height_hash_mismatch_detects_reorg_at_db_height() {
+        let start_height = 100_792;
+        let db_blocks = vec![(100_891, "stale-hash".to_string())];
+        let chain_hashes = (start_height..=100_891)
+            .map(|height| format!("hash-{height}"))
+            .collect::<Vec<_>>();
+
+        let reorg_start = find_reorg_start_block_in_window(start_height, &db_blocks, &chain_hashes);
+
+        assert_eq!(reorg_start, Some(100_891));
     }
 }

--- a/via_verifier/node/via_reorg_detector/src/lib.rs
+++ b/via_verifier/node/via_reorg_detector/src/lib.rs
@@ -206,16 +206,16 @@ impl ViaVerifierReorgDetector {
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
 
-        // let mut reorg_found = false;
-        let mut reorg_start_block_height_opt = None;
+        let chain_hashes = chain_blocks
+            .iter()
+            .map(|block| block.block_hash().to_string())
+            .collect::<Vec<_>>();
 
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                // reorg_found = true;
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
+        let reorg_start_block_height_opt =
+            find_reorg_start_block_in_window(start_height, &db_blocks, &chain_hashes);
+
+        if let Some(reorg_start_block_height) = reorg_start_block_height_opt {
+            tracing::warn!("Reorg detected at block {}", reorg_start_block_height);
         }
 
         if reorg_start_block_height_opt.is_none() {
@@ -303,5 +303,57 @@ impl ViaVerifierReorgDetector {
         }
 
         Ok(false)
+    }
+}
+
+fn find_reorg_start_block_in_window(
+    start_height: i64,
+    db_blocks: &[(i64, String)],
+    chain_hashes: &[String],
+) -> Option<i64> {
+    for (db_number, db_hash) in db_blocks {
+        let Ok(chain_index) = usize::try_from(*db_number - start_height) else {
+            continue;
+        };
+        let Some(chain_hash) = chain_hashes.get(chain_index) else {
+            continue;
+        };
+
+        if chain_hash != db_hash {
+            return Some(*db_number);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_reorg_start_block_in_window;
+
+    #[test]
+    fn sparse_l1_block_window_compares_hashes_by_height() {
+        let start_height = 100_792;
+        let db_blocks = vec![(100_891, "hash-100891".to_string())];
+        let chain_hashes = (start_height..=100_891)
+            .map(|height| format!("hash-{height}"))
+            .collect::<Vec<_>>();
+
+        let reorg_start = find_reorg_start_block_in_window(start_height, &db_blocks, &chain_hashes);
+
+        assert_eq!(reorg_start, None);
+    }
+
+    #[test]
+    fn matching_height_hash_mismatch_detects_reorg_at_db_height() {
+        let start_height = 100_792;
+        let db_blocks = vec![(100_891, "stale-hash".to_string())];
+        let chain_hashes = (start_height..=100_891)
+            .map(|height| format!("hash-{height}"))
+            .collect::<Vec<_>>();
+
+        let reorg_start = find_reorg_start_block_in_window(start_height, &db_blocks, &chain_hashes);
+
+        assert_eq!(reorg_start, Some(100_891));
     }
 }


### PR DESCRIPTION
## Summary

- Compares reorg detector DB rows to canonical Bitcoin hashes by explicit L1 height instead of zip position.
- Adds regression tests for sparse `via_l1_blocks` windows where only the bootstrap/end height is present.
- Applies the same fix to both the main/external-node reorg detector and the verifier reorg detector.

Closes #354

## Why

A fresh external-node database can have a sparse `via_l1_blocks` table. The previous zip-by-position comparison could compare a DB row for a later height, such as `100891`, against the canonical hash for the first height in the reorg window, such as `100792`. That can false-detect a reorg and trigger soft-reorg handling even when the DB row is canonical for its actual height.

## Validation

```bash
git diff --check
cargo fmt --check
cargo test -p via_main_node_reorg_detector
cargo test -p via_verifier_reorg_detector
cargo check -p via_main_node_reorg_detector -p via_verifier_reorg_detector
gitleaks protect --staged --redact --no-banner
gitleaks git --log-opts="main..HEAD" --redact --no-banner
```

Notes:
- `via_verifier_dal` currently emits a pre-existing unused-variable warning in `withdrawals_dal.rs`; this PR does not touch that file.
- No live infrastructure actions were run.

## Review notes

This PR intentionally keeps the change narrow: sparse DB windows are handled as a safe non-reorg path for rows whose explicit heights still match canonical chain hashes. It does not add historical backfilling; infra-side guarded recovery automation handles future fresh/sparse Hetzner EN DB repair separately.
