### PR TITLE
docs: add via-core agent and PR guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,171 @@
-## What ❔
+## Why
 
-<!-- What are the changes this PR brings about? -->
-<!-- Example: This PR adds a PR template to the repo. -->
-<!-- (For bigger PRs adding more context is appreciated) -->
+<!--
+Explain the runtime, protocol, developer-experience, or documentation problem in
+human terms.
 
-## Why ❔
+For protocol/runtime/safety changes, write a short narrative rather than a terse
+summary. The reader may be a future reviewer or operator trying to understand why
+this behavior exists during an incident, release, or migration.
 
-<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
-<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
+Cover the relevant parts of the story:
+- What was observed in source behavior, tests, logs, public APIs, live systems,
+  upstream code, or deployment desired state?
+- Why was the existing behavior unsafe, misleading, incomplete, hard to review,
+  or insufficient for operations?
+- What future maintainer, release, migration, external-node bootstrap, proof
+  flow, verifier path, BTC sender path, or incident-response path could be harmed
+  by leaving it as-is?
+- Which protocol/runtime invariant, config contract, ordering guarantee, data
+  shape, or deployment boundary should this repo enforce now?
 
-## Checklist
+Distinguish source changes from live proof. Code, docs, tests, configs, and
+Docker files in this repo describe behavior or artifacts; they do not by
+themselves prove what is currently deployed.
 
-<!-- Check your PR fulfills the following items. -->
-<!-- For draft PRs check the boxes as you complete them. -->
+Avoid leading with agent/tool process unless it materially affects review,
+safety, or reproducibility.
 
-- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
-- [ ] Tests for the changes have been added / updated.
-- [ ] Documentation comments have been added / updated.
-- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
+Use impersonal, operator-facing wording. Avoid first-person singular or plural
+phrasing. Name the component, crate, module, config key, runtime invariant,
+deployment boundary, or operator action instead.
+-->
+
+## What changed
+
+<!--
+Group concrete behavior changes by purpose. Prefer behavior-level bullets over a
+file-by-file changelog.
+
+Examples:
+- The reorg detector now compares sparse L1 block windows by explicit Bitcoin
+  height rather than row position.
+- The BTC sender now treats byte-reversed txids consistently when reporting
+  public explorer evidence.
+- The external-node guide now documents the bootstrap dependency that must be
+  satisfied before a restart durability check.
+-->
+
+## Boundaries and non-goals
+
+<!--
+State the source, review, and rollout boundary for this PR.
+
+Use this section to prevent unsafe assumptions, not to repeat the diff. Call out
+only non-goals that matter for protocol/runtime safety, release handling, or live
+operations.
+
+Good examples:
+- This PR updates source code, tests, or docs only; no live deployment was run
+  from this branch.
+- The runtime behavior changes, but no database rows, wallet state, Kubernetes
+  resources, Helm releases, DNS records, cloud resources, or host services were
+  changed.
+- Secret names or config keys changed, but no secret values were added, moved,
+  renamed, printed, or required by this PR.
+- The source change can affect future images built from `main`, but rollout to
+  `via-main-testnet`, Hetzner external nodes, verifier nodes, or other live
+  environments remains a separate operator step after review and approval.
+- Deployment desired state in `kube-state`, chart defaults in `helm-charts`, and
+  Hetzner/GCP infrastructure repos are unchanged unless explicitly listed.
+- The change is limited to a specific component or crate, such as BTC sender,
+  reorg detector, DA client, external-node bootstrap, verifier, prover, or docs;
+  sibling implementations are intentionally unchanged or separately called out.
+
+Prefer explaining the boundary that could be misunderstood over listing every
+possible subsystem that was not touched.
+-->
+
+## How to review
+
+<!--
+Tell reviewers where to focus and what could be risky.
+
+For runtime changes, mention the relevant crates/modules, invariants, and sibling
+paths that should be compared. Examples:
+- Bitcoin integration: `core/lib/via_btc_client/`, `core/node/via_btc_watch/`,
+  `core/node/via_btc_sender/`, and corresponding verifier-side BTC paths.
+- Reorg detection: `core/node/via_main_node_reorg_detector/` and
+  `via_verifier/node/via_reorg_detector/`.
+- DA/Celestia paths: `core/lib/via_da_clients/` and verifier DA client paths.
+- External-node bootstrap/restart surfaces: `docker/via-external-node/`,
+  external-node docs/examples, and config keys consumed by deployment repos.
+- Prover/verifier/coordinator paths under `prover/` and `via_verifier/`.
+- `zkstack_cli/` changes that require rebuilding the installed CLI with
+  `zkstackup --local` before validation reflects source changes.
+- `zkstack_cli` Forge-script parameter and output-path changes where missing
+  deployments, bad paths, or wrong command ordering should fail clearly rather
+  than being hidden by broad fallbacks.
+- ordering assumptions in async fetch/compare code.
+- DB read/write semantics and migration implications.
+- config key defaults and deployment follow-up in `kube-state` / `helm-charts`.
+
+Call out whether reviewers should compare against tests, upstream ZKsync code,
+public explorer APIs, kube-state desired state, live logs/metrics, or database
+state. If upstream ZKsync is used as a reference, identify whether the referenced
+files, commands, and behavior exist in this repo's current fork lineage. Do not
+imply that source review is a live rollout or live verification.
+-->
+
+## Checks run
+
+<!--
+Replace or edit this block with commands actually run. Keep exact commands
+copy/paste runnable where possible. Remove commands that were not run.
+-->
+
+```bash
+git diff --check
+zkstack dev fmt
+zkstack dev lint
+cargo test -p <crate-or-package>
+gitleaks protect --staged --redact --no-banner
+gitleaks git --log-opts="main..HEAD" --redact --no-banner
+```
+
+## Author checklist
+
+- [ ] PR title follows Conventional Commits.
+- [ ] Tests, docs, formatting, and linting were updated or marked not applicable.
+
+## Live infrastructure and deployment impact
+
+<!--
+State both:
+1. whether this PR already included live-system interaction, and
+2. what deployment impact is expected after merge.
+
+Use one of these patterns for pre-merge actions:
+
+- No live infrastructure actions were run.
+
+or:
+
+- Read-only live checks were run:
+  - `<exact command, public API, or read-only query>`
+  - `<exact command, public API, or read-only query>`
+
+or:
+
+- Live changes were run:
+  - Environment/context:
+  - Workload/service/database/resource:
+  - Exact command or operation:
+  - Reason:
+  - Verification:
+  - Rollback/follow-up:
+
+Be explicit about mutations: deployments, restarts, migrations, DB writes,
+secret reads/writes, wallet/cookie access, temporary pods, DNS/Cloudflare,
+ingress/public exposure, cloud resources, and host-level service changes.
+
+Then state expected post-merge behavior, for example:
+
+- Merging this PR changes source/docs/tests only and is not expected to deploy
+  live services by itself.
+
+or:
+
+- Merging this PR can affect future images built from `main`; rollout to a live
+  environment remains a separate deployment approval and verification step.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# AGENTS.md
+
+## Scope
+
+Applies to this repository root and all descendants unless a nested `AGENTS.md` adds more specific instructions.
+This repository contains Via Network protocol and runtime code. Keep changes reviewable, and grounded in source behavior, tests, and deployment facts.
+
+## Purpose
+
+This repo owns Via source/runtime behavior: main node, external node, verifier, indexer, BTC sender, prover, contracts, config semantics, docs, and developer tooling that ship with `via-core`.
+
+This repo does not own live or desired-state deployment. Use sibling repos for Kubernetes, Helm, Hetzner/OpenTofu/Ansible, GCP/Terragrunt, explorer code, and durable incident synthesis. Source changes here can affect future builds, but do not prove what is currently deployed.
+
+## Read first
+
+- Before changing non-trivial runtime behavior, read the relevant Via guide
+  (`docs/via_guides/development.md`, `docs/via_guides/architecture.md`, or
+  `docs/via_guides/data-flow.md`) and the nearest crate README/config; do not
+  infer behavior from file names alone.
+
+## Important paths
+
+- Runtime: `core/`; verifier: `via_verifier/`; prover/indexer: `prover/`, `via_indexer/`.
+- Bitcoin: `core/lib/via_btc_client/`, `core/node/via_btc_*/`, verifier BTC paths, and `core/lib/dal/src/via_btc_sender_dal.rs`.
+- DA/reorg: `core/lib/via_da_clients/`, verifier DA paths, `core/node/via_main_node_reorg_detector/`, and `via_verifier/node/via_reorg_detector/`.
+- Contracts/config/CLI/docs/examples: `contracts/`, `configs/`, `etc/`, `zkstack_cli/`, `docs/`, `docker/`, `.github/`.
+
+## Source-of-truth rules
+
+- Keep source, desired state, and live state separate: repo code does not prove
+  deployment, and deployment repos do not prove runtime behavior. Verify against
+  source, kube/Helm/infra repos, live cluster/host state, public APIs, DB state,
+  or tests as appropriate.
+- Do not assume upstream ZKsync behavior is unchanged after Via-specific forks.
+  Check Via files and upstream references before classifying a divergence.
+- Treat current upstream ZKsync `main` documentation as a reference, not as a
+  direct source of repo rules. Before importing newer upstream guidance, verify
+  the referenced files, commands, and upgrade architecture exist in this repo's
+  current ZKsync lineage and Via-specific fork state.
+- Prefer Via-specific `via_` modules, crates, services, binaries, and components
+  when extending fork behavior. Touch upstream-derived non-`via_` code only when
+  the task requires that exact path or a Via component depends on it, and explain
+  why a `via_` extension was not enough.
+- For Bitcoin transaction investigations, check byte-reversed 32-byte txids
+  before declaring a transaction missing from public explorers or node RPC.
+
+## Safety rules
+
+- Never commit secrets, private keys, wallet material, database URLs, RPC
+  passwords, cookies, decrypted env files, or generated local state.
+- Do not query or print live secrets from deployment repos or clusters while
+  working in this repo.
+- Do not deploy, restart workloads, run migrations against live databases, or
+  mutate live infrastructure from this repo without explicit operator approval.
+- Keep local diagnostic artifacts out of commits. Use `.git/info/exclude` for
+  local agent/indexing scratch directories such as `.gitnexus/`, `.claude/`, or
+  similar tool output if they appear.
+
+## Change discipline
+
+- For bug fixes, include a regression test when the affected crate/test harness
+  makes it practical.
+- Preserve rich error context in production/library paths. Prefer propagated
+  errors and `anyhow::Context` / `with_context` over flattening failures into
+  generic strings. Avoid `unwrap()` / `expect()` in non-test runtime paths.
+- Make examples model safe usage when they are copied by operators or integrators;
+  do not leave panic-prone examples around hardened library APIs.
+- Compact-by-default: prefer one-line expressions and short helper calls when
+  they remain readable and rustfmt accepts them; avoid manual wrapping churn and
+  do not reformat unrelated existing code just to change line shape.
+- Reuse-first: search for the canonical abstraction before adding helpers,
+  parsers, clients, DAL methods, conversions, or runtime glue. Prefer extension
+  over near-duplicates; if new code is needed, place it beside the closest owner
+  and explain the non-reuse decision in the PR.
+- For runtime behavior changes that affect deployments, document the required
+  deployment/config follow-up in the PR body. Do not imply live rollout has
+  happened unless it has been verified separately.
+- When touching duplicated main-node/verifier/external-node logic, check whether
+  the same bug exists in the sibling implementation before stopping.
+- When changing async fetch/compare code, preserve or explicitly encode ordering
+  assumptions. Do not compare height-indexed data by vector position unless the
+  ordering contract is proven and tested.
+- For `zkstack_cli/` Rust changes, rebuild the installed CLI with
+  `zkstackup --local` before validating CLI behavior.
+- For Forge/deployment/upgrade flows, verify generated paths, env vars,
+  deployment state, and call order against Via's actual command flow. Prefer
+  fail-fast root-cause fixes over broad fallbacks, `try/catch`, or low-level
+  `staticcall` probes that hide missing deployments or ordering bugs; use
+  `cast run` or equivalent tracing for opaque failures.
+- Protocol-sensitive areas include Bitcoin, DA/Celestia, verifier/prover, state
+  keeper, reorg/reverter, contracts/upgrades, migrations/DAL, serialization,
+  hashes, signatures, byte order, and inscriptions. Search call sites and
+  downstream consumers before changing APIs, config keys, DB schema, metrics, or
+  encoded data.
+- Long-lived services in `core/node` and `via_verifier/node` often communicate
+  through database state rather than direct calls. Before changing one, identify
+  the table/query it polls, rows it creates or updates, downstream consumers, and
+  retry/error/stop-signal behavior.
+
+## GitNexus and cross-repo review
+
+- Use GitNexus before non-trivial impact analysis or Via cross-repo review; then
+  verify decisive graph findings against exact source files.
+- Treat `kube-state` and `helm-charts` as deployment/config context, not live
+  proof. Keep `.gitnexus/`, `.claude/`, `.rooignore`, and similar agent artifacts
+  local/excluded unless an ignore-policy PR is explicitly intended.
+
+## Validation
+
+Choose checks that match the files changed and report exactly what ran.
+
+Common local gates:
+
+```bash
+git diff --check
+zkstack dev fmt
+zkstack dev lint
+cargo test -p <crate-or-package>
+```
+
+For targeted Rust changes, prefer the narrowest meaningful crate tests first,
+then broader checks if the change is shared or safety-critical. If a command
+cannot run locally, state why and list the source inspection or narrower check
+used instead.
+
+## PR descriptions
+
+Use `.github/pull_request_template.md` for PR bodies.
+
+Write PR descriptions for a human reviewer/operator, not as an agent/tool audit
+log. Explain why the change exists, what behavior changes, what intentionally did
+not change, how to review the risk, which checks ran, and whether any live
+infrastructure action occurred.
+
+Use impersonal, operator-facing wording. Avoid first-person singular or plural
+phrasing. Name the component, crate, runtime invariant, config key, deployment
+boundary, or operator action instead.
+
+For runtime/safety PRs, the `Why` section should describe the observed failure
+mode and the invariant the code should enforce. The `What did not change` section
+should prevent unsafe assumptions, especially around live rollout, database
+mutation, secrets, deployment desired state, and follow-up infra work.


