### PR TITLE
fix(reorg-detector): compare L1 blocks by explicit height on sparse via_l1_blocks

### DIFF
--- a/core/node/via_main_node_reorg_detector/src/lib.rs
+++ b/core/node/via_main_node_reorg_detector/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use bitcoin::Block;
@@ -10,6 +10,38 @@ use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 use crate::metrics::{ReorgType, METRICS};
 
 mod metrics;
+
+#[cfg(test)]
+mod tests;
+
+/// Result of comparing local DB blocks against the canonical chain map.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReorgScan {
+    /// All DB blocks present in the canonical map match.
+    NoReorg,
+    /// First height at which a DB hash does not match the canonical hash.
+    ReorgAt(i64),
+    /// Local DB has a row whose height is not present in the canonical map
+    /// (sparse/stale fetch). Caller must treat as inconclusive and skip.
+    SparseAt(i64),
+}
+
+/// Pure helper: compare DB rows (ascending by `number`) against a
+/// height-keyed canonical map. Comparison is by explicit block height,
+/// never by positional `zip`.
+pub(crate) fn scan_for_reorg(
+    db_blocks: &[(i64, String)],
+    canonical_by_height: &HashMap<i64, String>,
+) -> ReorgScan {
+    for (db_number, db_hash) in db_blocks {
+        match canonical_by_height.get(db_number) {
+            Some(canonical_hash) if canonical_hash == db_hash => continue,
+            Some(_) => return ReorgScan::ReorgAt(*db_number),
+            None => return ReorgScan::SparseAt(*db_number),
+        }
+    }
+    ReorgScan::NoReorg
+}
 
 #[derive(Debug)]
 pub struct ViaMainNodeReorgDetector {
@@ -76,23 +108,36 @@ impl ViaMainNodeReorgDetector {
         Ok(())
     }
 
+    /// Fetch canonical blocks paired with their fetched height, so that
+    /// downstream code never relies on `buffer_unordered` preserving order.
     async fn fetch_blocks(
         &self,
         from_block_height: i64,
         to_block_height: i64,
-    ) -> anyhow::Result<Vec<Block>> {
+    ) -> anyhow::Result<Vec<(i64, Block)>> {
         use futures::stream::{self, StreamExt};
 
         let heights: Vec<i64> = (from_block_height..=to_block_height).collect();
 
         let results = stream::iter(heights)
-            .map(|height| async move { self.btc_client.fetch_block(height as u128).await })
+            .map(|height| async move {
+                self.btc_client
+                    .fetch_block(height as u128)
+                    .await
+                    .map(|block| (height, block))
+            })
             .buffer_unordered(self.config.max_concurrent_fetches())
             .collect::<Vec<_>>()
             .await;
 
-        let blocks: Result<Vec<_>, _> = results.into_iter().collect();
-        blocks.context("Failed to fetch blocks")
+        let mut blocks: Vec<(i64, Block)> = results
+            .into_iter()
+            .collect::<Result<_, _>>()
+            .context("Failed to fetch blocks")?;
+        // Restore ascending height order; `buffer_unordered` yields results
+        // in completion order, not request order.
+        blocks.sort_by_key(|(height, _)| *height);
+        Ok(blocks)
     }
 
     async fn init(&mut self) -> anyhow::Result<()> {
@@ -128,7 +173,7 @@ impl ViaMainNodeReorgDetector {
     async fn is_canonical_chain(&self, block_height: i64, hash: String) -> anyhow::Result<bool> {
         let blocks = self.fetch_blocks(block_height, block_height).await?;
 
-        let Some(block) = blocks.first() else {
+        let Some((_, block)) = blocks.first() else {
             anyhow::bail!("Cannot fetch the block {}", block_height);
         };
 
@@ -165,7 +210,7 @@ impl ViaMainNodeReorgDetector {
 
         let mut transaction = storage.start_transaction().await?;
 
-        for (height, block) in (from_block_height..=to_block_height).zip(blocks) {
+        for (height, block) in blocks {
             tracing::debug!(
                 "Fetched block {height} with hash {}",
                 block.block_hash().to_string()
@@ -196,18 +241,32 @@ impl ViaMainNodeReorgDetector {
             .list_l1_blocks(start_height, window)
             .await?;
 
-        // Fetch chain blocks in batch
+        // Fetch chain blocks in batch, keyed by explicit canonical height so
+        // we never compare positionally against a sparse DB window.
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+        let canonical_by_height: HashMap<i64, String> = chain_blocks
+            .into_iter()
+            .map(|(height, block)| (height, block.block_hash().to_string()))
+            .collect();
 
-        let mut reorg_start_block_height_opt = None;
-
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
+        let reorg_start_block_height_opt = match scan_for_reorg(&db_blocks, &canonical_by_height) {
+            ReorgScan::NoReorg => None,
+            ReorgScan::ReorgAt(height) => {
+                tracing::warn!("Reorg detected at block {}", height);
+                Some(height)
             }
-        }
+            ReorgScan::SparseAt(height) => {
+                // Stale/incomplete canonical fetch for a height that is
+                // present in the local DB. Treat as inconclusive so we do
+                // not falsely demote the BtcWatch cursor below the wallet
+                // bootstrap block when via_l1_blocks is sparse.
+                tracing::warn!(
+                    "Skipping reorg check: canonical chain fetch missing block {height} \
+                     for height-keyed comparison (sparse local via_l1_blocks window)"
+                );
+                return Ok(());
+            }
+        };
 
         if reorg_start_block_height_opt.is_none() {
             return Ok(());

--- a/core/node/via_main_node_reorg_detector/src/tests.rs
+++ b/core/node/via_main_node_reorg_detector/src/tests.rs
@@ -1,0 +1,104 @@
+//! Unit tests for the pure reorg-scan helper.
+//!
+//! These tests pin down the regression described in the Hetzner private
+//! external-node rehearsal: a fresh/sparse `via_l1_blocks` table must not
+//! cause the detector to compare a wallet bootstrap block height against
+//! the wrong canonical block by positional `zip`.
+
+use std::collections::HashMap;
+
+use super::{scan_for_reorg, ReorgScan};
+
+fn canon(entries: &[(i64, &str)]) -> HashMap<i64, String> {
+    entries
+        .iter()
+        .map(|(h, s)| (*h, (*s).to_string()))
+        .collect()
+}
+
+#[test]
+fn no_reorg_when_db_subset_matches_canonical() {
+    let db = vec![(100_891, "hash_891".to_string())];
+    let canonical = canon(&[(100_792, "hash_792"), (100_891, "hash_891")]);
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::NoReorg);
+}
+
+/// Regression: bootstrap inserted exactly one row at the wallet block
+/// (e.g. 100_891) while the detector window starts at 100_792. Positional
+/// zip would compare DB row index 0 (height 100_891) against canonical
+/// chain index 0 (height 100_792) and falsely report a reorg at 100_891.
+#[test]
+fn sparse_db_does_not_falsely_compare_against_window_start() {
+    let db = vec![(100_891, "wallet_bootstrap_hash".to_string())];
+
+    // Canonical chain across the whole 100-block reorg window. All canonical
+    // hashes are distinct from the bootstrap hash so a positional zip would
+    // have flagged a reorg at 100_891 vs canonical 100_792.
+    let canonical: HashMap<i64, String> = (100_792..=100_891)
+        .map(|h| (h, format!("canonical_{h}")))
+        .collect();
+    let mut canonical = canonical;
+    // The wallet bootstrap row IS on canonical chain at its own height; the
+    // detector must agree.
+    canonical.insert(100_891, "wallet_bootstrap_hash".to_string());
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::NoReorg);
+}
+
+#[test]
+fn missing_canonical_height_for_present_db_row_returns_sparse() {
+    let db = vec![(100_891, "wallet_bootstrap_hash".to_string())];
+
+    // Simulate a stale/partial fetch where canonical map does not contain
+    // the height the DB knows about. We must NOT silently fall back to
+    // positional comparison; we must signal sparse.
+    let canonical = canon(&[(100_792, "canonical_792"), (100_793, "canonical_793")]);
+
+    assert_eq!(
+        scan_for_reorg(&db, &canonical),
+        ReorgScan::SparseAt(100_891)
+    );
+}
+
+#[test]
+fn real_reorg_is_reported_at_diverging_height() {
+    let db = vec![
+        (100_890, "hash_890".to_string()),
+        (100_891, "stale_891".to_string()),
+        (100_892, "stale_892".to_string()),
+    ];
+    let canonical = canon(&[
+        (100_890, "hash_890"),
+        (100_891, "canonical_891"),
+        (100_892, "canonical_892"),
+    ]);
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::ReorgAt(100_891));
+}
+
+/// The DB rows are returned ordered ascending by `number`; the helper must
+/// pick the lowest diverging height, not the first encountered after a
+/// missing one.
+#[test]
+fn first_diverging_db_row_wins() {
+    let db = vec![
+        (100_890, "ok_890".to_string()),
+        (100_891, "bad_891".to_string()),
+        (100_892, "bad_892".to_string()),
+    ];
+    let canonical = canon(&[
+        (100_890, "ok_890"),
+        (100_891, "good_891"),
+        (100_892, "good_892"),
+    ]);
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::ReorgAt(100_891));
+}
+
+#[test]
+fn empty_db_is_no_reorg() {
+    let db: Vec<(i64, String)> = vec![];
+    let canonical = canon(&[(100_891, "anything")]);
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::NoReorg);
+}

--- a/via_verifier/node/via_reorg_detector/src/lib.rs
+++ b/via_verifier/node/via_reorg_detector/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use bitcoin::Block;
@@ -11,6 +11,38 @@ use zksync_dal::{Connection, ConnectionPool};
 use crate::metrics::{ReorgInfo, METRICS};
 
 mod metrics;
+
+#[cfg(test)]
+mod tests;
+
+/// Result of comparing local DB blocks against the canonical chain map.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReorgScan {
+    /// All DB blocks present in the canonical map match.
+    NoReorg,
+    /// First height at which a DB hash does not match the canonical hash.
+    ReorgAt(i64),
+    /// Local DB has a row whose height is not present in the canonical map
+    /// (sparse/stale fetch). Caller must treat as inconclusive and skip.
+    SparseAt(i64),
+}
+
+/// Pure helper: compare DB rows (ascending by `number`) against a
+/// height-keyed canonical map. Comparison is by explicit block height,
+/// never by positional `zip`.
+pub(crate) fn scan_for_reorg(
+    db_blocks: &[(i64, String)],
+    canonical_by_height: &HashMap<i64, String>,
+) -> ReorgScan {
+    for (db_number, db_hash) in db_blocks {
+        match canonical_by_height.get(db_number) {
+            Some(canonical_hash) if canonical_hash == db_hash => continue,
+            Some(_) => return ReorgScan::ReorgAt(*db_number),
+            None => return ReorgScan::SparseAt(*db_number),
+        }
+    }
+    ReorgScan::NoReorg
+}
 
 #[derive(Debug)]
 pub struct ViaVerifierReorgDetector {
@@ -113,29 +145,42 @@ impl ViaVerifierReorgDetector {
         Ok(())
     }
 
+    /// Fetch canonical blocks paired with their fetched height, so that
+    /// downstream code never relies on `buffer_unordered` preserving order.
     async fn fetch_blocks(
         &self,
         from_block_height: i64,
         to_block_height: i64,
-    ) -> anyhow::Result<Vec<Block>> {
+    ) -> anyhow::Result<Vec<(i64, Block)>> {
         use futures::stream::{self, StreamExt};
 
         let heights: Vec<i64> = (from_block_height..=to_block_height).collect();
 
         let results = stream::iter(heights)
-            .map(|height| async move { self.btc_client.fetch_block(height as u128).await })
+            .map(|height| async move {
+                self.btc_client
+                    .fetch_block(height as u128)
+                    .await
+                    .map(|block| (height, block))
+            })
             .buffer_unordered(self.config.max_concurrent_fetches())
             .collect::<Vec<_>>()
             .await;
 
-        let blocks: Result<Vec<_>, _> = results.into_iter().collect();
-        blocks.context("Failed to fetch blocks")
+        let mut blocks: Vec<(i64, Block)> = results
+            .into_iter()
+            .collect::<Result<_, _>>()
+            .context("Failed to fetch blocks")?;
+        // Restore ascending height order; `buffer_unordered` yields results
+        // in completion order, not request order.
+        blocks.sort_by_key(|(height, _)| *height);
+        Ok(blocks)
     }
 
     async fn is_canonical_chain(&self, block_height: i64, hash: String) -> anyhow::Result<bool> {
         let blocks = self.fetch_blocks(block_height, block_height).await?;
 
-        let Some(block) = blocks.first() else {
+        let Some((_, block)) = blocks.first() else {
             anyhow::bail!("Cannot fetch the block {}", block_height);
         };
 
@@ -172,7 +217,7 @@ impl ViaVerifierReorgDetector {
 
         let mut transaction = storage.start_transaction().await?;
 
-        for (height, block) in (from_block_height..=to_block_height).zip(blocks) {
+        for (height, block) in blocks {
             tracing::debug!(
                 "Fetched block {height} with hash {}",
                 block.block_hash().to_string()
@@ -203,20 +248,31 @@ impl ViaVerifierReorgDetector {
             .list_l1_blocks(start_height, window)
             .await?;
 
-        // Fetch chain blocks in batch
+        // Fetch chain blocks in batch, keyed by explicit canonical height so
+        // we never compare positionally against a sparse DB window.
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+        let canonical_by_height: HashMap<i64, String> = chain_blocks
+            .into_iter()
+            .map(|(height, block)| (height, block.block_hash().to_string()))
+            .collect();
 
-        // let mut reorg_found = false;
-        let mut reorg_start_block_height_opt = None;
-
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                // reorg_found = true;
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
+        let reorg_start_block_height_opt = match scan_for_reorg(&db_blocks, &canonical_by_height) {
+            ReorgScan::NoReorg => None,
+            ReorgScan::ReorgAt(height) => {
+                tracing::warn!("Reorg detected at block {}", height);
+                Some(height)
             }
-        }
+            ReorgScan::SparseAt(height) => {
+                // Stale/incomplete canonical fetch for a height that is
+                // present in the local DB. Treat as inconclusive so we do
+                // not falsely act on sparse local via_l1_blocks state.
+                tracing::warn!(
+                    "Skipping reorg check: canonical chain fetch missing block {height} \
+                     for height-keyed comparison (sparse local via_l1_blocks window)"
+                );
+                return Ok(false);
+            }
+        };
 
         if reorg_start_block_height_opt.is_none() {
             return Ok(false);

--- a/via_verifier/node/via_reorg_detector/src/tests.rs
+++ b/via_verifier/node/via_reorg_detector/src/tests.rs
@@ -1,0 +1,89 @@
+//! Unit tests for the pure reorg-scan helper. Mirrors the regression
+//! coverage in the main-node detector so the same sparse `via_l1_blocks`
+//! invariant is enforced on the verifier side.
+
+use std::collections::HashMap;
+
+use super::{scan_for_reorg, ReorgScan};
+
+fn canon(entries: &[(i64, &str)]) -> HashMap<i64, String> {
+    entries
+        .iter()
+        .map(|(h, s)| (*h, (*s).to_string()))
+        .collect()
+}
+
+#[test]
+fn no_reorg_when_db_subset_matches_canonical() {
+    let db = vec![(100_891, "hash_891".to_string())];
+    let canonical = canon(&[(100_792, "hash_792"), (100_891, "hash_891")]);
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::NoReorg);
+}
+
+/// Regression: bootstrap inserted exactly one row at the wallet block
+/// (e.g. 100_891) while the detector window starts at 100_792. Positional
+/// zip would compare DB row index 0 (height 100_891) against canonical
+/// chain index 0 (height 100_792) and falsely report a reorg at 100_891.
+#[test]
+fn sparse_db_does_not_falsely_compare_against_window_start() {
+    let db = vec![(100_891, "wallet_bootstrap_hash".to_string())];
+
+    let mut canonical: HashMap<i64, String> = (100_792..=100_891)
+        .map(|h| (h, format!("canonical_{h}")))
+        .collect();
+    canonical.insert(100_891, "wallet_bootstrap_hash".to_string());
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::NoReorg);
+}
+
+#[test]
+fn missing_canonical_height_for_present_db_row_returns_sparse() {
+    let db = vec![(100_891, "wallet_bootstrap_hash".to_string())];
+
+    let canonical = canon(&[(100_792, "canonical_792"), (100_793, "canonical_793")]);
+
+    assert_eq!(
+        scan_for_reorg(&db, &canonical),
+        ReorgScan::SparseAt(100_891)
+    );
+}
+
+#[test]
+fn real_reorg_is_reported_at_diverging_height() {
+    let db = vec![
+        (100_890, "hash_890".to_string()),
+        (100_891, "stale_891".to_string()),
+        (100_892, "stale_892".to_string()),
+    ];
+    let canonical = canon(&[
+        (100_890, "hash_890"),
+        (100_891, "canonical_891"),
+        (100_892, "canonical_892"),
+    ]);
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::ReorgAt(100_891));
+}
+
+#[test]
+fn first_diverging_db_row_wins() {
+    let db = vec![
+        (100_890, "ok_890".to_string()),
+        (100_891, "bad_891".to_string()),
+        (100_892, "bad_892".to_string()),
+    ];
+    let canonical = canon(&[
+        (100_890, "ok_890"),
+        (100_891, "good_891"),
+        (100_892, "good_892"),
+    ]);
+
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::ReorgAt(100_891));
+}
+
+#[test]
+fn empty_db_is_no_reorg() {
+    let db: Vec<(i64, String)> = vec![];
+    let canonical = canon(&[(100_891, "anything")]);
+    assert_eq!(scan_for_reorg(&db, &canonical), ReorgScan::NoReorg);
+}


### PR DESCRIPTION
## Why

A Via external-node bootstrap observed during the Hetzner private external-node
rehearsal produced a false soft reorg at the wallet bootstrap block and broke
wallet-resource startup on the next restart. The failure mode was rooted in
the L1 reorg detector and was not specific to that operator run; any fresh or
sparse `via_l1_blocks` table on a node that already has a `via_btc_watch`
cursor at the wallet bootstrap height could trigger the same path.

Two source defects combined to produce the false positive:

1. Both `core/node/via_main_node_reorg_detector` and
   `via_verifier/node/via_reorg_detector` fetched the 100-block canonical
   reorg window with `futures::buffer_unordered`, which yields results in
   completion order, not request order. The fetched `Vec<Block>` was then
   used as if it were ordered by ascending height.
2. `detect_reorg` compared the local DB rows to the canonical chain rows by
   positional `zip`, not by explicit height. With a freshly bootstrapped
   `via_l1_blocks` containing only one row at the wallet bootstrap block
   (for example `100891`), the detector window started at `100792`, so the
   single DB row at `100891` was compared against the canonical chain
   element at index `0` (height `100792`). The hashes did not match and the
   detector logged `Reorg detected at block 100891`.

The main-node soft-reorg handler then reset `via_btc_watch.last_processed`
below the wallet bootstrap block. On the next restart, the wallet-resource
bootstrap path could not find its rows, because `via_btc_watch` no longer
considered the wallet bootstrap block processed. This breaks the invariant
that a node booted with `VIA_BTC_WATCH_START_L1_BLOCK_NUMBER` and
`VIA_BTC_WATCH_RESTART_INDEXING=false` should not regress its BTC-watch
cursor purely because local `via_l1_blocks` state is sparse.

The same positional-zip and unordered-fetch pattern existed in the verifier
detector, so the invariant must be enforced on both sides.

## What changed

Applied to both `core/node/via_main_node_reorg_detector/src/lib.rs` and
`via_verifier/node/via_reorg_detector/src/lib.rs`:

- `fetch_blocks` now returns `Vec<(i64, Block)>`, pairing each block with its
  requested height and re-sorting ascending after `buffer_unordered`. This
  removes the silent ordering dependency. `sync_l1_blocks` was also relying
  on positional zip with a height range; it now consumes the explicit
  `(height, block)` pairs directly.
- `detect_reorg` builds a `HashMap<i64, String>` of canonical block hashes
  keyed by height and delegates to a pure `scan_for_reorg` helper that walks
  the DB rows in ascending order and compares each row by its explicit
  `number` against `canonical_by_height[number]`. Positional `zip` is gone.
- New `ReorgScan::SparseAt(height)` variant signals that the canonical fetch
  is missing a height that the local DB knows about (for example, a stale
  RPC or a partially failed batch fetch). The detector logs the height and
  returns without acting, so a sparse local window cannot cause a false
  reorg event or a BtcWatch demotion.
- Six unit tests per crate, including
  `sparse_db_does_not_falsely_compare_against_window_start`, which pins the
  exact `100891`-vs-`100792` regression.

## Performance / Complexity Impact

This change touches reorg detection and L1 sync (a Via-specific area called
out as requiring this section).

| Operation                                   | Before                       | After                                  | Notes |
|---------------------------------------------|------------------------------|----------------------------------------|-------|
| `fetch_blocks` (per detector iteration)     | `O(W)` RPC + `O(W)` collect  | `O(W)` RPC + `O(W log W)` final sort   | `W = reorg_window = 100`. Adds one in-memory sort over up to 100 elements. RPC fan-out (`max_concurrent_fetches = 10`) is unchanged. |
| Reorg scan over the window                  | `O(min(D, W))` positional zip| `O(W)` HashMap build + `O(D)` scan     | `D = rows returned by list_l1_blocks` (`<= W`). Same asymptotic cost. |
| Allocations per iteration                   | `Vec<Block>` + `Vec<height>` | adds `HashMap<i64, String>` of size `W`| One small additional allocation; freed at end of iteration. |
| `sync_l1_blocks` insert loop                | `O(N)` zip over range        | `O(N)` direct iteration                | No change in cost. |

`W` is fixed at 100 by `ViaReorgDetectorConfig::reorg_window`, so the extra
sort and the HashMap are bounded and run at most once per poll interval. No
hot DAL path or BTC-client path changed.

## Boundaries and non-goals

- This PR updates source code and unit tests only. No live deployment was
  run from this branch.
- No DAL signatures, SQL, schema, migrations, config keys, env vars, metric
  names, or chain-state were changed. `init()` still seeds exactly one
  bootstrap row when `via_l1_blocks` is empty; the height-keyed comparison
  makes that safe rather than requiring a coherent full-window backfill.
- No changes to `kube-state`, `helm-charts`, or any Hetzner / GCP
  infrastructure repo. Rollout of the new behavior to `via-main-testnet`,
  Hetzner external nodes, or verifier nodes remains a separate operator
  step after review and approval.
- No secrets, wallet material, or cookies were read, printed, or moved.

## How to review

Suggested review focus:

- `core/node/via_main_node_reorg_detector/src/lib.rs` and
  `via_verifier/node/via_reorg_detector/src/lib.rs`: confirm both detectors
  now route through `scan_for_reorg` and that the `SparseAt` branch returns
  without inserting reorg metadata or touching `via_btc_watch`.
- `fetch_blocks`: confirm the height pairing + sort is correct and that the
  signature change is propagated to `sync_l1_blocks` and `is_canonical_chain`
  in both crates.
- `core/node/via_main_node_reorg_detector/src/tests.rs` and
  `via_verifier/node/via_reorg_detector/src/tests.rs`: the
  `sparse_db_does_not_falsely_compare_against_window_start` test is the
  named regression for the Hetzner observation; the
  `missing_canonical_height_for_present_db_row_returns_sparse` test pins the
  safe non-reorg path when the canonical fetch is stale or incomplete.
- Sibling check requested by repo guidance: both the main-node/external-node
  and verifier detectors received the same fix in the same PR; there are no
  remaining positional-zip comparisons against canonical chain blocks in
  these two files.

No upstream ZKsync reference is needed; the affected code is Via-specific.

## Checks run

```bash
cargo build -p via_main_node_reorg_detector -p via_verifier_reorg_detector
cargo test  -p via_main_node_reorg_detector -p via_verifier_reorg_detector
cargo fmt   -p via_main_node_reorg_detector -p via_verifier_reorg_detector --check
cargo clippy -p via_main_node_reorg_detector -p via_verifier_reorg_detector --tests
```

All 12 new unit tests (6 per crate) passed. Clippy emitted no new warnings in
the touched crates (pre-existing warnings in `core/lib/dal` are unrelated).

`zkstack dev fmt` / `zkstack dev lint` were not run in this environment; the
narrower `cargo fmt --check` and `cargo clippy` above were used in their
place for the two affected crates.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.

## Live infrastructure and deployment impact

- No live infrastructure actions were run.
- Merging this PR changes source and unit tests only and is not expected to
  deploy live services by itself.
- Merging can affect future images built from `main`; rollout to a live
  environment (Hetzner external nodes, `via-main-testnet`, verifier nodes)
  remains a separate deployment approval and verification step. Operators
  rolling this out on a node that has already been reset by the previous
  buggy soft-reorg path may also need to restore the wallet bootstrap
  cursor; that recovery is out of scope for this PR.
