### PR TITLE
fix: handle sparse L1 reorg detector windows

### DIFF
--- a/core/node/via_main_node_reorg_detector/src/lib.rs
+++ b/core/node/via_main_node_reorg_detector/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use bitcoin::Block;
@@ -80,19 +80,60 @@ impl ViaMainNodeReorgDetector {
         &self,
         from_block_height: i64,
         to_block_height: i64,
-    ) -> anyhow::Result<Vec<Block>> {
+    ) -> anyhow::Result<Vec<(i64, Block)>> {
         use futures::stream::{self, StreamExt};
 
         let heights: Vec<i64> = (from_block_height..=to_block_height).collect();
 
         let results = stream::iter(heights)
-            .map(|height| async move { self.btc_client.fetch_block(height as u128).await })
+            .map(|height| async move {
+                self.btc_client
+                    .fetch_block(height as u128)
+                    .await
+                    .map(|block| (height, block))
+            })
             .buffer_unordered(self.config.max_concurrent_fetches())
             .collect::<Vec<_>>()
             .await;
 
-        let blocks: Result<Vec<_>, _> = results.into_iter().collect();
-        blocks.context("Failed to fetch blocks")
+        let mut blocks = results
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to fetch blocks")?;
+        blocks.sort_by_key(|(height, _)| *height);
+
+        Ok(blocks)
+    }
+
+    async fn insert_l1_block_hashes(
+        &self,
+        storage: &mut Connection<'_, Core>,
+        blocks: &[(i64, String)],
+    ) -> anyhow::Result<()> {
+        let mut transaction = storage.start_transaction().await?;
+        for (height, hash) in blocks {
+            transaction
+                .via_l1_block_dal()
+                .insert_l1_block(*height, hash.clone())
+                .await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
+    async fn insert_l1_block_window(
+        &self,
+        storage: &mut Connection<'_, Core>,
+        block_height: i64,
+    ) -> anyhow::Result<()> {
+        let start_height = reorg_window_start(block_height, self.config.reorg_window());
+        let blocks = self.fetch_blocks(start_height, block_height).await?;
+        let blocks = blocks
+            .iter()
+            .map(|(height, block)| (*height, block.block_hash().to_string()))
+            .collect::<Vec<_>>();
+        self.insert_l1_block_hashes(storage, &blocks).await
     }
 
     async fn init(&mut self) -> anyhow::Result<()> {
@@ -109,11 +150,7 @@ impl ViaMainNodeReorgDetector {
                     .get_last_processed_l1_block("via_btc_watch")
                     .await? as i64;
 
-                let block = self.btc_client.fetch_block(block_height as u128).await?;
-
-                storage
-                    .via_l1_block_dal()
-                    .insert_l1_block(block_height, block.block_hash().to_string())
+                self.insert_l1_block_window(&mut storage, block_height)
                     .await?;
             }
         };
@@ -128,7 +165,7 @@ impl ViaMainNodeReorgDetector {
     async fn is_canonical_chain(&self, block_height: i64, hash: String) -> anyhow::Result<bool> {
         let blocks = self.fetch_blocks(block_height, block_height).await?;
 
-        let Some(block) = blocks.first() else {
+        let Some((_, block)) = blocks.first() else {
             anyhow::bail!("Cannot fetch the block {}", block_height);
         };
 
@@ -165,7 +202,7 @@ impl ViaMainNodeReorgDetector {
 
         let mut transaction = storage.start_transaction().await?;
 
-        for (height, block) in (from_block_height..=to_block_height).zip(blocks) {
+        for (height, block) in blocks {
             tracing::debug!(
                 "Fetched block {height} with hash {}",
                 block.block_hash().to_string()
@@ -188,7 +225,7 @@ impl ViaMainNodeReorgDetector {
         };
 
         let window = self.config.reorg_window();
-        let start_height = block_height.saturating_sub(window - 1).max(1);
+        let start_height = reorg_window_start(block_height, window);
 
         // Fetch DB blocks in batch
         let db_blocks = storage
@@ -198,18 +235,18 @@ impl ViaMainNodeReorgDetector {
 
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+        let chain_blocks = chain_blocks
+            .iter()
+            .map(|(height, block)| (*height, block.block_hash().to_string()))
+            .collect::<Vec<_>>();
 
-        let mut reorg_start_block_height_opt = None;
-
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
-        }
+        let reorg_start_block_height_opt =
+            find_reorg_start_height(&db_blocks, &chain_blocks, start_height, block_height)?;
 
         if reorg_start_block_height_opt.is_none() {
+            if db_blocks.len() != chain_blocks.len() {
+                self.insert_l1_block_hashes(storage, &chain_blocks).await?;
+            }
             return Ok(());
         }
 
@@ -312,5 +349,100 @@ impl ViaMainNodeReorgDetector {
         }
 
         Ok(false)
+    }
+}
+
+fn reorg_window_start(block_height: i64, window: i64) -> i64 {
+    if block_height <= 1 {
+        block_height
+    } else {
+        block_height.saturating_sub(window.saturating_sub(1)).max(1)
+    }
+}
+
+fn find_reorg_start_height(
+    db_blocks: &[(i64, String)],
+    chain_blocks: &[(i64, String)],
+    start_height: i64,
+    end_height: i64,
+) -> anyhow::Result<Option<i64>> {
+    let expected_len = (end_height - start_height + 1) as usize;
+    if chain_blocks.len() != expected_len {
+        anyhow::bail!(
+            "Fetched {} canonical L1 blocks for expected window {}..={}",
+            chain_blocks.len(),
+            start_height,
+            end_height
+        );
+    }
+
+    let chain_blocks_by_height = chain_blocks
+        .iter()
+        .map(|(height, hash)| (*height, hash.as_str()))
+        .collect::<HashMap<_, _>>();
+
+    for height in start_height..=end_height {
+        if !chain_blocks_by_height.contains_key(&height) {
+            anyhow::bail!("Canonical L1 block window is missing height {}", height);
+        }
+    }
+
+    if db_blocks.len() != expected_len {
+        tracing::warn!(
+            "Sparse via_l1_blocks reorg window {}..={}: found {} of {} DB rows; comparing only stored heights",
+            start_height,
+            end_height,
+            db_blocks.len(),
+            expected_len
+        );
+    }
+
+    for (db_number, db_hash) in db_blocks {
+        let Some(chain_hash) = chain_blocks_by_height.get(db_number) else {
+            anyhow::bail!(
+                "DB L1 block {} is outside canonical reorg window",
+                db_number
+            );
+        };
+
+        if *chain_hash != db_hash {
+            tracing::warn!("Reorg detected at block {}", db_number);
+            return Ok(Some(*db_number));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain_window(start_height: i64, end_height: i64) -> Vec<(i64, String)> {
+        (start_height..=end_height)
+            .map(|height| (height, format!("hash-{height}")))
+            .collect()
+    }
+
+    #[test]
+    fn sparse_db_window_compares_by_height() {
+        let chain_blocks = chain_window(100792, 100891);
+        let db_blocks = vec![(100891, "hash-100891".to_string())];
+
+        let reorg_start =
+            find_reorg_start_height(&db_blocks, &chain_blocks, 100792, 100891).unwrap();
+
+        assert_eq!(reorg_start, None);
+    }
+
+    #[test]
+    fn sparse_db_window_detects_mismatch_at_stored_height() {
+        let chain_blocks = chain_window(100792, 100891);
+        let db_blocks = vec![(100891, "stale-hash".to_string())];
+
+        let reorg_start =
+            find_reorg_start_height(&db_blocks, &chain_blocks, 100792, 100891).unwrap();
+
+        assert_eq!(reorg_start, Some(100891));
     }
 }

--- a/via_verifier/node/via_reorg_detector/src/lib.rs
+++ b/via_verifier/node/via_reorg_detector/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use bitcoin::Block;
@@ -96,11 +96,7 @@ impl ViaVerifierReorgDetector {
                     .get_last_processed_l1_block("via_btc_watch")
                     .await? as i64;
 
-                let block = self.btc_client.fetch_block(block_height as u128).await?;
-
-                storage
-                    .via_l1_block_dal()
-                    .insert_l1_block(block_height, block.block_hash().to_string())
+                self.insert_l1_block_window(&mut storage, block_height)
                     .await?;
             }
         };
@@ -117,25 +113,66 @@ impl ViaVerifierReorgDetector {
         &self,
         from_block_height: i64,
         to_block_height: i64,
-    ) -> anyhow::Result<Vec<Block>> {
+    ) -> anyhow::Result<Vec<(i64, Block)>> {
         use futures::stream::{self, StreamExt};
 
         let heights: Vec<i64> = (from_block_height..=to_block_height).collect();
 
         let results = stream::iter(heights)
-            .map(|height| async move { self.btc_client.fetch_block(height as u128).await })
+            .map(|height| async move {
+                self.btc_client
+                    .fetch_block(height as u128)
+                    .await
+                    .map(|block| (height, block))
+            })
             .buffer_unordered(self.config.max_concurrent_fetches())
             .collect::<Vec<_>>()
             .await;
 
-        let blocks: Result<Vec<_>, _> = results.into_iter().collect();
-        blocks.context("Failed to fetch blocks")
+        let mut blocks = results
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to fetch blocks")?;
+        blocks.sort_by_key(|(height, _)| *height);
+
+        Ok(blocks)
+    }
+
+    async fn insert_l1_block_hashes(
+        &self,
+        storage: &mut Connection<'_, Verifier>,
+        blocks: &[(i64, String)],
+    ) -> anyhow::Result<()> {
+        let mut transaction = storage.start_transaction().await?;
+        for (height, hash) in blocks {
+            transaction
+                .via_l1_block_dal()
+                .insert_l1_block(*height, hash.clone())
+                .await?;
+        }
+        transaction.commit().await?;
+
+        Ok(())
+    }
+
+    async fn insert_l1_block_window(
+        &self,
+        storage: &mut Connection<'_, Verifier>,
+        block_height: i64,
+    ) -> anyhow::Result<()> {
+        let start_height = reorg_window_start(block_height, self.config.reorg_window());
+        let blocks = self.fetch_blocks(start_height, block_height).await?;
+        let blocks = blocks
+            .iter()
+            .map(|(height, block)| (*height, block.block_hash().to_string()))
+            .collect::<Vec<_>>();
+        self.insert_l1_block_hashes(storage, &blocks).await
     }
 
     async fn is_canonical_chain(&self, block_height: i64, hash: String) -> anyhow::Result<bool> {
         let blocks = self.fetch_blocks(block_height, block_height).await?;
 
-        let Some(block) = blocks.first() else {
+        let Some((_, block)) = blocks.first() else {
             anyhow::bail!("Cannot fetch the block {}", block_height);
         };
 
@@ -172,7 +209,7 @@ impl ViaVerifierReorgDetector {
 
         let mut transaction = storage.start_transaction().await?;
 
-        for (height, block) in (from_block_height..=to_block_height).zip(blocks) {
+        for (height, block) in blocks {
             tracing::debug!(
                 "Fetched block {height} with hash {}",
                 block.block_hash().to_string()
@@ -195,7 +232,7 @@ impl ViaVerifierReorgDetector {
         };
 
         let window = self.config.reorg_window();
-        let start_height = block_height.saturating_sub(window - 1).max(1);
+        let start_height = reorg_window_start(block_height, window);
 
         // Fetch DB blocks in batch
         let db_blocks = storage
@@ -205,20 +242,18 @@ impl ViaVerifierReorgDetector {
 
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+        let chain_blocks = chain_blocks
+            .iter()
+            .map(|(height, block)| (*height, block.block_hash().to_string()))
+            .collect::<Vec<_>>();
 
-        // let mut reorg_found = false;
-        let mut reorg_start_block_height_opt = None;
-
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                // reorg_found = true;
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
-        }
+        let reorg_start_block_height_opt =
+            find_reorg_start_height(&db_blocks, &chain_blocks, start_height, block_height)?;
 
         if reorg_start_block_height_opt.is_none() {
+            if db_blocks.len() != chain_blocks.len() {
+                self.insert_l1_block_hashes(storage, &chain_blocks).await?;
+            }
             return Ok(false);
         }
 
@@ -303,5 +338,100 @@ impl ViaVerifierReorgDetector {
         }
 
         Ok(false)
+    }
+}
+
+fn reorg_window_start(block_height: i64, window: i64) -> i64 {
+    if block_height <= 1 {
+        block_height
+    } else {
+        block_height.saturating_sub(window.saturating_sub(1)).max(1)
+    }
+}
+
+fn find_reorg_start_height(
+    db_blocks: &[(i64, String)],
+    chain_blocks: &[(i64, String)],
+    start_height: i64,
+    end_height: i64,
+) -> anyhow::Result<Option<i64>> {
+    let expected_len = (end_height - start_height + 1) as usize;
+    if chain_blocks.len() != expected_len {
+        anyhow::bail!(
+            "Fetched {} canonical L1 blocks for expected window {}..={}",
+            chain_blocks.len(),
+            start_height,
+            end_height
+        );
+    }
+
+    let chain_blocks_by_height = chain_blocks
+        .iter()
+        .map(|(height, hash)| (*height, hash.as_str()))
+        .collect::<HashMap<_, _>>();
+
+    for height in start_height..=end_height {
+        if !chain_blocks_by_height.contains_key(&height) {
+            anyhow::bail!("Canonical L1 block window is missing height {}", height);
+        }
+    }
+
+    if db_blocks.len() != expected_len {
+        tracing::warn!(
+            "Sparse via_l1_blocks reorg window {}..={}: found {} of {} DB rows; comparing only stored heights",
+            start_height,
+            end_height,
+            db_blocks.len(),
+            expected_len
+        );
+    }
+
+    for (db_number, db_hash) in db_blocks {
+        let Some(chain_hash) = chain_blocks_by_height.get(db_number) else {
+            anyhow::bail!(
+                "DB L1 block {} is outside canonical reorg window",
+                db_number
+            );
+        };
+
+        if *chain_hash != db_hash {
+            tracing::warn!("Reorg detected at block {}", db_number);
+            return Ok(Some(*db_number));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain_window(start_height: i64, end_height: i64) -> Vec<(i64, String)> {
+        (start_height..=end_height)
+            .map(|height| (height, format!("hash-{height}")))
+            .collect()
+    }
+
+    #[test]
+    fn sparse_db_window_compares_by_height() {
+        let chain_blocks = chain_window(100792, 100891);
+        let db_blocks = vec![(100891, "hash-100891".to_string())];
+
+        let reorg_start =
+            find_reorg_start_height(&db_blocks, &chain_blocks, 100792, 100891).unwrap();
+
+        assert_eq!(reorg_start, None);
+    }
+
+    #[test]
+    fn sparse_db_window_detects_mismatch_at_stored_height() {
+        let chain_blocks = chain_window(100792, 100891);
+        let db_blocks = vec![(100891, "stale-hash".to_string())];
+
+        let reorg_start =
+            find_reorg_start_height(&db_blocks, &chain_blocks, 100792, 100891).unwrap();
+
+        assert_eq!(reorg_start, Some(100891));
     }
 }


### PR DESCRIPTION
## Why

A fresh Via external-node or verifier database can start with `via_btc_watch` metadata and wallet-related state while `via_l1_blocks` is empty or only partially populated. The reorg detector used that table as the local Bitcoin-chain checkpoint source, but the bootstrap path inserted only the current `via_btc_watch` height when the table was empty.

That single-row bootstrap was unsafe because reorg detection later fetched a full fixed-size canonical Bitcoin window and compared DB rows to canonical rows by iterator position. With a sparse local window ending at block `100891`, the first DB row for `100891` could be compared to the first canonical row for `100792`, producing a false reorg. On an external node, soft-reorg handling can then reset `via_btc_watch` below the wallet bootstrap block, making wallet rows invisible after restart and causing startup failures.

The runtime invariant enforced by this PR is that reorg detection must compare Bitcoin block hashes by explicit L1 height, not by positional assumptions about locally stored rows. Sparse local `via_l1_blocks` coverage is treated as a bootstrap/sync gap unless a stored height actually disagrees with the canonical Bitcoin hash for the same height.

## What changed

- The main-node/external-node reorg detector and verifier reorg detector now carry explicit block heights through asynchronous Bitcoin fetches and sort fetched results before use.
- Empty `via_l1_blocks` bootstrap now inserts the full reorg window ending at the current `via_btc_watch` block instead of inserting only one row.
- Reorg detection now builds a canonical hash lookup by block height and compares each stored DB row against the canonical hash for the same height.
- Sparse but matching local windows are backfilled from the already fetched canonical window with `ON CONFLICT DO NOTHING` inserts.
- Regression tests cover the sparse-window case where the DB contains only block `100891` while the canonical comparison window is `100792..=100891`.

## Performance / Complexity Impact

| Operation | Before | After | Notes |
| --- | --- | --- | --- |
| Fetch canonical window | O(n) network fetches | O(n) network fetches + O(n log n) sort | The sort makes ordering explicit after `buffer_unordered`; `n` is bounded by the reorg window. |
| Compare DB rows to canonical rows | O(m) positional zip | O(n) map build + O(n) coverage check + O(m) DB-row comparison | Avoids false comparisons when DB rows are sparse; `n` is bounded by the reorg window. |
| Empty-table bootstrap | 1 block fetch / insert | O(n) block fetches / inserts | Only runs when `via_l1_blocks` is empty; creates a coherent detector window. |
| Sparse matching window | No backfill | O(n) attempted inserts | Uses existing `ON CONFLICT DO NOTHING`; only runs when DB coverage is sparse and no reorg is detected. |

The added allocations are bounded by the configured reorg window: one vector of `(height, hash)` pairs and one height-to-hash lookup map during detection.

## Boundaries and non-goals

This PR updates source code and tests only. No live infrastructure actions, database writes, wallet state changes, Kubernetes/Helm changes, host restarts, or deployments were run from this branch.

Merging this PR can affect future main-node, external-node, and verifier images built from `main`. Rollout to Hetzner external nodes, verifier nodes, or any other live environment remains a separate operator approval and verification step after review.

Deployment desired state in sibling infrastructure repositories is not changed by this PR. The referenced Hetzner external-node rehearsal is operational evidence for the source bug, not proof of current live state.

## How to review

Focus on the reorg detector invariants in:

- `core/node/via_main_node_reorg_detector/src/lib.rs`
- `via_verifier/node/via_reorg_detector/src/lib.rs`

The main review points are:

- async block fetch ordering no longer leaks into sync or compare behavior;
- sparse DB rows cannot compare block `100891` against canonical block `100792` by position;
- sparse-but-matching windows are backfilled without declaring a reorg;
- actual hash mismatches at stored heights still produce the same reorg handling path;
- the same invariant is applied to both main-node/external-node and verifier detector implementations.

## Checks run

```bash
cargo fmt --package via_main_node_reorg_detector --package via_verifier_reorg_detector
cargo test -p via_main_node_reorg_detector
cargo test -p via_verifier_reorg_detector
git diff --check
```

`cargo test -p via_verifier_reorg_detector` emitted an existing unrelated warning in `via_verifier/lib/verifier_dal/src/withdrawals_dal.rs` for an unused `result` variable.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR changes source and tests only and is not expected to deploy live services by itself. Future images built from `main` will include the corrected reorg detector behavior; live rollout remains a separate deployment approval and verification step.