### PR DESCRIPTION
## Why

`via-core` already had a small root `AGENTS.md` and a compact pull request template, but both were much thinner than the guidance now present in `kube-state` and `via-infra-hetzner`. That made protocol/runtime reviews easier to frame as generic code changes instead of reviews with explicit ownership boundaries, live-vs-source distinctions, validation expectations, and deployment impact notes.

This repository owns runtime behavior that deployment repos consume through images, binaries, config keys, and docs. Reviewers and future operators benefit from a repo-local routing file and a PR template that clearly separate source behavior from live deployment proof, especially for external-node bootstrap, Bitcoin/L1 handling, verifier/prover paths, CLI-driven setup paths, and incident-response follow-up.

The guidance was refined with GitNexus group context from the Via repository set (`vianetwork`, `via-platform-core`, and `via-infra-foundation`), direct GitNexus inspection of `via-core` component surfaces, and a full pass over the current upstream ZKsync `AGENTS.md`. Upstream ZKsync guidance was not copied wholesale; only the parts that match this Via checkout were adapted.

## What changed

- Expanded the root `AGENTS.md` into a via-core-specific routing and safety guide.
- Added explicit ownership boundaries between `via-core`, `kube-state`, `helm-charts`, `via-infra-hetzner`, and GCP infrastructure repos.
- Added more specific via-core path guidance for:
  - BTC client / BTC watch / BTC sender paths
  - main-node and verifier reorg detectors
  - verifier-side BTC/DA sibling implementations
  - DA clients
  - prover, verifier, indexer, contracts, configs, Docker examples, and `zkstack_cli`
