### PR TITLE
fix: compare reorg windows by l1 height

### DIFF
--- a/core/node/via_main_node_reorg_detector/src/lib.rs
+++ b/core/node/via_main_node_reorg_detector/src/lib.rs
@@ -11,6 +11,70 @@ use crate::metrics::{ReorgType, METRICS};
 
 mod metrics;
 
+fn chain_hashes_by_height(start_height: i64, chain_blocks: &[Block]) -> Vec<(i64, String)> {
+    (start_height..)
+        .zip(chain_blocks)
+        .map(|(height, block)| (height, block.block_hash().to_string()))
+        .collect()
+}
+
+fn is_sparse_l1_block_window(
+    db_blocks: &[(i64, String)],
+    start_height: i64,
+    end_height: i64,
+) -> bool {
+    let expected_len = (end_height - start_height + 1) as usize;
+    db_blocks.len() != expected_len
+        || db_blocks
+            .windows(2)
+            .any(|blocks| blocks[1].0 != blocks[0].0 + 1)
+        || db_blocks
+            .first()
+            .is_some_and(|(height, _)| *height != start_height)
+        || db_blocks
+            .last()
+            .is_some_and(|(height, _)| *height != end_height)
+}
+
+fn find_reorg_start_block(
+    db_blocks: &[(i64, String)],
+    chain_hashes: &[(i64, String)],
+) -> anyhow::Result<Option<i64>> {
+    let Some((start_height, _)) = chain_hashes.first() else {
+        anyhow::bail!("Cannot detect reorg against an empty canonical chain window");
+    };
+    let Some((end_height, _)) = chain_hashes.last() else {
+        anyhow::bail!("Cannot detect reorg against an empty canonical chain window");
+    };
+
+    let mut previous_height = start_height - 1;
+    for (db_height, db_hash) in db_blocks {
+        if db_height < start_height || db_height > end_height {
+            anyhow::bail!(
+                "DB L1 block {db_height} is outside canonical comparison window {start_height}..={end_height}"
+            );
+        }
+        if *db_height <= previous_height {
+            anyhow::bail!("DB L1 blocks are not strictly ordered by height");
+        }
+
+        let chain_index = (*db_height - start_height) as usize;
+        let (chain_height, chain_hash) = &chain_hashes[chain_index];
+        if chain_height != db_height {
+            anyhow::bail!(
+                "Canonical L1 block window is not indexed by expected height {db_height}; found {chain_height}"
+            );
+        }
+        if chain_hash != db_hash {
+            return Ok(Some(*db_height));
+        }
+
+        previous_height = *db_height;
+    }
+
+    Ok(None)
+}
+
 #[derive(Debug)]
 pub struct ViaMainNodeReorgDetector {
     config: ViaReorgDetectorConfig,
@@ -86,13 +150,21 @@ impl ViaMainNodeReorgDetector {
         let heights: Vec<i64> = (from_block_height..=to_block_height).collect();
 
         let results = stream::iter(heights)
-            .map(|height| async move { self.btc_client.fetch_block(height as u128).await })
+            .map(
+                |height| async move { (height, self.btc_client.fetch_block(height as u128).await) },
+            )
             .buffer_unordered(self.config.max_concurrent_fetches())
             .collect::<Vec<_>>()
             .await;
 
-        let blocks: Result<Vec<_>, _> = results.into_iter().collect();
-        blocks.context("Failed to fetch blocks")
+        let mut blocks = results
+            .into_iter()
+            .map(|(height, block)| block.map(|block| (height, block)))
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to fetch blocks")?;
+        blocks.sort_by_key(|(height, _)| *height);
+
+        Ok(blocks.into_iter().map(|(_, block)| block).collect())
     }
 
     async fn init(&mut self) -> anyhow::Result<()> {
@@ -109,12 +181,19 @@ impl ViaMainNodeReorgDetector {
                     .get_last_processed_l1_block("via_btc_watch")
                     .await? as i64;
 
-                let block = self.btc_client.fetch_block(block_height as u128).await?;
+                let start_height = block_height
+                    .saturating_sub(self.config.reorg_window() - 1)
+                    .max(1);
+                let blocks = self.fetch_blocks(start_height, block_height).await?;
 
-                storage
-                    .via_l1_block_dal()
-                    .insert_l1_block(block_height, block.block_hash().to_string())
-                    .await?;
+                let mut transaction = storage.start_transaction().await?;
+                for (height, block) in (start_height..=block_height).zip(blocks) {
+                    transaction
+                        .via_l1_block_dal()
+                        .insert_l1_block(height, block.block_hash().to_string())
+                        .await?;
+                }
+                transaction.commit().await?;
             }
         };
 
@@ -199,14 +278,17 @@ impl ViaMainNodeReorgDetector {
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
 
-        let mut reorg_start_block_height_opt = None;
+        if is_sparse_l1_block_window(&db_blocks, start_height, block_height) {
+            tracing::warn!(
+                "L1 block reorg detection window {start_height}..={block_height} is sparse in DB; comparing only explicit heights"
+            );
+        }
 
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
+        let chain_hashes = chain_hashes_by_height(start_height, &chain_blocks);
+        let reorg_start_block_height_opt = find_reorg_start_block(&db_blocks, &chain_hashes)?;
+
+        if let Some(db_number) = reorg_start_block_height_opt {
+            tracing::warn!("Reorg detected at block {}", db_number);
         }
 
         if reorg_start_block_height_opt.is_none() {
@@ -312,5 +394,39 @@ impl ViaMainNodeReorgDetector {
         }
 
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain_hashes(start: i64, end: i64) -> Vec<(i64, String)> {
+        (start..=end)
+            .map(|height| (height, format!("hash-{height}")))
+            .collect()
+    }
+
+    #[test]
+    fn sparse_db_window_compares_by_explicit_height() {
+        let chain_hashes = chain_hashes(100_792, 100_891);
+        let db_blocks = vec![(100_891, "hash-100891".to_string())];
+
+        assert!(is_sparse_l1_block_window(&db_blocks, 100_792, 100_891));
+        assert_eq!(
+            find_reorg_start_block(&db_blocks, &chain_hashes).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn mismatch_at_explicit_height_detects_reorg_at_that_height() {
+        let chain_hashes = chain_hashes(100_792, 100_891);
+        let db_blocks = vec![(100_891, "stale-hash-100891".to_string())];
+
+        assert_eq!(
+            find_reorg_start_block(&db_blocks, &chain_hashes).unwrap(),
+            Some(100_891)
+        );
     }
 }

--- a/via_verifier/node/via_reorg_detector/src/lib.rs
+++ b/via_verifier/node/via_reorg_detector/src/lib.rs
@@ -12,6 +12,70 @@ use crate::metrics::{ReorgInfo, METRICS};
 
 mod metrics;
 
+fn chain_hashes_by_height(start_height: i64, chain_blocks: &[Block]) -> Vec<(i64, String)> {
+    (start_height..)
+        .zip(chain_blocks)
+        .map(|(height, block)| (height, block.block_hash().to_string()))
+        .collect()
+}
+
+fn is_sparse_l1_block_window(
+    db_blocks: &[(i64, String)],
+    start_height: i64,
+    end_height: i64,
+) -> bool {
+    let expected_len = (end_height - start_height + 1) as usize;
+    db_blocks.len() != expected_len
+        || db_blocks
+            .windows(2)
+            .any(|blocks| blocks[1].0 != blocks[0].0 + 1)
+        || db_blocks
+            .first()
+            .is_some_and(|(height, _)| *height != start_height)
+        || db_blocks
+            .last()
+            .is_some_and(|(height, _)| *height != end_height)
+}
+
+fn find_reorg_start_block(
+    db_blocks: &[(i64, String)],
+    chain_hashes: &[(i64, String)],
+) -> anyhow::Result<Option<i64>> {
+    let Some((start_height, _)) = chain_hashes.first() else {
+        anyhow::bail!("Cannot detect reorg against an empty canonical chain window");
+    };
+    let Some((end_height, _)) = chain_hashes.last() else {
+        anyhow::bail!("Cannot detect reorg against an empty canonical chain window");
+    };
+
+    let mut previous_height = start_height - 1;
+    for (db_height, db_hash) in db_blocks {
+        if db_height < start_height || db_height > end_height {
+            anyhow::bail!(
+                "DB L1 block {db_height} is outside canonical comparison window {start_height}..={end_height}"
+            );
+        }
+        if *db_height <= previous_height {
+            anyhow::bail!("DB L1 blocks are not strictly ordered by height");
+        }
+
+        let chain_index = (*db_height - start_height) as usize;
+        let (chain_height, chain_hash) = &chain_hashes[chain_index];
+        if chain_height != db_height {
+            anyhow::bail!(
+                "Canonical L1 block window is not indexed by expected height {db_height}; found {chain_height}"
+            );
+        }
+        if chain_hash != db_hash {
+            return Ok(Some(*db_height));
+        }
+
+        previous_height = *db_height;
+    }
+
+    Ok(None)
+}
+
 #[derive(Debug)]
 pub struct ViaVerifierReorgDetector {
     config: ViaReorgDetectorConfig,
@@ -96,12 +160,19 @@ impl ViaVerifierReorgDetector {
                     .get_last_processed_l1_block("via_btc_watch")
                     .await? as i64;
 
-                let block = self.btc_client.fetch_block(block_height as u128).await?;
+                let start_height = block_height
+                    .saturating_sub(self.config.reorg_window() - 1)
+                    .max(1);
+                let blocks = self.fetch_blocks(start_height, block_height).await?;
 
-                storage
-                    .via_l1_block_dal()
-                    .insert_l1_block(block_height, block.block_hash().to_string())
-                    .await?;
+                let mut transaction = storage.start_transaction().await?;
+                for (height, block) in (start_height..=block_height).zip(blocks) {
+                    transaction
+                        .via_l1_block_dal()
+                        .insert_l1_block(height, block.block_hash().to_string())
+                        .await?;
+                }
+                transaction.commit().await?;
             }
         };
 
@@ -123,13 +194,21 @@ impl ViaVerifierReorgDetector {
         let heights: Vec<i64> = (from_block_height..=to_block_height).collect();
 
         let results = stream::iter(heights)
-            .map(|height| async move { self.btc_client.fetch_block(height as u128).await })
+            .map(
+                |height| async move { (height, self.btc_client.fetch_block(height as u128).await) },
+            )
             .buffer_unordered(self.config.max_concurrent_fetches())
             .collect::<Vec<_>>()
             .await;
 
-        let blocks: Result<Vec<_>, _> = results.into_iter().collect();
-        blocks.context("Failed to fetch blocks")
+        let mut blocks = results
+            .into_iter()
+            .map(|(height, block)| block.map(|block| (height, block)))
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to fetch blocks")?;
+        blocks.sort_by_key(|(height, _)| *height);
+
+        Ok(blocks.into_iter().map(|(_, block)| block).collect())
     }
 
     async fn is_canonical_chain(&self, block_height: i64, hash: String) -> anyhow::Result<bool> {
@@ -206,16 +285,17 @@ impl ViaVerifierReorgDetector {
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
 
-        // let mut reorg_found = false;
-        let mut reorg_start_block_height_opt = None;
+        if is_sparse_l1_block_window(&db_blocks, start_height, block_height) {
+            tracing::warn!(
+                "L1 block reorg detection window {start_height}..={block_height} is sparse in DB; comparing only explicit heights"
+            );
+        }
 
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                // reorg_found = true;
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
+        let chain_hashes = chain_hashes_by_height(start_height, &chain_blocks);
+        let reorg_start_block_height_opt = find_reorg_start_block(&db_blocks, &chain_hashes)?;
+
+        if let Some(db_number) = reorg_start_block_height_opt {
+            tracing::warn!("Reorg detected at block {}", db_number);
         }
 
         if reorg_start_block_height_opt.is_none() {
@@ -303,5 +383,39 @@ impl ViaVerifierReorgDetector {
         }
 
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain_hashes(start: i64, end: i64) -> Vec<(i64, String)> {
+        (start..=end)
+            .map(|height| (height, format!("hash-{height}")))
+            .collect()
+    }
+
+    #[test]
+    fn sparse_db_window_compares_by_explicit_height() {
+        let chain_hashes = chain_hashes(100_792, 100_891);
+        let db_blocks = vec![(100_891, "hash-100891".to_string())];
+
+        assert!(is_sparse_l1_block_window(&db_blocks, 100_792, 100_891));
+        assert_eq!(
+            find_reorg_start_block(&db_blocks, &chain_hashes).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn mismatch_at_explicit_height_detects_reorg_at_that_height() {
+        let chain_hashes = chain_hashes(100_792, 100_891);
+        let db_blocks = vec![(100_891, "stale-hash-100891".to_string())];
+
+        assert_eq!(
+            find_reorg_start_block(&db_blocks, &chain_hashes).unwrap(),
+            Some(100_891)
+        );
     }
 }


### PR DESCRIPTION
## Why

A fresh Via external-node or verifier database can contain `via_btc_watch` bootstrap metadata before `via_l1_blocks` has dense local coverage. The existing reorg detector bootstrap inserted only the current watched Bitcoin block when `via_l1_blocks` was empty, then `detect_reorg()` fetched a fixed reorg window from the DB and compared those rows to the canonical Bitcoin window by vector position.

That position-based comparison is unsafe when the local DB window is sparse: a locally stored block at the bootstrap height can be compared against the first canonical block in the window instead of the canonical block with the same height. During fresh external-node bootstrap, this can falsely classify sparse local state as a Bitcoin reorg and trigger soft-reorg handling that rewinds `via_btc_watch` below the bootstrap block. The runtime invariant should be that reorg detection compares Bitcoin block hashes by explicit L1 height, and sparse local coverage must not shift identities by row position.

This source change addresses both the main-node/external-node detector and the verifier detector because they shared the same bootstrap and comparison pattern.

## What changed

- Empty `via_l1_blocks` bootstrap now seeds the full configured reorg window ending at the current `via_btc_watch` block instead of inserting only one row.
- Reorg detection now maps canonical block hashes by explicit Bitcoin height and compares DB rows against the same height.
- Sparse DB windows are logged and compared only for heights present locally, preventing block `100891` from being compared against canonical block `100792` by position.
- Concurrent Bitcoin block fetches now restore height ordering before returning results.
- Regression tests cover the sparse-window case and mismatch-at-explicit-height behavior in both detector crates.

## Performance / Complexity Impact

| Operation | Before | After | Notes |
| --- | --- | --- | --- |
| Initial empty-table seed | O(1) fetch/insert | O(w) fetch/insert | `w` is the configured reorg window; this happens only when `via_l1_blocks` is empty. |
| Canonical fetch result handling | O(w) | O(w log w) | Results from `buffer_unordered` are sorted by height to preserve ordering. |
| Reorg comparison | O(n) | O(n) | DB rows are still scanned once; comparison indexes directly by explicit height within the canonical window. |

The runtime path allocates one `Vec<(height, hash)>` for the canonical window comparison. The window is bounded by `reorg_window`, so memory growth remains bounded by existing configuration.

## Boundaries and non-goals

This PR changes source and tests only. No live infrastructure actions, database mutations, deployments, restarts, Kubernetes/Helm changes, secret reads, or wallet-state changes were run from this branch.

Merging this PR can affect future main-node, external-node, and verifier images built from `main`; rollout to live environments remains a separate operator action after review and approval.

## How to review

Focus review on:

- `core/node/via_main_node_reorg_detector/src/lib.rs`
- `via_verifier/node/via_reorg_detector/src/lib.rs`

Check that the detector no longer relies on vector-position identity for sparse DB windows, that the bootstrap window insertion is bounded by `reorg_window`, and that the main-node/external-node and verifier implementations preserve the same invariant.

## Checks run

```bash
git diff --check
cargo fmt --package via_main_node_reorg_detector --package via_verifier_reorg_detector
cargo test -p via_main_node_reorg_detector -p via_verifier_reorg_detector
```

`zkstack dev lint` and local secret scanning were not run.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR changes source/tests only and is not expected to deploy live services by itself. Future rollout to external-node, main-node, or verifier environments requires separate deployment approval and verification.