- Added source-of-truth, safety, change-discipline, validation, GitNexus, and PR-description guidance for runtime/protocol work.
- Adapted the upstream ZKsync `zkstack_cli` rebuild rule for Via: Rust changes under `zkstack_cli/` require rebuilding the installed CLI with `zkstackup --local` before CLI validation reflects source changes.
- Adapted the upstream Forge-script lesson narrowly for this checkout: `zkstack_cli` commands that construct Forge script parameters or output paths should verify generated paths and fail clearly instead of masking missing deployments, wrong ordering, or bad paths with broad fallbacks.
- Added a scoped fail-fast rule to `AGENTS.md` for deployment/upgrade orchestration scripts: avoid `try/catch` and low-level `staticcall` fallback probes when they would hide missing deployments, initialization-order bugs, or timing problems; explicit state checks are preferred. Static-call tests and precompile/EVM-behavior tests are explicitly excluded from that rule. The PR template keeps this as broader `zkstack_cli`/review-focus guidance rather than a mandatory checklist item.
- Reworked `.github/pull_request_template.md` into reviewer/operator-focused sections:
  - `Why`
  - `What changed`
  - `Boundaries and non-goals`
  - `How to review`
  - `Checks run`
  - `Live infrastructure and deployment impact`

## Boundaries and non-goals

- No runtime code, contracts, configs, Docker files, or workflows changed.
- No live infrastructure actions were run.
- No database rows, wallet state, Kubernetes resources, Helm releases, DNS records, cloud resources, or host services changed.
- No secret values were added, moved, renamed, printed, or required by this PR.
- The existing PR-title workflow and conventional-commit requirement remain unchanged.
- This PR intentionally updates repo guidance only; it does not fix the open sparse reorg-window runtime bug in PR #355.
- Upstream ZKsync's v31 ecosystem upgrade-script architecture was reviewed but not copied because this Via checkout does not contain the same `deploy-scripts/upgrade/...` files.
- The upstream `try/catch` / `staticcall` rule was included only as a scoped orchestration-script rule, not as a blanket ban across all Solidity, because this checkout legitimately uses `staticcall` in test/precompile semantics code.

## How to review

Focus on whether the guidance is useful for future `via-core` protocol/runtime reviews without overclaiming live deployment state.

Review points:
- `AGENTS.md` should route agents/reviewers to the right repo and avoid conflating source behavior with live desired state.
- The listed paths should be specific enough to help with Via runtime review without becoming a brittle full source map.
- The upstream ZKsync-derived guidance should be limited to parts that exist or clearly apply in this Via checkout.
- `.github/pull_request_template.md` should preserve the useful checklist intent while asking for stronger context, validation, and rollout boundaries.
- The template should remain broadly usable for code, docs, tests, configs, runtime safety PRs, and tooling changes.
- The text should not imply that a source PR performs a deployment or live verification by itself.

## Checks run

```bash
git diff --check
git diff --cached --check
gitleaks protect --staged --redact --no-banner
curl -fsSL https://raw.githubusercontent.com/matter-labs/zksync-era/refs/heads/main/AGENTS.md -o /tmp/zksync-era-AGENTS.md
NODE_NO_WARNINGS=1 gitnexus analyze --skip-agents-md "$PWD"
NODE_NO_WARNINGS=1 gitnexus query -r via-core -c 'Improving via-core AGENTS.md and PR template with repo-specific runtime review guidance' -g 'Identify Via runtime components and review boundaries' -l 10 'via btc sender reorg detector external node verifier prover indexer config'
NODE_NO_WARNINGS=1 gitnexus cypher -r via-core "MATCH (f:File) WHERE f.filePath CONTAINS 'via_btc_sender' OR f.filePath CONTAINS 'via_btc_client' OR f.filePath CONTAINS 'via_da_client' OR f.filePath CONTAINS 'via_btc_watch' OR f.filePath CONTAINS 'via_main_node_reorg_detector' RETURN f.name, f.filePath LIMIT 80"
```

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR changes repository guidance and the default pull request body only. It is not expected to deploy live services by itself.
