### PR TITLE
feat(via-structural): introduce format-changed.sh and compact formatting support for via_* paths

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -79,19 +79,27 @@ reviews:
         and coordination with via_btc_watch. Check sibling logic in via_verifier/node/via_btc_sender when relevant.
         Preserve explicit height/hash/txid identity; audit async completion order versus requested order.
 
+        Before adding or modifying significant logic here, review via_verifier/node/via_btc_sender/ for overlap.
+        Follow the root AGENTS.md → "Reuse and duplication discipline". Prefer extracting shared behavior to core/lib/ when possible.
+
     - path: "core/node/via_btc_watch/**"
       instructions: |
         Focus on L1-to-L2 message processing, governance upgrades, withdrawals, and system wallet handling.
         Cross-check against via_verifier/node/via_btc_watch when touching shared or duplicated behavior.
+        Follow the root AGENTS.md → "Reuse and duplication discipline" for any new or changed logic.
 
     - path: "via_verifier/node/via_btc_sender/**"
       instructions: |
         Verifier-side BTC sender. Apply the same byte-order, inscription, inflight-state, and identity rules
         as the main-node side. Check for unintended divergence from core/node/via_btc_sender.
 
+        Before adding or modifying significant logic here, review core/node/via_btc_sender/ for overlap.
+        Follow the root AGENTS.md → "Reuse and duplication discipline". Prefer extracting shared behavior to core/lib/ when possible.
+
     - path: "via_verifier/node/via_btc_watch/**"
       instructions: |
         Verifier-side BTC watch. Cross-check against the main-node implementation when behavior overlaps.
+        Follow the root AGENTS.md → "Reuse and duplication discipline" for any new or changed logic.
 
     - path: "core/lib/dal/src/via_btc_sender_dal.rs"
       instructions: |
@@ -103,18 +111,28 @@ reviews:
         Verifier-side BTC sender DAL. Keep identity, ordering, and state-transition semantics aligned
         with the main-node side unless the PR explicitly justifies divergence.
 
+        Before making significant changes, review core/lib/dal/src/via_btc_sender_dal.rs for overlap.
+        Follow the root AGENTS.md → "Reuse and duplication discipline".
+
     - path: "core/lib/config/src/configs/via_btc_*.rs"
       instructions: |
         BTC-related config. Review defaults, env mapping, operational safety, and consistency across
         sender/watch/client and main-node/verifier usage.
 
+        When making changes, check the corresponding verifier-side config (if it exists) and follow the root AGENTS.md → "Reuse and duplication discipline". Prefer keeping configuration aligned unless divergence is explicitly justified.
+
     - path: "core/lib/env_config/src/via_btc_*.rs"
       instructions: |
         BTC environment/config loading. Review for naming consistency, safe defaults, and parity with config structs.
 
+        When making changes, consider the corresponding verifier-side usage. Follow the root AGENTS.md → "Reuse and duplication discipline" for any duplicated configuration loading logic.
+
     - path: "core/node/node_framework/src/implementations/layers/via_btc_sender/**"
       instructions: |
         Node framework wiring for BTC sender. Changes affect startup, dependency injection, and runtime task composition.
+
+        When modifying this layer, consider impact on the verifier-side equivalent in via_verifier/node/node_framework/.
+        Follow the root AGENTS.md → "Reuse and duplication discipline" if changes affect duplicated behavior across main-node and verifier.
 
     - path: "core/node/node_framework/src/implementations/layers/via_btc_watch.rs"
       instructions: |
@@ -124,9 +142,13 @@ reviews:
       instructions: |
         Node framework wiring for BTC client. Review RPC/client resource construction and config boundaries.
 
+        When modifying this layer, consider impact on the verifier-side equivalent. Follow the root AGENTS.md → "Reuse and duplication discipline" if changes affect duplicated behavior across main-node and verifier.
+
     - path: "core/node/node_framework/src/implementations/resources/via_btc_client.rs"
       instructions: |
         Resource layer for BTC client. Review ownership, sharing, and runtime dependency semantics.
+
+        When modifying this layer, consider impact on the verifier-side equivalent. Follow the root AGENTS.md → "Reuse and duplication discipline" if changes affect duplicated behavior across main-node and verifier.
 
     - path: "core/node/reorg_detector/**"
       instructions: |
@@ -139,15 +161,24 @@ reviews:
         Main-node reorg detector. Review together with via_verifier/node/via_reorg_detector when behavior overlaps.
         Enforce explicit height/hash identity. Audit sparse rows, async fetch ordering, and Vec/zip usage.
 
+        Before adding or modifying logic here, check whether equivalent behavior exists in via_verifier/node/via_reorg_detector/.
+        Follow the root AGENTS.md → "Reuse and duplication discipline". If duplication is being introduced, it must be explicitly justified with a clear invariant or ownership boundary.
+
     - path: "via_verifier/node/via_reorg_detector/**"
       instructions: |
         Verifier reorg detector. Treat as sibling of the main-node version; check both when either changes.
         Preserve explicit height/hash identity and DB ordering assumptions.
 
+        Before adding or modifying logic here, check whether equivalent behavior exists in core/node/via_main_node_reorg_detector/.
+        Follow the root AGENTS.md → "Reuse and duplication discipline". If duplication is being introduced, it must be explicitly justified with a clear invariant or ownership boundary.
+
     - path: "core/node/node_framework/src/implementations/layers/*reorg_detector*.rs"
       instructions: |
         Node framework reorg detector layers for base, Via main-node, and verifier wiring.
         Changes affect detector startup and dependency injection.
+
+        When modifying these layers, consider impact on both main-node and verifier reorg detectors.
+        Follow the root AGENTS.md → "Reuse and duplication discipline" if changes affect duplicated behavior.
 
     - path: "core/lib/dal/src/via_l1_block_dal.rs"
       instructions: |
@@ -161,6 +192,7 @@ reviews:
       instructions: |
         DA client implementations. Focus on blob/batch identity, inclusion proofs, availability, fallback behavior,
         and source-vs-live boundaries.
+        Cross-check against via_verifier/lib/via_da_client/ when behavior overlaps. Follow the root AGENTS.md → "Reuse and duplication discipline".
 
     - path: "core/lib/via_da_dispatcher/**"
       instructions: |
@@ -170,9 +202,13 @@ reviews:
       instructions: |
         Node-level DA dispatcher. Review task lifecycle, metrics, retry/error behavior, and interaction with sequencer state.
 
+        When modifying this layer, consider the verifier-side equivalent and follow the root AGENTS.md → "Reuse and duplication discipline" if behavior overlaps.
+
     - path: "via_verifier/lib/via_da_client/**"
       instructions: |
         Verifier-side DA client. Check for unintended divergence from main-node DA client paths.
+        Follow the root AGENTS.md → "Reuse and duplication discipline" when adding or modifying logic.
+        Before making significant changes, review core/lib/via_da_clients/ for overlap and prefer extraction when appropriate.
 
     - path: "**/migrations/**/*.sql"
       instructions: |
@@ -259,6 +295,8 @@ reviews:
     - path: "**/via_*/**"
       instructions: |
         This is Via-specific code. When the change involves replacing an existing algorithm or introducing new functions or data structures, consider and describe the performance impact (time complexity, allocations, and cache behavior where relevant), in addition to correctness.
+
+        Strongly prefer extracting shared logic to core/lib/ rather than duplicating it between core/node/ and via_verifier/node/. Before adding new logic in a via_* path, check whether equivalent behavior already exists (or should exist) in the corresponding main-node or verifier sibling. Follow the root AGENTS.md → "Reuse and duplication discipline".
 
   tools:
     github-checks:

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,7 +10,200 @@ NC='\033[0m' # No Color
 INSTALL_PROPT="Please install ZK Stack CLI using zkstackup from https://github.com/matter-labs/zksync-era/tree/main/zkstack_cli/zkstackup"
 FORMAT_PROMPT="Please format the code via 'zkstack dev fmt', cannot push unformatted code"
 
-# Check that prettier formatting rules are not violated.
+load_sibling_high_risk_paths() {
+    local sibling_paths_file=".github/sibling-paths.yml"
+
+    if [ ! -f "$sibling_paths_file" ]; then
+        return
+    fi
+
+    # Expected format is the compact pair list used by .github/sibling-paths.yml:
+    #   - [core/path, verifier/path]
+    # Keep this hook dependency-free so it can run in local Git hook contexts
+    # without requiring yq/ruby/python.
+    awk '
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+        /^[[:space:]]*-[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]+#.*$/, "", line)
+            sub(/^[^[]*\[[[:space:]]*/, "", line)
+            sub(/[[:space:]]*\].*$/, "", line)
+            split(line, paths, ",")
+            if (paths[1] != "" && paths[2] != "") {
+                print trim(paths[1])
+                print trim(paths[2])
+            }
+        }
+    ' "$sibling_paths_file"
+}
+
+load_structural_tooling_paths() {
+    local via_areas_file=".github/via-areas.yml"
+
+    if [ ! -f "$via_areas_file" ]; then
+        return
+    fi
+
+    # Expected format is the mapping list used by .github/via-areas.yml:
+    #   - path: ".github/lint/via-structural/**"
+    #     area: structural
+    # The parser accepts path/area in either order within one mapping.
+    awk '
+        function trim(value) {
+            gsub(/^"|"$/, "", value)
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+        function emit_if_structural() {
+            if (path != "" && area == "structural") {
+                print path
+            }
+        }
+        /^[[:space:]]*-[[:space:]]*/ {
+            emit_if_structural()
+            path = ""
+            area = ""
+        }
+        /^[[:space:]]*-[[:space:]]*path:/ {
+            path = $0
+            sub(/^[[:space:]]*-[[:space:]]*path:[[:space:]]*/, "", path)
+            path = trim(path)
+            next
+        }
+        /^[[:space:]]*-[[:space:]]*area:/ {
+            area = $0
+            sub(/^[[:space:]]*-[[:space:]]*area:[[:space:]]*/, "", area)
+            area = trim(area)
+            next
+        }
+        /^[[:space:]]*path:/ {
+            path = $0
+            sub(/^[[:space:]]*path:[[:space:]]*/, "", path)
+            path = trim(path)
+            next
+        }
+        /^[[:space:]]*area:/ {
+            area = $0
+            sub(/^[[:space:]]*area:[[:space:]]*/, "", area)
+            area = trim(area)
+            next
+        }
+        END {
+            emit_if_structural()
+        }
+    ' "$via_areas_file"
+}
+
+normalize_high_risk_paths() {
+    local path
+
+    while IFS= read -r path; do
+        path="${path%%#*}"
+        path="${path#"${path%%[![:space:]]*}"}"
+        path="${path%"${path##*[![:space:]]}"}"
+
+        if [ -z "$path" ]; then
+            continue
+        fi
+
+        case "$path" in
+            *'/**')
+                printf '%s/\n' "${path%/**}"
+                ;;
+            *'/*')
+                printf '%s/\n' "${path%/*}"
+                ;;
+            */)
+                printf '%s\n' "$path"
+                ;;
+            *.*)
+                printf '%s\n' "$path"
+                ;;
+            *)
+                printf '%s/\n' "$path"
+                ;;
+        esac
+    done
+}
+
+# High-risk paths for Via structural rules are sourced from shared metadata so
+# the hook stays aligned with PR checks and structural tooling ownership.
+load_high_risk_paths() {
+    {
+        load_sibling_high_risk_paths
+        load_structural_tooling_paths
+    } | normalize_high_risk_paths | awk 'NF && !seen[$0]++'
+}
+
+path_matches_high_risk_prefix() {
+    local changed_path="$1"
+    local high_risk_path
+
+    for high_risk_path in "${HIGH_RISK_PATHS[@]}"; do
+        if [[ "$changed_path" == "$high_risk_path"* ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Check if the push touches any high-risk Via paths
+should_run_via_structural_check() {
+    local range
+    local base_sha
+
+    while read -r local_ref local_sha remote_ref remote_sha; do
+        if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+            continue
+        fi
+
+        if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+            # New branch: compare the pushed history against the nearest known base.
+            local upstream_ref
+            upstream_ref="$(git for-each-ref --format='%(upstream)' "$local_ref")"
+
+            if [ -n "$upstream_ref" ] && git rev-parse --verify "$upstream_ref" >/dev/null 2>&1 \
+                && base_sha="$(git merge-base "$upstream_ref" "$local_sha" 2>/dev/null)"; then
+                range="$base_sha..$local_sha"
+            elif git rev-parse --verify origin/main >/dev/null 2>&1 \
+                && base_sha="$(git merge-base origin/main "$local_sha" 2>/dev/null)"; then
+                range="$base_sha..$local_sha"
+            elif git rev-parse --verify origin/master >/dev/null 2>&1 \
+                && base_sha="$(git merge-base origin/master "$local_sha" 2>/dev/null)"; then
+                range="$base_sha..$local_sha"
+            elif git rev-parse --verify "$local_sha^" >/dev/null 2>&1; then
+                range="$local_sha^..$local_sha"
+            else
+                range="$(git hash-object -t tree /dev/null)..$local_sha"
+            fi
+        else
+            range="$remote_sha..$local_sha"
+        fi
+
+        while IFS= read -r changed_path; do
+            if path_matches_high_risk_prefix "$changed_path"; then
+                return 0
+            fi
+        done < <(git diff --name-only "$range")
+    done
+
+    return 1
+}
+
+HIGH_RISK_PATHS=()
+while IFS= read -r high_risk_path; do
+    HIGH_RISK_PATHS+=("$high_risk_path")
+done < <(load_high_risk_paths)
+
+# =====================
+# 1. Formatting check (original behavior - blocking)
+# =====================
 if which zkstack >/dev/null; then
   if ! zkstack dev fmt --check; then
       echo -e "${RED}Push error!${NC}"
@@ -32,3 +225,22 @@ else
     exit 1
   fi
 fi
+
+# =====================
+# 2. Via Structural Rules (advisory mode for now)
+# =====================
+if should_run_via_structural_check; then
+    echo ""
+    echo "Via structural rules check triggered (advisory mode)"
+    echo "------------------------------------------------------"
+
+    if ! VIA_STRUCTURAL_RULES_MODE=advisory .github/scripts/check-via-structural-rules.sh; then
+        echo "Warning: advisory Via structural rules check did not complete successfully."
+    fi
+
+    echo "------------------------------------------------------"
+    echo "Note: This is currently advisory only — push will continue."
+    echo ""
+fi
+
+exit 0

--- a/.github/lint/via-structural/README.md
+++ b/.github/lint/via-structural/README.md
@@ -1,0 +1,41 @@
+# Via Structural Rules
+
+This directory contains **Via-specific structural review aids**.
+
+These rules exist to protect high-risk areas in Via code (especially reorg detection, L1 sync, BTC integration, and related ordering/identity logic) from classes of bugs that are easy to introduce and hard to catch in normal review or testing.
+
+## Purpose
+
+The rules are deliberately narrow and focused on known dangerous patterns that have caused real incidents (see PR #355 for the motivating example).
+
+They are **not** general Rust linting. They are review prompts that force explicit consideration of ordering, identity, and async assumptions in critical paths.
+
+## Scope
+
+These rules only apply to Via-specific code paths. They are intentionally kept separate from the generic ZK Stack lint tooling (`zkstack dev lint`).
+
+## Current Tools
+
+- [ast-grep](./ast-grep/) — Structural pattern matching using tree-sitter-based rules.
+
+## Running the Checks
+
+```bash
+# Advisory mode (default) — shows findings but exits 0
+.github/scripts/check-via-structural-rules.sh
+
+# Strict mode — exits non-zero on new unbaselined findings or scanner errors
+VIA_STRUCTURAL_RULES_MODE=strict .github/scripts/check-via-structural-rules.sh
+```
+
+## Philosophy
+
+- A match does **not** automatically mean the code is wrong.
+- A match means: "This pattern has bitten us before. Please explicitly justify why the ordering/identity contract is still safe here."
+- The rules are advisory by default so they can be introduced without breaking existing code while the team builds confidence in them.
+- Strict mode uses `ast-grep/baseline.txt` during rollout: known findings stay visible, but only new unbaselined findings fail the check.
+- Over time, baseline entries should be removed as the underlying code is fixed or the rule is narrowed.
+
+## Future
+
+This directory is designed to hold multiple complementary mechanisms (ast-grep, custom lints, property testing helpers, etc.) under the same `via-structural` umbrella as we strengthen defenses around the most dangerous parts of the Via runtime.

--- a/.github/lint/via-structural/ast-grep/README.md
+++ b/.github/lint/via-structural/ast-grep/README.md
@@ -1,0 +1,223 @@
+# Via Structural Rules — ast-grep
+
+This folder contains [ast-grep](https://ast-grep.github.io/) rules for Via-specific structural patterns that have historically led to subtle but high-impact bugs.
+
+## Why ast-grep?
+
+ast-grep provides fast, structural (tree-sitter based) pattern matching on Rust source. It is well suited for catching dangerous idioms that are hard to express with normal Clippy lints or simple regex (e.g., positional `zip` after `buffer_unordered`, manual pending UTXO chain management).
+
+## Current Rules
+
+| Rule File                    | ID                            | Purpose                                                                 | Status    |
+|------------------------------|-------------------------------|-------------------------------------------------------------------------|-----------|
+| `reorg-ordering.yml`         | `via-reorg-buffer-unordered`  | Flags `buffer_unordered` inside reorg detector crates. Results lose request order. | Advisory  |
+| `via-reorg-height-association-required.yml` | `via-reorg-height-association-required` | Targets common dangerous zip patterns after async fetches in reorg detectors (range zips, `.iter().zip`, `.into_iter().zip`, `.iter_mut().zip`). Includes suppression guidance (`// height-order-guaranteed`). Best used together with `via-reorg-buffer-unordered`. | Advisory |
+| `via-da-batch-before-proof.yml` | `via-da-batch-before-proof` | Flags calls to `dispatch_real_proofs` in the DA dispatcher. Advisory heuristic for batch-before-proof ordering. Requires scoping and review. | Candidate / Advisory |
+| `via-avoid-duplicate-export.yml` | `via-avoid-duplicate-export` | Flags `pub use $B::$C` when `pub mod $B` is declared in the same file. Prevents unnecessary public API duplication and multiple canonical paths to the same item. | Advisory |
+
+**Core identity being protected**: `bitcoin_block_height_hash` — Bitcoin blocks must be compared and ordered by **explicit height**, never by vector position or async completion order.
+
+Some rule metadata references the Via Agent Harness, which is maintained outside
+this repository. If the harness is not checked out locally, treat these as
+external references rather than in-repo paths:
+
+- `components/reorg-detector.md`
+- `llm-wiki/generated/IDENTITIES.tsv` (especially `bitcoin_block_height_hash`)
+- `llm-wiki/generated/STATE_TRANSITIONS.tsv`
+- `llm-wiki/generated/RISK_REGISTER.md` (`risk.reorg.positional_height_comparison`)
+
+## Running Locally
+
+```bash
+# Advisory mode (recommended for development)
+just via-check
+
+# Strict / blocking mode (use in CI for high-risk paths)
+just via-check-strict
+```
+
+Direct invocation:
+
+```bash
+ast-grep scan --config .github/lint/via-structural/ast-grep/sgconfig.yml
+```
+
+**Local Availability**: ensure `ast-grep` is on your `PATH`. The CI workflow installs pinned `ast-grep` v0.42.0 into `$HOME/.local/bin` before running the structural rules.
+
+**Harness Integration**: High-quality test and rule proposals live in the external harness under `proposals/critical/`.
+The current location of the harness is declared in the harness root README (search for "Current Location").
+Many proposals are directly derived from the risk register and are ready for implementation or rule writing. See especially REORG-01, DA-01/02, SK-01/02, CG-01/02, VRF-01/02, FINAL-01, BTC-WATCH-01.
+
+## Refactoring with `ast-grep run --rewrite`
+
+`ast-grep scan` (used by `just via-check` / `via-check-strict`) is for **detection** of dangerous structural patterns. For **mechanical, safe code transformations** across many sites, use `ast-grep run --rewrite`.
+
+This is particularly useful when applying the same change to sibling implementations (main-node ↔ verifier) or to many similar call sites.
+
+### Basic usage
+
+```bash
+# Preview changes as a diff (safe — nothing is written)
+ast-grep run -p 'old_pattern' -r 'new_pattern' --lang rust path/
+
+# Interactive mode — confirm or edit each change
+ast-grep run -p '...' -r '...' --lang rust -i path/
+
+# Apply all rewrites (review the diff first!)
+ast-grep run -p '...' -r '...' --lang rust -U path/
+```
+
+By default `ast-grep run` only shows what *would* change. Use `-U` / `--update-all` (or `-i` / `--interactive`) to mutate files.
+
+The `-p` / `--pattern` form (with `-r` for rewrite) is the quickest for one-off rewrites. For anything non-trivial, prefer a small rule file (see below).
+
+### Realistic Rust example — adding error context to fetch calls
+
+Both reorg detectors contain call sites like:
+
+```rust
+let blocks = self
+    .fetch_blocks(from_block_height, to_block_height)
+    .await?;
+```
+
+When these fail it is valuable to know the exact height range that was requested. We can mechanically add `.with_context(...)` at every matching site:
+
+```bash
+ast-grep run \
+  -p 'self.fetch_blocks($FROM, $TO).await?' \
+  -r 'self.fetch_blocks($FROM, $TO).await.with_context(|| format!("failed to fetch L1 blocks {}-{}", $FROM, $TO))?' \
+  --lang rust \
+  core/node/via_main_node_reorg_detector/src/lib.rs \
+  via_verifier/node/via_reorg_detector/src/lib.rs
+```
+
+**Tested note**: The pattern and rewrite above were run against the current detector sources. The structural matcher successfully handled both single-line and multi-line call sites and correctly substituted the metavariables.
+
+### Practical notes from testing
+
+- Multi-line call chains are collapsed into single lines. Run `zkstack dev fmt` (or rustfmt) afterward.
+- Rewrites using `.with_context(...)` require `use anyhow::Context;` in scope (already present in the reorg detectors).
+- The direct `-r` / replacement string form is convenient for exploration but easy to get slightly wrong on complex expressions. For any rewrite you actually intend to keep, use a rule file instead.
+
+### Using a rewrite rule file (preferred for real changes)
+
+Create a temporary `.yml` file:
+
+```yaml
+id: add-fetch-context
+language: Rust
+rule:
+  pattern: self.fetch_blocks($FROM, $TO).await?
+fix: |
+  self.fetch_blocks($FROM, $TO)
+    .await
+    .with_context(|| format!("failed to fetch L1 blocks {}-{}", $FROM, $TO))?
+```
+
+Run it with:
+
+```bash
+# Preview
+ast-grep scan -r temp-rewrite.yml path/
+
+# Apply after review
+ast-grep scan -r temp-rewrite.yml -U path/
+```
+
+Rule files make the transformation explicit, reviewable, and easier to version alongside the resulting diff.
+
+### Guardrails in this repository
+
+- A rewrite is still a code change. Run `git diff --check`, review the diff, run relevant tests, and execute `just via-check` (or `just via-check-strict` for sibling-paired paths) before pushing.
+- If the mechanical change highlights duplicated logic between `core/node/...` and `via_verifier/node/...`, prefer extracting the common behavior to `core/lib/` rather than applying the same rewrite in two places (see root AGENTS.md → *Reuse and duplication discipline*).
+- Never use `-U` (or `--update-all`) in a fully automated way on production paths without a human in the loop.
+
+This workflow complements the structural lint rules: use `scan` to find problems, use `run -p/-r` or `scan -r` to perform mechanical rewrites once the desired shape is agreed.
+
+## Rule Philosophy & Lifecycle
+
+- Rules start **advisory** by default.
+- A match is a prompt for explanation, not an automatic defect.
+- Rules target patterns that have previously caused real (or near-miss) bugs in Via reorg detection and BTC inscription logic.
+- Preferred: narrow, high-signal rules over broad noisy ones.
+- Known findings can be recorded in `baseline.txt` during rollout. `just via-check-strict` still prints those findings, but fails only on new unbaselined findings or scanner errors.
+- Every active rule should have:
+  - Linked entry in the harness (`IDENTITIES.tsv` / `RISK_REGISTER.md`)
+  - Fixture coverage (good + bad examples)
+  - False-positive review
+
+**Lifecycle**:
+candidate → fixture-tested → repo sweep + false-positive review → active (advisory or strict)
+
+## Fixtures
+
+Good and bad examples live under `fixtures/`:
+
+```text
+fixtures/
+  reorg/
+    zip_bad.rs     # positional zip after unordered fetch on height data
+    zip_good.rs    # explicit height-based re-association (HashMap or equivalent)
+```
+
+When adding or changing a rule, add or update the corresponding fixtures.
+
+## Scoping
+
+Intended glob restrictions are recorded in `sgconfig.yml` under the `rules:` section and mirrored by the checker script.
+
+The checker script currently passes the same scope through `ast-grep scan --globs` because ast-grep 0.42 did not reliably enforce rule-level globs in this repository setup.
+
+Example (from current `sgconfig.yml`):
+
+```yaml
+rules:
+  - include: "via-reorg-buffer-unordered"
+    glob:
+      - "core/node/via_main_node_reorg_detector/**/*.rs"
+      - "via_verifier/node/via_reorg_detector/**/*.rs"
+
+  - include: "via-reorg-height-association-required"
+    glob:
+      - "core/node/via_main_node_reorg_detector/**/*.rs"
+      - "via_verifier/node/via_reorg_detector/**/*.rs"
+```
+
+**Guideline for new rules:**
+
+- Prefer recording intended glob/ignore scoping in `sgconfig.yml` when the rule targets a specific Via module or crate.
+- Keep the checker script's explicit `--globs` list in sync with `sgconfig.yml`.
+- Avoid adding `glob` blocks to individual rule files while ast-grep 0.42 remains the constraint; use `sgconfig.yml` as the canonical scope source.
+
+## Adding New Rules
+
+1. Add a new `.yml` file in `rules/`.
+2. Define scoping in `sgconfig.yml` under the `rules:` section and mirror that scope in the checker script's `--globs` list. See the **Scoping** section above.
+3. Add good/bad fixtures under `fixtures/`.
+4. Update this README.
+5. Link the rule to the relevant harness artifacts (`IDENTITIES.tsv`, component card, RISK_REGISTER entry).
+6. Decide initial mode (advisory vs strict).
+
+## Inscriber / Pending-Chain Patterns (Future Work)
+
+The BTC inscriber maintains an ordered `fifo_queue` of pending `InscriptionRequest` objects. Spendability of change outputs depends on position in that queue (only the head's reveal change output is treated as immediately spendable).
+
+This creates a second class of ordering/identity risk (`pending_chain_utxo_outpoint`, `fifo_queue_head_change_outpoint`).
+
+No syntactic ast-grep rule has been added yet (the pattern is mostly data-structure + HashMap filtering), but the area is documented in:
+
+- `IDENTITIES.tsv` (new rows added after inscriber review)
+- Future BTC sender component card
+
+When a clear, high-signal syntactic smell appears, a rule can be added here.
+
+## References
+
+- Via Agent Harness (primary source of truth for identities and risks)
+- AGENTS.md (Via Structural Rules section)
+- just via-check / via-check-strict
+
+---
+
+*Maintained as part of the Via Agent Harness cartography effort.*

--- a/.github/lint/via-structural/ast-grep/baseline.txt
+++ b/.github/lint/via-structural/ast-grep/baseline.txt
@@ -1,0 +1,13 @@
+# Known structural findings that pre-date strict enforcement.
+# Format: rule_id|path
+# Repeat an entry when a file has multiple known findings for the same rule.
+# Advisory output still reports exact locations; strict mode fails only when a
+# rule/path finding count exceeds this baseline.
+via-reorg-buffer-unordered|via_verifier/node/via_reorg_detector/src/lib.rs
+via-reorg-buffer-unordered|core/node/via_main_node_reorg_detector/src/lib.rs
+via-reorg-height-association-required|via_verifier/node/via_reorg_detector/src/lib.rs
+via-reorg-height-association-required|core/node/via_main_node_reorg_detector/src/lib.rs
+via-da-batch-before-proof|core/node/via_da_dispatcher/src/da_dispatcher.rs
+via-avoid-duplicate-export|core/lib/types/src/lib.rs
+via-avoid-duplicate-export|core/lib/types/src/lib.rs
+via-avoid-duplicate-export|core/lib/types/src/lib.rs

--- a/.github/lint/via-structural/ast-grep/fixtures/reorg/zip_bad.rs
+++ b/.github/lint/via-structural/ast-grep/fixtures/reorg/zip_bad.rs
@@ -1,0 +1,42 @@
+// fixtures/reorg/zip_bad.rs
+// BAD pattern - positional zip after unordered fetch on height-indexed data.
+// This is the exact anti-pattern that caused false reorg detections on sparse windows.
+
+async fn detect_reorg_bad(&self, storage: &mut Connection<'_, Core>) -> anyhow::Result<()> {
+    let Some((block_height, _)) = storage.via_l1_block_dal().get_last_l1_block().await? else {
+        anyhow::bail!("No blocks found");
+    };
+
+    let window = self.config.reorg_window();
+    let start_height = block_height.saturating_sub(window - 1).max(1);
+
+    // DB rows ordered by height
+    let db_blocks = storage
+        .via_l1_block_dal()
+        .list_l1_blocks(start_height, window)
+        .await?;
+
+    // Async fetch - order not guaranteed
+    let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+
+    // DANGEROUS: positional zip assumes order is preserved
+    for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
+        if chain_block.block_hash().to_string() != *db_hash {
+            // false reorg possible here when window is sparse or fetches are out of order
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+async fn fetch_blocks(&self, from: i64, to: i64) -> anyhow::Result<Vec<Block>> {
+    // uses buffer_unordered internally
+    use futures::stream::{self, StreamExt};
+    let heights: Vec<i64> = (from..=to).collect();
+    let results = stream::iter(heights)
+        .map(|h| async move { self.btc_client.fetch_block(h as u128).await })
+        .buffer_unordered(self.config.max_concurrent_fetches())
+        .collect::<Vec<_>>()
+        .await;
+    // ...
+}

--- a/.github/lint/via-structural/ast-grep/fixtures/reorg/zip_good.rs
+++ b/.github/lint/via-structural/ast-grep/fixtures/reorg/zip_good.rs
@@ -1,0 +1,35 @@
+// fixtures/reorg/zip_good.rs
+// GOOD pattern - explicit height-based association after unordered fetch.
+
+use std::collections::HashMap;
+
+async fn detect_reorg_good(&self, storage: &mut Connection<'_, Core>) -> anyhow::Result<()> {
+    let Some((block_height, _)) = storage.via_l1_block_dal().get_last_l1_block().await? else {
+        anyhow::bail!("No blocks found");
+    };
+
+    let window = self.config.reorg_window();
+    let start_height = block_height.saturating_sub(window - 1).max(1);
+
+    let db_blocks = storage
+        .via_l1_block_dal()
+        .list_l1_blocks(start_height, window)
+        .await?;
+
+    let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+
+    // GOOD: build height -> hash map from DB
+    let db_by_height: HashMap<i64, String> = db_blocks.into_iter().collect();
+
+    // Re-associate fetched blocks by explicit height
+    for block in chain_blocks {
+        // Extract height from block (or request context) to associate with DB data
+        let height = block.height();
+        if let Some(expected_hash) = db_by_height.get(&height) {
+            if block.block_hash().to_string() != *expected_hash {
+                // real reorg
+            }
+        }
+    }
+    Ok(())
+}

--- a/.github/lint/via-structural/ast-grep/rules/candidate-inscriber-pending-chain.md
+++ b/.github/lint/via-structural/ast-grep/rules/candidate-inscriber-pending-chain.md
@@ -1,0 +1,57 @@
+# Candidate: Inscriber Pending-Chain UTXO Management
+
+## Status
+
+Candidate / Documentation only (no active .yml rule yet).
+
+## Why This Area Is Risky
+
+The `Inscriber` in `via_btc_client` maintains a persisted `fifo_queue: VecDeque<InscriptionRequest>` of unconfirmed commit/reveal pairs.
+
+When preparing the next commit transaction (`prepare_commit_tx_input`):
+
+- It walks the entire queue and builds a set of "spent" OutPoints:
+  - All `spent_utxo` from previous commit transactions
+  - Reveal fee-payer inputs
+  - Reveal change outputs from all but the **head** of the queue
+- It then filters live UTXOs and **only** re-introduces the head of the queue's reveal change output as spendable.
+
+This creates a manual "pending UTXO chain" abstraction where:
+
+- Position in the `fifo_queue` determines whether a change output is locked or spendable.
+- `OutPoint` (txid + vout) of specific reveal change outputs carry conditional identity.
+- The head change output (identified via `fee_payer_ctx`) is special.
+
+## Related Identities (from IDENTITIES.tsv)
+
+- `pending_inscription_fifo_queue`
+- `pending_chain_utxo_outpoint`
+- `fifo_queue_head_change_outpoint`
+- `fee_payer_ctx`
+
+## Current Protection
+
+- Documented in the Via Agent Harness (`IDENTITIES.tsv`, future `btc-sender-watch.md` card).
+- `get_balance()` also walks the queue to add pending outputs.
+- Strong comment in the code warning that only the service should use the address.
+
+## Potential Future Rule
+
+A syntactic ast-grep rule is difficult because the pattern is mostly:
+
+- Building a `HashMap<OutPoint, bool>` from a queue iteration
+- Special-casing `queue.front()`
+- Filtering + re-adding one specific change output
+
+Possible lightweight approaches later:
+
+- Flag direct iteration over `context.fifo_queue` combined with `spent_utxos.insert` on reveal change outputs.
+- Flag use of fixed vout constants (`REVEAL_TX_CHANGE_OUTPUT_INDEX`) without clear comments.
+
+For now the protection is **documentation + review** rather than automated structural rule.
+
+## References
+
+- `core/lib/via_btc_client/src/inscriber/mod.rs` (prepare_commit_tx_input, get_balance, sync_context_with_blockchain)
+- `IDENTITIES.tsv` (new rows added 2026-05)
+- `RISK_REGISTER.md` (risk.btc.pending_vs_trusted_balance_and_utxo_identity)

--- a/.github/lint/via-structural/ast-grep/rules/reorg-ordering.yml
+++ b/.github/lint/via-structural/ast-grep/rules/reorg-ordering.yml
@@ -1,0 +1,37 @@
+id: via-reorg-buffer-unordered
+language: Rust
+severity: warning
+message: |
+  `buffer_unordered` used inside a reorg detector.
+
+  Results from `buffer_unordered` do not preserve request order.
+  When later combined with positional logic (zip, enumerate, range indexing)
+  against data from `list_l1_blocks` (or any height-indexed collection),
+  the `bitcoin_block_height_hash` identity is violated.
+
+  Height must be the explicit comparison key. Never rely on vector position
+  or async completion order after an unordered fetch.
+
+  See external Via Agent Harness references documented in
+  .github/lint/via-structural/ast-grep/README.md:
+  reorg-detector.md, IDENTITIES.tsv (bitcoin_block_height_hash),
+  and RISK_REGISTER.md (risk.reorg.positional_height_comparison).
+note: |
+  Advisory rule. A match requires the author to explain why height ordering
+  is still guaranteed after this unordered fetch.
+  Prefer collecting into a height-keyed map or using an order-preserving
+  stream + explicit height association.
+rule:
+  pattern: $RECEIVER.buffer_unordered($$$ARGS)
+
+metadata:
+  category: correctness
+  related:
+    - ordering
+    - reorg-detector
+    - async
+    - identity
+  harness_refs:
+    - components/reorg-detector.md
+    - llm-wiki/generated/IDENTITIES.tsv
+    - llm-wiki/generated/RISK_REGISTER.md

--- a/.github/lint/via-structural/ast-grep/rules/via-avoid-duplicate-export.yml
+++ b/.github/lint/via-structural/ast-grep/rules/via-avoid-duplicate-export.yml
@@ -1,0 +1,26 @@
+id: via-avoid-duplicate-export
+language: Rust
+severity: warning
+message: |
+  `pub use $B::$C;` from a module that is also declared as `pub mod $B;` in the same file.
+  This creates two public paths to the same item (e.g. both `crate::$C` and `crate::$B::$C`).
+  Prefer one canonical public path to reduce duplication and confusion.
+note: |
+  This is a Via-specific structural rule. Re-exporting items from a publicly declared
+  sibling module at the same level increases the public API surface unnecessarily.
+  It is especially relevant for library entry points and shared Via crates.
+rule:
+  all:
+    - pattern: pub use $B::$C;
+    - inside:
+        kind: source_file
+        has:
+          pattern: pub mod $B;   # same metavariable ensures we only match the declared module
+metadata:
+  category: duplication
+  related:
+    - public-api
+    - modularity
+    - reuse
+  harness_refs:
+    - components/reuse-duplication

--- a/.github/lint/via-structural/ast-grep/rules/via-da-batch-before-proof.yml
+++ b/.github/lint/via-structural/ast-grep/rules/via-da-batch-before-proof.yml
@@ -1,0 +1,34 @@
+id: via-da-batch-before-proof
+language: Rust
+severity: warning
+message: |
+  `dispatch_real_proofs` or proof-related inscription logic appears without a clear
+  preceding confirmed batch data dispatch for the same l1_batch_number.
+
+  In Via, batch data must be durably published via DA (and often inscribed on Bitcoin)
+  before the corresponding proof data. Violating this ordering can lead to finalization
+  of batches whose data was never properly made available.
+
+  See external Via Agent Harness references documented in
+  .github/lint/via-structural/ast-grep/README.md:
+    - mappings/da-dispatcher-deeper.md
+    - proposals/critical/DA-01-batch-before-proof-ordering.md
+    - proposals/critical/DA-02-batch-before-proof-astgrep.md
+
+rule:
+  # Targets calls to dispatch_real_proofs (the actual proof dispatch action),
+  # not bare member access or the function definition itself.
+  # This is still a heuristic rule. Use with scoping in sgconfig.yml and manual review.
+  all:
+    - kind: call_expression
+    - pattern: $R.dispatch_real_proofs($$$)
+
+metadata:
+  category: correctness
+  related:
+    - da
+    - ordering
+    - finalization
+  harness_refs:
+    - mappings/da-dispatcher-deeper.md
+    - proposals/critical/DA-01-batch-before-proof-ordering.md

--- a/.github/lint/via-structural/ast-grep/rules/via-reorg-height-association-required.yml
+++ b/.github/lint/via-structural/ast-grep/rules/via-reorg-height-association-required.yml
@@ -1,0 +1,43 @@
+id: via-reorg-height-association-required
+language: Rust
+severity: warning
+message: |
+  Positional zip detected in reorg detector code.
+  After `buffer_unordered` fetches, Vec order reflects async completion order,
+  not Bitcoin block height order. Zipping two Vecs positionally silently assumes
+  index correspondence that is not guaranteed.
+  Re-associate by height explicitly: use a BTreeMap<u64, _> keyed on block.height,
+  or zip only over structures you can prove are height-sorted at the call site.
+
+note: |
+  Advisory rule scoped to reorg detector crates via sgconfig.yml.
+  If the positional association is intentional, add a reviewer-facing comment
+  `// height-order-guaranteed: <reason>` near the zip expression and document
+  WHY ordering is safe (e.g. "input was sorted by height before this point",
+  not "buffer_unordered happened to return in order"). This annotation does not
+  automatically suppress the rule; strict mode still requires a baseline update.
+
+rule:
+  any:
+    - pattern: ($R..).zip($B)
+    - pattern: $A.iter().zip($B)
+    - pattern: $A.into_iter().zip($B)
+    - pattern: $A.iter_mut().zip($B)
+metadata:
+  category: correctness
+  related:
+    - ordering
+    - reorg-detector
+    - async
+    - identity
+    - bitcoin_block_height_hash
+  false_positive_guidance: |
+    Common safe patterns that will still fire and need manual review:
+      - zip over two slices that were explicitly sorted by height beforehand
+      - zip in test harnesses over deterministic fixture data
+      - zip in helper functions that are only called with height-sorted input
+    In all these cases, add `// height-order-guaranteed: <reason>` and the
+    reviewer should verify the reason is about HEIGHT, not about Vec order.
+  harness_refs:
+    - proposals/critical/REORG-01-positional-height-comparison-rule.md
+    - components/reorg-detector.md

--- a/.github/lint/via-structural/ast-grep/sgconfig.yml
+++ b/.github/lint/via-structural/ast-grep/sgconfig.yml
@@ -1,0 +1,32 @@
+# ast-grep configuration for Via Structural Rules
+#
+# These rules protect critical Via identity and ordering invariants,
+# especially `bitcoin_block_height_hash` comparison after async fetches.
+
+ruleDirs:
+  - rules
+
+# Intended scope for each rule. The runner script also passes these globs via
+# `ast-grep scan --globs` because ast-grep 0.42 does not reliably enforce these
+# rule-level globs in this repository setup.
+rules:
+  - include: "via-reorg-buffer-unordered"
+    glob:
+      - "core/node/via_main_node_reorg_detector/**/*.rs"
+      - "via_verifier/node/via_reorg_detector/**/*.rs"
+
+  - include: "via-reorg-height-association-required"
+    glob:
+      - "core/node/via_main_node_reorg_detector/**/*.rs"
+      - "via_verifier/node/via_reorg_detector/**/*.rs"
+
+  - include: "via-da-batch-before-proof"
+    glob:
+      - "core/node/via_da_dispatcher/**/*.rs"
+
+  - include: "via-avoid-duplicate-export"
+    glob:
+      - "core/node/via_*/**/*.rs"
+      - "via_verifier/**/*.rs"
+      - "core/lib/via_*/**/*.rs"
+      - "core/lib/types/src/**/*.rs"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,35 +50,93 @@ Examples:
   satisfied before a restart durability check.
 -->
 
-## Performance / Complexity Impact
+## Reuse & Duplication
 
-This section is **required for Via-specific code** (`via_*` paths) in the following areas:
+<!--
+Required for any PR that adds or changes production logic. For docs-only,
+comments-only, generated-only, test-only, or process-only changes, write
+"Not applicable — <one-line reason>".
 
-- Reorg detection and L1 sync
-- BTC sender, watch, or client
-- DA / Celestia
-- Hot database paths (especially `via_*_dal`)
+Name the specific function, module, or crate. Vague answers such as
+"searched the repo" or "no duplication found" are not acceptable.
 
-For all other changes, this section is optional but encouraged.
+- Closest existing implementation: Name the function, module, or crate that
+  already does something similar. If none was found, state where you searched
+  (at minimum the nearest via_* crate and the sibling core/ or via_verifier/ path).
 
-Please describe the performance characteristics of the change. Cover the relevant points:
+- Reuse decision: State whether you extended, extracted, replaced, or
+  deliberately duplicated existing logic — and why. If duplication was
+  introduced or left in place, justify it.
 
-- Was an existing function or algorithm **replaced**, or were **new** functions or data structures introduced?
-- Time complexity of the main operation(s) before vs after
-- Allocation behavior
-- Any relevant cache or memory access implications
+- Sibling check: For changes in reorg detection, Bitcoin handling, DA clients,
+  watch services, verifier/prover paths, or any logic mirrored across core/
+  and via_verifier/, explicitly state whether you reviewed the sibling
+  implementation and whether it shares the bug, shares the fix, or is
+  intentionally different.
 
-A small table is often the clearest way to present this, especially when replacing logic. It is not mandatory, but it is encouraged when it improves clarity.
+High-risk areas (Bitcoin, DA/Celestia, reorg/reverter, verifier/prover, hot DAL
+paths, migrations, serialization, hashes, signatures, inscriptions) require
+especially specific answers.
 
-**Example:**
+Anti-pattern example:
+- New detector logic added in both core/node/.../reorg_detector and via_verifier/node/.../reorg_detector with only minor differences.
+- No shared code was extracted.
 
-| Operation                        | Before     | After      | Notes |
-|----------------------------------|------------|------------|-------|
-| Lookup by height                 | O(n)       | O(log n)   | Binary search on sorted Vec |
-| Full window comparison           | O(n)       | O(n)       | Two-pointer merge |
-| Building the structure           | O(n)       | O(n log n) | One-time sort on construction |
+Required pattern:
+- Shared logic extracted to core/lib/ (or appropriate shared crate).
+- Only thin node-specific wrappers remain in core/node/ and via_verifier/node/.
+-->
 
-If the change has no meaningful performance impact, simply state that.
+**Required for any PR that adds or changes production logic in a `via_*` path.**
+
+Before writing implementation code, you must have completed the checks described in the root `AGENTS.md` → *Reuse and duplication discipline*.
+
+**You must include the following in this section** (answers must be specific — vague or placeholder text will be rejected):
+
+- Closest existing implementation considered: `<function or module name>`
+- Sibling paths inspected: `<list of specific paths>`
+- Search command run: `<exact rg/grep command>`
+- Shared extraction decision: extracted to `<path>` **OR** not extracted because `<exact invariant / ownership / execution-context difference>`
+
+Vague answers such as "searched the repo" or "no duplication found" are not accepted.
+
+> Self-check before submitting: Have you named a specific function? Have you listed sibling paths actually inspected (with backticks)? If any answer is no, revise this section.
+
+## Performance, Complexity, and Resource Impact
+
+<!--
+Required for changes touching Via runtime paths (via_* crates, reorg detection,
+Bitcoin sender/watch/client, DA/Celestia, verifier, prover, state keeper, hot
+DAL queries, async fetch/compare logic, ordering-sensitive code). Encouraged
+elsewhere. For docs-only or process-only changes, write
+"Not applicable — <one-line reason>".
+
+Focus on the dimensions that matter for this change. A table is usually the
+clearest way to show trade-offs — use or adapt the format below. Prose is also
+acceptable.
+
+Do not fabricate precision. Do not optimize for fewer lines at the expense of
+correctness or error context.
+-->
+
+**Recommended table format (adapt rows as needed):**
+
+| Dimension                        | Before                          | After                           | Notes |
+|----------------------------------|---------------------------------|---------------------------------|-------|
+| Time complexity (main operation) | O(n)                            | O(n)                            | Now compares by explicit height |
+| Allocations per operation        | 1 Vec + N clones                | 1 HashMap build + sort          | After buffer_unordered |
+| Happy-path work per call         | Positional zip                  | Height-keyed HashMap lookup     | Correctly handles sparse windows |
+| Memory pressure                  | Grows with window size          | Bounded (~100 entries)          | - |
+| DB / I/O / RPCs                  | -                               | -                               | No change |
+| Net production LOC (approx.)     | -                               | +~65 lines                      | Excluding comments, docs & tests |
+
+**Guidance:**
+- Include a complexity row when the shape of the work actually changed.
+- Prioritize allocations and real work done on the common (happy) path.
+- Treat production LOC as audit cost — disclose the approximate delta.
+- You may add, remove, or rename rows. A table is not required if it would not improve clarity.
+
+If the change has no meaningful performance or resource impact, state that clearly.
 
 ## Boundaries and non-goals
 
@@ -150,14 +208,19 @@ copy/paste runnable where possible. Remove commands that were not run.
 
 ```bash
 git diff --check
+
 zkstack dev fmt
 zkstack dev lint
-cargo test -p <crate-or-package>
 
-# Secret scanning:
-# - CI uses TruffleHog if .github/workflows/secrets_scanner.yaml.disabled is
-#   re-enabled as an active workflow.
-# - For local checks, run the repo-approved scanner or gitleaks if available.
+# Via structural rules (ast-grep)
+# Run for sibling-paired paths (see .github/sibling-paths.yml) or other high-risk areas.
+# Use `just via-check-strict` when required. See root AGENTS.md → Validation section.
+just via-check
+just via-check-strict
+
+cargo test -p <relevant-crate>
+
+# Secret scanning
 gitleaks protect --staged --redact --no-banner
 gitleaks git --log-opts="main..HEAD" --redact --no-banner
 ```
@@ -166,6 +229,7 @@ gitleaks git --log-opts="main..HEAD" --redact --no-banner
 
 - [ ] PR title follows Conventional Commits.
 - [ ] Tests, docs, formatting, and linting were updated or marked not applicable.
+- [ ] Ran `just via-check` (and `just via-check-strict` where required) and recorded results in the Checks run section.
 
 ## Live infrastructure and deployment impact
 

--- a/.github/scripts/check-via-structural-rules.sh
+++ b/.github/scripts/check-via-structural-rules.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Via Structural Rules Checker
+#
+# Runs Via-specific structural safety rules (currently powered by ast-grep).
+# These rules are advisory review aids for high-risk ordering/identity patterns.
+#
+# Usage:
+#   .github/scripts/check-via-structural-rules.sh
+#
+#   # Advisory mode (default): prints findings but exits 0
+#   VIA_STRUCTURAL_RULES_MODE=advisory .github/scripts/check-via-structural-rules.sh
+#
+#   # Strict mode: exits non-zero on scanner errors or new unbaselined findings
+#   VIA_STRUCTURAL_RULES_MODE=strict .github/scripts/check-via-structural-rules.sh
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RULES_DIR="$REPO_ROOT/.github/lint/via-structural/ast-grep/rules"
+BASELINE_FILE="$REPO_ROOT/.github/lint/via-structural/ast-grep/baseline.txt"
+MODE="${VIA_STRUCTURAL_RULES_MODE:-advisory}"
+FINDING_SEVERITY_RE='(\[(warning|error)\]|(warning|error)\[)'
+
+case "$MODE" in
+    advisory|strict) ;;
+    *)
+        echo "Error: VIA_STRUCTURAL_RULES_MODE must be 'advisory' or 'strict' (got: $MODE)" >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v ast-grep >/dev/null 2>&1; then
+    echo "Error: ast-grep is not installed." >&2
+    echo "Install it from https://ast-grep.github.io/guide/quick-start.html" >&2
+    exit 127
+fi
+
+if [[ ! -d "$RULES_DIR" ]]; then
+    echo "Error: Rules directory not found: $RULES_DIR" >&2
+    exit 1
+fi
+
+echo "Running Via structural rules (mode: $MODE)..."
+echo
+
+# ast-grep config file
+AST_GREP_DIR="$(dirname "$RULES_DIR")"
+SGCONFIG="$AST_GREP_DIR/sgconfig.yml"
+
+if [[ ! -f "$SGCONFIG" ]]; then
+    echo "Error: ast-grep config not found at $SGCONFIG" >&2
+    exit 1
+fi
+
+HAS_ISSUES=false
+HAS_UNBASELINED_FINDINGS=false
+HAS_SCANNER_ERRORS=false
+OUTPUT=""
+UNBASELINED_FINDINGS=""
+SCANNER_ERRORS=""
+ACTUAL_FINDINGS=""
+
+finding_counts() {
+    sed -nE 's#^([^#][^|]*\|[^|]+)(\|[0-9]+\|[0-9]+)?$#\1#p' \
+        | sort \
+        | uniq -c \
+        | awk '{ count = $1; $1 = ""; sub(/^[[:space:]]+/, ""); print $0 "|" count }'
+}
+
+compare_findings_to_baseline() {
+    local actual_counts
+    local baseline_counts
+    local unbaselined_findings
+    actual_counts="$(mktemp)"
+    baseline_counts="$(mktemp)"
+    unbaselined_findings="$(mktemp)"
+
+    printf '%s' "$ACTUAL_FINDINGS" | finding_counts > "$actual_counts"
+    if [[ -f "$BASELINE_FILE" ]]; then
+        finding_counts < "$BASELINE_FILE" > "$baseline_counts"
+    else
+        : > "$baseline_counts"
+    fi
+
+    awk -F'|' '
+        NR == FNR {
+            baseline[$1 "|" $2] = $3
+            next
+        }
+        {
+            key = $1 "|" $2
+            baseline_count = (key in baseline) ? baseline[key] : 0
+            if ($3 > baseline_count) {
+                print $1 "|" $2 " (actual: " $3 ", baseline: " baseline_count ")"
+            }
+        }
+    ' "$baseline_counts" "$actual_counts" > "$unbaselined_findings"
+
+    if [[ -s "$unbaselined_findings" ]]; then
+        HAS_UNBASELINED_FINDINGS=true
+        UNBASELINED_FINDINGS="$(cat "$unbaselined_findings")"$'\n'
+    fi
+
+    rm -f "$actual_counts" "$baseline_counts" "$unbaselined_findings"
+}
+
+run_scoped_rule() {
+    local rule_id="$1"
+    shift
+
+    local args=("scan" "--config" "$SGCONFIG" "--filter" "$rule_id" "--report-style" "short" "--color=never")
+    local glob
+    for glob in "$@"; do
+        args+=("--globs" "$glob")
+    done
+
+    local scan_output
+    local scan_error
+    scan_error="$(mktemp)"
+    local exit_code
+    set +e
+    # Run from repo root so CLI globs are evaluated against repository paths.
+    scan_output=$(cd "$REPO_ROOT" && ast-grep "${args[@]}" 2>"$scan_error")
+    exit_code=$?
+    set -e
+
+    if [[ -n "$scan_output" ]]; then
+        OUTPUT+="$scan_output"$'\n\n'
+    fi
+    if [[ -s "$scan_error" ]]; then
+        OUTPUT+="stderr from $rule_id:"$'\n'
+        OUTPUT+="$(cat "$scan_error")"$'\n\n'
+    fi
+
+    # Treat non-zero exit from ast-grep itself as a scanner error
+    # (invalid config, invalid rule, runtime failure, etc.).
+    if [[ $exit_code -ne 0 ]]; then
+        HAS_ISSUES=true
+        HAS_SCANNER_ERRORS=true
+        SCANNER_ERRORS+="$rule_id exited with status $exit_code"$'\n'
+    fi
+    rm -f "$scan_error"
+
+    # Use the tool's own signaling for robustness. ast-grep 0.42 short output
+    # is `warning[rule-id]`; accept `[warning]` too in case the format changes.
+    if grep -qE "$FINDING_SEVERITY_RE" <<< "$scan_output"; then
+        HAS_ISSUES=true
+    fi
+
+    local finding_path
+    while IFS= read -r finding_path; do
+        [[ -n "$finding_path" ]] || continue
+        ACTUAL_FINDINGS+="$rule_id|$finding_path"$'\n'
+    done < <(
+        sed -nE "s#^([^:]+):[0-9]+:[0-9]+: ${FINDING_SEVERITY_RE}.*#\\1#p" <<< "$scan_output"
+    )
+}
+
+# ast-grep 0.42 does not apply the intended rule-level globs from sgconfig.yml
+# in this repo setup, so the runner enforces scope via CLI globs. Keep this list
+# in sync with .github/lint/via-structural/ast-grep/sgconfig.yml.
+run_scoped_rule "via-reorg-buffer-unordered" \
+    "core/node/via_main_node_reorg_detector/**/*.rs" \
+    "via_verifier/node/via_reorg_detector/**/*.rs"
+
+run_scoped_rule "via-reorg-height-association-required" \
+    "core/node/via_main_node_reorg_detector/**/*.rs" \
+    "via_verifier/node/via_reorg_detector/**/*.rs"
+
+run_scoped_rule "via-da-batch-before-proof" \
+    "core/node/via_da_dispatcher/**/*.rs"
+
+run_scoped_rule "via-avoid-duplicate-export" \
+    "core/node/via_*/**/*.rs" \
+    "via_verifier/**/*.rs" \
+    "core/lib/via_*/**/*.rs" \
+    "core/lib/types/src/**/*.rs"
+
+if [[ -n "$OUTPUT" ]]; then
+    echo "$OUTPUT"
+    echo
+fi
+
+compare_findings_to_baseline
+
+if [[ "$HAS_ISSUES" == false ]]; then
+    echo "✓ No structural issues found."
+    exit 0
+fi
+
+# Issues were found
+if [[ "$MODE" == "strict" ]]; then
+    if [[ "$HAS_SCANNER_ERRORS" == true ]]; then
+        echo "✗ Via structural scanner error(s) found (strict mode)."
+        echo "$SCANNER_ERRORS"
+        echo "Failing the check."
+        exit 1
+    fi
+
+    if [[ "$HAS_UNBASELINED_FINDINGS" == true ]]; then
+        echo "✗ New Via structural rules findings found (strict mode)."
+        echo "Unbaselined findings:"
+        echo "$UNBASELINED_FINDINGS"
+        echo "Failing the check."
+        exit 1
+    fi
+
+    echo "✓ Only baselined structural warnings found (strict mode)."
+    echo "Known warnings remain visible above; new findings will fail this check."
+    exit 0
+else
+    echo "⚠ Via structural rules warnings found (advisory mode)."
+    echo "These are review prompts — not automatic defects."
+    echo "Please review the findings above and justify the ordering/identity assumptions."
+    echo "See .github/lint/via-structural/ast-grep/README.md for details."
+    exit 0
+fi

--- a/.github/sibling-paths.yml
+++ b/.github/sibling-paths.yml
@@ -1,0 +1,14 @@
+# .github/sibling-paths.yml
+#
+# Machine-readable mapping of high-risk paths to their sibling(s).
+# This file is used by the PR template lint and CodeRabbit rules.
+#
+# Format: [path_in_core, path_in_via_verifier]
+
+pairs:
+  - [core/node/via_main_node_reorg_detector, via_verifier/node/via_reorg_detector]
+  - [core/node/via_btc_watch, via_verifier/node/via_btc_watch]
+  - [core/node/via_btc_sender, via_verifier/node/via_btc_sender]
+  - [core/lib/via_da_clients, via_verifier/lib/via_da_client]  # note: naming differs (clients vs client)
+
+  # Add more pairs here as they are identified

--- a/.github/via-areas.yml
+++ b/.github/via-areas.yml
@@ -1,0 +1,52 @@
+# .github/via-areas.yml
+#
+# Maps file paths/globs to Via-Area values.
+# Intended for CI auto-injection of Via-Change / Via-Area trailers
+# and future path-aware linting / review rules.
+#
+# This file should be kept in sync with .github/sibling-paths.yml where possible.
+
+mappings:
+  - path: "core/node/via_main_node_reorg_detector/**"
+    area: reorg
+
+  - path: "via_verifier/node/via_reorg_detector/**"
+    area: reorg
+
+  - path: "core/node/via_btc_watch/**"
+    area: btc
+
+  - path: "via_verifier/node/via_btc_watch/**"
+    area: btc
+
+  - path: "core/node/via_btc_sender/**"
+    area: btc
+
+  - path: "via_verifier/node/via_btc_sender/**"
+    area: btc
+
+  - path: "core/node/via_da_dispatcher/**"
+    area: da
+
+  - path: "core/lib/via_da_clients/**"
+    area: da
+
+  - path: "via_verifier/lib/via_da_client/**"
+    area: da
+
+  - path: ".github/lint/via-structural/**"
+    area: structural
+
+  - path: ".github/scripts/check-via-structural-rules.sh"
+    area: structural
+
+  - path: ".github/workflows/via-structural-rules.yml"
+    area: structural
+
+  - path: ".githooks/pre-push"
+    area: structural
+
+  # Add more mappings as needed
+  # Example for future shared crates:
+  # - path: "core/lib/via_reorg_detector/**"
+  #   area: reorg

--- a/.github/via-scopes.yml
+++ b/.github/via-scopes.yml
@@ -1,0 +1,19 @@
+# .github/via-scopes.yml
+#
+# Allowed Conventional Commit scopes in via-core.
+# Reference metadata for commitlint / PR title checks.
+#
+# Use a `via-` scope for any change that is specific to Via
+# and not intended to be contributed upstream as-is. Use `upstream-sync`
+# only for upstream ZKsync merges that are not Via-specific.
+
+scopes:
+  via-reorg:     Reorg detection and L1 reorg handling
+  via-btc:       Bitcoin client, sender, watcher, and inscriptions
+  via-da:        Data Availability (Celestia, etc.)
+  via-verifier:  Verifier-specific logic and components
+  via-indexer:   Indexer-specific logic
+  via-prover:    Prover-specific logic
+  via-structural: Structural rules and linting (ast-grep)
+  via:           Cross-cutting Via-only changes (use sparingly)
+  upstream-sync: Merging upstream ZKsync changes (not Via-specific)

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,269 @@
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  pr-template-check:
+    name: PR template check
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to post/update the PR template check comment.
+      pull-requests: write
+      # Required to read .github/sibling-paths.yml from the checked-out tree.
+      contents: read
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Check PR Template (Content-Aware + Path-Aware)
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number || context.issue.number;
+            if (!prNumber) {
+              core.setFailed('Could not determine pull request number from workflow payload.');
+              return;
+            }
+
+            let pr = context.payload.pull_request;
+            if (!pr) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              pr = response.data;
+            }
+
+            const body = pr.body || '';
+            const visibleBody = body.replace(/<!--[\s\S]*?-->/g, '');
+
+            // Load sibling pairs from the base commit, not the PR head. Otherwise a PR
+            // could weaken the check by editing .github/sibling-paths.yml itself.
+            let siblingData = '';
+            try {
+              const siblingFile = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.github/sibling-paths.yml',
+                ref: pr.base.sha
+              });
+              siblingData = Buffer.from(siblingFile.data.content, siblingFile.data.encoding).toString('utf8');
+            } catch (error) {
+              if (error.status === 404) {
+                const fs = require('fs');
+                core.warning('Base .github/sibling-paths.yml does not exist yet; using the checked-out PR copy for bootstrap.');
+                siblingData = fs.readFileSync('.github/sibling-paths.yml', 'utf8');
+              } else {
+                core.setFailed(`Could not load base .github/sibling-paths.yml: ${error.message}`);
+                return;
+              }
+            }
+
+            const siblingPairs = [];
+            const lines = siblingData.split('\n');
+            for (const line of lines) {
+              const match = line.match(/-\s*\[(.+?),\s*(.+?)\]/);
+              if (match) siblingPairs.push([match[1].trim(), match[2].trim()]);
+            }
+
+            const requiredSections = [
+              'Why', 'What changed', 'Reuse & Duplication', 'Performance, Complexity, and Resource Impact'
+            ];
+
+            const missingSections = [];
+            const sectionContent = {};
+            const headings = [...visibleBody.matchAll(/^##\s+(.+)$/gm)];
+
+            const getSectionContent = (section) => {
+              const headingIndex = headings.findIndex(match =>
+                match[1].trim().toLowerCase() === section.toLowerCase()
+              );
+              if (headingIndex === -1) return '';
+
+              const start = headings[headingIndex].index + headings[headingIndex][0].length;
+              const next = headings[headingIndex + 1];
+              const end = next ? next.index : visibleBody.length;
+              return visibleBody.slice(start, end).trim();
+            };
+
+            for (const section of requiredSections) {
+              const content = getSectionContent(section);
+              if (!content) {
+                missingSections.push(section);
+              } else {
+                sectionContent[section] = content;
+              }
+            }
+
+            // === Quality & Anti-pattern Checks ===
+            const bannedPhrases = ['searched the repo', 'no duplication found', 'n/a'];
+            const reuseContent = sectionContent['Reuse & Duplication'] || '';
+            const reuseBody = reuseContent.replace(/^##\s+Reuse & Duplication\s*/i, '').trim();
+            const authoredReuseContent = reuseBody
+              .replace(/\*\*Required for any PR that adds or changes production logic in a `via_\*` path\.\*\*/g, '')
+              .replace(/Before writing implementation code, you must have completed the checks described in the root `AGENTS\.md` → \*Reuse and duplication discipline\*\./g, '')
+              .replace(/\*\*You must include the following in this section\*\* \(answers must be specific — vague or placeholder text will be rejected\):/g, '')
+              .replace(/-\s+Closest existing implementation considered: `<function or module name>`/g, '')
+              .replace(/-\s+Sibling paths inspected: `<list of specific paths>`/g, '')
+              .replace(/-\s+Search command run: `<exact rg\/grep command>`/g, '')
+              .replace(/-\s+Shared extraction decision: extracted to `<path>` \*\*OR\*\* not extracted because `<exact invariant \/ ownership \/ execution-context difference>`/g, '')
+              .replace(/Vague answers such as "searched the repo" or "no duplication found" are not accepted\./g, '')
+              .replace(/>\s+Self-check before submitting: Have you named a specific function\? Have you listed sibling paths actually inspected \(with backticks\)\? If any answer is no, revise this section\./g, '')
+              .trim();
+
+            const hasBannedPhrase = bannedPhrases.some(phrase =>
+              authoredReuseContent.toLowerCase().includes(phrase)
+            );
+
+            const hasBacktick = /`[^`]+`/.test(authoredReuseContent);
+
+            let qualityIssues = [];
+
+            if (hasBannedPhrase) {
+              qualityIssues.push('Contains banned/vague phrases (e.g. "searched the repo", "no duplication found")');
+            }
+            const isNotApplicable = /not applicable/i.test(authoredReuseContent);
+            if (!hasBacktick && authoredReuseContent.length > 30 && !isNotApplicable) {
+              qualityIssues.push('Reuse & Duplication section is missing backtick code references (e.g. `functionName`)');
+            }
+
+            // === Path-Aware Sibling Enforcement ===
+            // Use pagination to handle PRs with many files (default is only 30)
+            let filePaths = [];
+            let page = 1;
+            while (true) {
+              const response = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+                page
+              });
+              filePaths = filePaths.concat(response.data.map(f => f.filename));
+              if (response.data.length < 100) break;
+              page++;
+            }
+            const missingSiblingMentions = [];
+
+            for (const [pathA, pathB] of siblingPairs) {
+              const touchesA = filePaths.some(f => f.startsWith(pathA));
+              const touchesB = filePaths.some(f => f.startsWith(pathB));
+
+              if (touchesA || touchesB) {
+                const mentionsA = visibleBody.includes(pathA);
+                const mentionsB = visibleBody.includes(pathB);
+
+                if ((touchesA && !mentionsB) || (touchesB && !mentionsA)) {
+                  missingSiblingMentions.push([pathA, pathB]);
+                }
+              }
+            }
+
+            // === Build Comment ===
+            let commentBody = '### PR Template Check\n\n';
+
+            const hasIssues = missingSections.length > 0 || qualityIssues.length > 0 || missingSiblingMentions.length > 0;
+
+            if (!hasIssues) {
+              commentBody += 'All required sections appear present with reasonable content.';
+            } else {
+              if (missingSections.length > 0) {
+                commentBody += '**Missing required sections:**\n';
+                missingSections.forEach(s => commentBody += `- ${s}\n`);
+              }
+
+              if (qualityIssues.length > 0) {
+                commentBody += '\n**Quality issues in Reuse & Duplication section:**\n';
+                qualityIssues.forEach(issue => commentBody += `- ${issue}\n`);
+              }
+
+              if (missingSiblingMentions.length > 0) {
+                commentBody += '\n**Missing sibling path references:**\n';
+                for (const [a, b] of missingSiblingMentions) {
+                  commentBody += `- This PR touches one of \`${a}\` or \`${b}\`, but the sibling path is not referenced.\n`;
+                }
+              }
+
+              commentBody += '\n\n> This is currently a **warning only**. It will not block merging.\n';
+              commentBody += '> See the "Reuse & Duplication" section of the PR template and the root AGENTS.md → "Reuse and duplication discipline" for guidance.';
+            }
+
+            // === Structural rules reminder (advisory only) ===
+            // If the PR touches a sibling-paired path but doesn't mention the structural check,
+            // add a gentle note. This is intentionally non-blocking.
+            const touchesHighRisk = siblingPairs.some(([a, b]) =>
+              filePaths.some(f => f.startsWith(a) || f.startsWith(b))
+            );
+            const defaultChecksScaffold = new Set([
+              '```bash',
+              '```',
+              'git diff --check',
+              'zkstack dev fmt',
+              'zkstack dev lint',
+              '# Via structural rules (ast-grep)',
+              '# Run for sibling-paired paths (see .github/sibling-paths.yml) or other high-risk areas.',
+              '# Use `just via-check-strict` when required. See root AGENTS.md → Validation section.',
+              'just via-check',
+              'just via-check-strict',
+              'cargo test -p <relevant-crate>',
+              '# Secret scanning',
+              'gitleaks protect --staged --redact --no-banner',
+              'gitleaks git --log-opts="main..HEAD" --redact --no-banner'
+            ]);
+            const checksBody = getSectionContent('Checks run')
+              .replace(/^##\s+Checks run\s*/i, '')
+              .split('\n')
+              .map(line => line.trim())
+              .filter(line => line && !defaultChecksScaffold.has(line))
+              .join('\n');
+            const mentionsStructural = /via-check|structural.*lint|ast-grep/i.test(checksBody);
+
+            if (touchesHighRisk && !mentionsStructural) {
+              commentBody += '\n\n**Note:** This PR touches sibling-paired path(s). Consider running `just via-check-strict` (see root AGENTS.md → Validation) and recording it in the Checks run section.';
+            }
+
+            // Find and update existing comment
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100
+            });
+
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('PR Template Check')
+            );
+
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: commentBody
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: commentBody
+                });
+              }
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning(`Skipping PR Template Check comment because token cannot write PR comments: ${error.message}`);
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/via-structural-rules.yml
+++ b/.github/workflows/via-structural-rules.yml
@@ -1,0 +1,43 @@
+name: Via Structural Rules
+
+on:
+  pull_request:
+
+# Permissions are intentionally minimal.
+permissions:
+  contents: read
+
+jobs:
+  via-structural-rules:
+    name: Via Structural Rules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Install ast-grep
+        run: |
+          VERSION="0.42.0"
+          ZIP="app-x86_64-unknown-linux-gnu.zip"
+          URL="https://github.com/ast-grep/ast-grep/releases/download/${VERSION}/${ZIP}"
+          SHA256="e825a05603f0bcc4cd9076c4cc8c9abd6d008b7cd07d9aa3cc323ba4b8606651"
+
+          curl -fsSL "$URL" -o "/tmp/${ZIP}"
+          echo "${SHA256}  /tmp/${ZIP}" | sha256sum --check -
+          mkdir -p "$HOME/.local/bin"
+          unzip -o "/tmp/${ZIP}" ast-grep -d "$HOME/.local/bin"
+          chmod +x "$HOME/.local/bin/ast-grep"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/ast-grep" --version
+
+      - name: Run Via Structural Rules (Advisory Mode)
+        env:
+          # Change to "strict" to make this check blocking
+          VIA_STRUCTURAL_RULES_MODE: advisory
+        run: .github/scripts/check-via-structural-rules.sh

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ tags
 *.orig
 .direnv
 
+# Local agent / AI working directory (never commit)
+.agents/
+.antigravitycli/
+
+# Local LLM-wiki / agent-harness knowledge base (experimental, not committed yet)
+llm-wiki/
+
 # Yarn files
 .yarn/
 .yarnrc.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,190 +2,162 @@
 
 ## Scope
 
-Applies to this repository root and all descendants unless a nested `AGENTS.md` adds more specific instructions.
-This repository contains Via Network protocol and runtime code. Keep changes reviewable, and grounded in source behavior, tests, and deployment facts.
+Applies to this repository and all descendants unless a nested `AGENTS.md` adds more specific instructions.
 
 ## Purpose
 
-This repo owns Via source/runtime behavior: main node, external node, verifier, indexer, BTC sender, prover, contracts, config semantics, docs, and developer tooling that ship with `via-core`.
-
-This repo does not own live or desired-state deployment. Use sibling repos for Kubernetes, Helm, Hetzner/OpenTofu/Ansible, GCP/Terragrunt, explorer code, and durable incident synthesis. Source changes here can affect future builds, but do not prove what is currently deployed.
+This repository owns Via source and runtime behavior. It does not own live or desired-state deployment.
 
 ## Read first
 
-- Before changing non-trivial runtime behavior, read the relevant Via guide
-  (`docs/via_guides/development.md`, `docs/via_guides/architecture.md`, or
-  `docs/via_guides/data-flow.md`) and the nearest crate README/config; do not
-  infer behavior from file names alone.
+Before changing non-trivial runtime behavior, read the relevant Via guide and the nearest crate README or config.
 
 ## Important paths
 
-- Runtime: `core/`; verifier: `via_verifier/`; prover/indexer: `prover/`, `via_indexer/`.
-- Bitcoin: `core/lib/via_btc_client/`, `core/node/via_btc_*/`, verifier BTC paths, and `core/lib/dal/src/via_btc_sender_dal.rs`.
-- DA/reorg: `core/lib/via_da_clients/`, verifier DA paths, `core/node/via_main_node_reorg_detector/`, and `via_verifier/node/via_reorg_detector/`.
-- Contracts/config/CLI/docs/examples: `contracts/`, `configs/`, `etc/`, `zkstack_cli/`, `docs/`, `docker/`, `.github/`.
+- Runtime: `core/`
+- Verifier: `via_verifier/`
+- Prover / Indexer: `prover/`, `via_indexer/`
+- Bitcoin: `core/lib/via_btc_client/`, `core/node/via_btc_*`, and verifier BTC paths
+- DA / Reorg: `core/lib/via_da_clients/`, `core/node/via_main_node_reorg_detector/`, and `via_verifier/node/via_reorg_detector/`. (When touching one, check the other — see *Reuse and duplication discipline*.)
 
 ## Source-of-truth rules
 
-- Keep source, desired state, and live state separate: repo code does not prove
-  deployment, and deployment repos do not prove runtime behavior. Verify against
-  source, kube/Helm/infra repos, live cluster/host state, public APIs, DB state,
-  or tests as appropriate.
-- Do not assume upstream ZKsync behavior is unchanged after Via-specific forks.
-  Check Via files and upstream references before classifying a divergence.
-- Treat current upstream ZKsync `main` documentation as a reference, not as a
-  direct source of repo rules. Before importing newer upstream guidance, verify
-  the referenced files, commands, and upgrade architecture exist in this repo's
-  current ZKsync lineage and Via-specific fork state.
-- Prefer Via-specific `via_` modules, crates, services, binaries, and components
-  when extending fork behavior. Touch upstream-derived non-`via_` code only when
-  the task requires that exact path or a Via component depends on it, and explain
-  why a `via_` extension was not enough.
-- For Bitcoin transaction investigations, check byte-reversed 32-byte txids
-  before declaring a transaction missing from public explorers or node RPC.
+- Source code describes behavior; it does not prove deployment.
+- Prefer Via-specific `via_` modules when extending fork behavior.
+- Follow the call graph into upstream (non-`via_*`) code when necessary, and explain why a Via extension was insufficient.
+- For Bitcoin work, remember that txids are byte-reversed.
 
 ## Safety rules
 
-- Never commit secrets, private keys, wallet material, database URLs, RPC
-  passwords, cookies, decrypted env files, or generated local state.
-- Do not query or print live secrets from deployment repos or clusters while
-  working in this repo.
-- Do not deploy, restart workloads, run migrations against live databases, or
-  mutate live infrastructure from this repo without explicit operator approval.
-- Keep local diagnostic artifacts out of commits. Use `.git/info/exclude` for
-  local agent/indexing scratch directories such as `.gitnexus/`, `.claude/`, or
-  similar tool output if they appear.
+- Never commit secrets or live credentials.
+- Do not run migrations or deploy from this repo without explicit approval.
+- Keep local agent scratch directories (`.gitnexus/`, `.agents/`, etc.) out of commits.
+
+## Reuse and duplication discipline
+
+Apply this section before writing implementation code. The PR template’s *Reuse & Duplication* and *Performance, Complexity, and Resource Impact* sections cannot be filled in honestly after the fact — they exist to surface the reasoning required here.
+
+**Production code is permanent audit cost.** Every new function, detector, client, poller, watcher, or worker adds ongoing review and maintenance burden. Production LOC is measured as **net delta** (lines added minus lines removed, excluding comments, documentation, tests, and generated files). Before writing new code, identify the existing function or module that should own the behavior. If you cannot name it, you are likely introducing duplication.
+
+**Do not tunnel on `via_*`.** `via_*` directories are not hard boundaries. Follow the call graph into upstream and non-`via_*` modules. Always check sibling implementations across node types (main-node vs. verifier, `core/` vs. `via_verifier/`) before adding new logic.
+
+Detector, poller, watcher, and fetch/compare logic copied across main-node and verifier paths is the canonical anti-pattern this section exists to prevent (see PRs #355–#360).
+
+**Mandatory pre-coding check.** Before creating a new file, struct, detector, poller, watcher, client, DAL method, parser, or conversion in a `via_*` path, complete the following:
+
+1. Name the closest existing function or module you considered extending or replacing.
+2. List the specific sibling paths you inspected (main-node ↔ verifier, `core/` ↔ `via_verifier/`). For reorg-related work this must include both `core/node/via_main_node_reorg_detector/` and `via_verifier/node/via_reorg_detector/`.
+3. If you are not extracting shared logic, state the exact invariant, ownership boundary, or execution-context difference that prevents extraction.
+
+If you cannot complete the steps above, stop and do the search before writing implementation code.
+
+### Anti-pattern vs Required Pattern (example)
+
+**Anti-pattern** (duplication of sibling logic):
+
+- Similar detector / poller / watcher logic added in both a `core/node/` path and the corresponding `via_verifier/node/` path with only minor differences.
+- No attempt to extract shared behavior.
+
+**Required pattern**:
+
+- Shared logic extracted to `core/lib/` (or the most appropriate shared crate).
+- Only thin node-specific wrappers remain in `core/node/` and `via_verifier/node/`.
+
+This pattern applies to any duplicated logic across main-node and verifier (not just reorg detectors).
+
+### Maintaining supporting files
+
+When new duplication patterns, high-risk areas, or sibling relationships are discovered, update the following files:
+
+- `.github/sibling-paths.yml` — Add new main-node ↔ verifier path pairs.
+- `.github/via-scopes.yml` — Add new `via-*` scopes when a recurring area of work appears.
+- `.github/via-areas.yml` — Map new paths to the appropriate `Via-Area` value.
+
+Also consider adding a small `AGENTS.md` file in the relevant high-risk directory if one does not already exist.
+
+## Commit Message Convention
+
+Use Conventional Commits. All Via-specific changes must use a `via-` scope.
+
+**Format:**
+
+```text
+<type>(via-<area>): <imperative subject>
+```
+
+**Allowed types:** `feat`, `fix`, `perf`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`, `revert`
+
+**Examples:**
+
+- `feat(via-reorg): detect deep reorgs from DA layer`
+- `fix(via-btc): correct txid byte-reversal in mempool watcher`
+- `refactor(via-da): extract shared inclusion proof parsing`
+- `perf(via-verifier): batch L1 batch metadata loads`
+- `fix(via-reorg): align reorg handling with new upstream batch finality rules`
+- `chore(upstream-sync): merge ZKsync vX.Y.Z`
+
+**Scopes:** See `.github/via-scopes.yml` for the current list of allowed scopes, including Via-specific `via-*` scopes and the non-Via `upstream-sync` scope.
+
+When merging upstream ZKsync changes that are **not** Via-specific, use the `upstream-sync` scope instead of a `via-` scope.
 
 ## Change discipline
 
-- For bug fixes, include a regression test when the affected crate/test harness
-  makes it practical.
-- Preserve rich error context in production/library paths. Prefer propagated
-  errors and `anyhow::Context` / `with_context` over flattening failures into
-  generic strings. Avoid `unwrap()` / `expect()` in non-test runtime paths.
-- Make examples model safe usage when they are copied by operators or integrators;
-  do not leave panic-prone examples around hardened library APIs.
-- Compact-by-default: prefer one-line expressions and short helper calls when
-  they remain readable and rustfmt accepts them; avoid manual wrapping churn and
-  do not reformat unrelated existing code just to change line shape.
-- Reuse-first: search for the canonical abstraction before adding helpers,
-  parsers, clients, DAL methods, conversions, or runtime glue. Prefer extension
-  over near-duplicates; if new code is needed, place it beside the closest owner
-  and explain the non-reuse decision in the PR.
-- For runtime behavior changes that affect deployments, document the required
-  deployment/config follow-up in the PR body. Do not imply live rollout has
-  happened unless it has been verified separately.
-- When touching duplicated main-node/verifier/external-node logic, check whether
-  the same bug exists in the sibling implementation before stopping.
-- When changing async fetch/compare code, preserve or explicitly encode ordering
-  assumptions. Do not compare height-indexed data by vector position unless the
-  ordering contract is proven and tested.
-- For `zkstack_cli/` Rust changes, rebuild the installed CLI with
-  `zkstackup --local` before validating CLI behavior.
-- For Forge/deployment/upgrade flows, verify generated paths, env vars,
-  deployment state, and call order against Via's actual command flow. Prefer
-  fail-fast root-cause fixes over broad fallbacks, `try/catch`, or low-level
-  `staticcall` probes that hide missing deployments or ordering bugs; use
-  `cast run` or equivalent tracing for opaque failures.
-- Protocol-sensitive areas include Bitcoin, DA/Celestia, verifier/prover, state
-  keeper, reorg/reverter, contracts/upgrades, migrations/DAL, serialization,
-  hashes, signatures, byte order, and inscriptions. Search call sites and
-  downstream consumers before changing APIs, config keys, DB schema, metrics, or
-  encoded data.
-- Long-lived services in `core/node` and `via_verifier/node` often communicate
-  through database state rather than direct calls. Before changing one, identify
-  the table/query it polls, rows it creates or updates, downstream consumers, and
-  retry/error/stop-signal behavior.
+- Include a regression test for bug fixes when practical.
+- Preserve rich error context (`anyhow::Context`, `with_context`, `?`) in production paths. Never strip it to shorten a diff.
+- When changing async fetch/compare code, preserve or explicitly document ordering assumptions.
+- Protocol-sensitive areas (Bitcoin, DA, reorg, verifier/prover, serialization, hashes, signatures, inscriptions) require extra care. Search call sites and downstream consumers before changing them.
 
-## GitNexus and cross-repo review
-
-- Use GitNexus before non-trivial impact analysis or Via cross-repo review; then
-  verify decisive graph findings against exact source files.
-- Treat `kube-state` and `helm-charts` as deployment/config context, not live
-  proof. Keep `.gitnexus/`, `.claude/`, `.rooignore`, and similar agent artifacts
-  local/excluded unless an ignore-policy PR is explicitly intended.
-
-## Automated review
-
-`.coderabbit.yaml` configures advisory CodeRabbit reviews. Treat CodeRabbit
-comments as review input, not authority.
-
-CodeRabbit is configured to use this `AGENTS.md`, the PR template, issue forms,
-and the issue-template validator as review guidance. It also has path-specific
-instructions for BTC, L1/reorg, DA, migrations, and process files.
-
-- Verify CodeRabbit suggestions against source, tests, sibling main-node/verifier
-  paths, deployment boundaries, and live evidence before applying them.
-- Recurring incorrect or noisy feedback should be fixed in `.coderabbit.yaml` or
-  this document rather than repeatedly overridden in PRs.
-- CodeRabbit is advisory; objective enforcement belongs in GitHub Actions and
-  repository validators.
+Reuse and duplication rules are defined in the dedicated section above.
 
 ## Review Expectations
 
-When making changes, authors and reviewers should consider both correctness **and** performance characteristics.
+When making changes, consider both correctness **and** performance.
 
-This is especially important for Via-specific code (any path containing `via_`). The level of detail expected scales with risk:
+High-risk areas (reorg detection, L1 sync, BTC integration, DA, and hot database paths) require explicit reasoning about time complexity, allocations, and cache behavior.
 
-- **High-risk areas** (reorg detection, L1 sync, BTC integration, DA, and hot database paths) require explicit reasoning about time complexity, allocations, and cache behavior when algorithms or data structures are changed or introduced.
-- For other Via-specific code, a lighter discussion of performance impact is expected when relevant.
-- For upstream-derived code that has not been significantly modified, performance considerations can remain light unless the change affects critical paths.
+Reason about the common (happy) path, not only worst-case Big-O. State the expected work in concrete terms: allocations per operation, DB calls, RPCs, locks held, serialization, background work, and approximate production LOC added. Asymptotic complexity hides the constants that matter at production throughput.
 
-See the PR template for the expected format of the “Performance / Complexity Impact” section.
+Unjustified duplication or missing sibling checks are grounds for blocking merge.
 
 ## Validation
 
-Choose checks that match the files changed and report exactly what ran.
-
-Common local gates:
+Run the standard local checks before pushing:
 
 ```bash
 git diff --check
 zkstack dev fmt
 zkstack dev lint
-cargo test -p <crate-or-package>
+cargo test -p <crate>
+just via-check          # structural lint (ast-grep), advisory
 ```
 
-For targeted Rust changes, prefer the narrowest meaningful crate tests first,
-then broader checks if the change is shared or safety-critical. If a command
-cannot run locally, state why and list the source inspection or narrower check
-used instead.
+**Structural lint (blocking for sibling-paired paths)**
 
-## GitHub issues
+If your change touches any of the following, run `just via-check-strict` and ensure it passes before pushing:
 
-Use the closest `.github/ISSUE_TEMPLATE/` form when creating issues. For
-CLI/API-created issues, manually include the selected form's required fields;
-GitHub only applies issue forms automatically in the web UI.
+- `core/node/via_main_node_reorg_detector/`
+- `via_verifier/node/via_reorg_detector/`
+- Any path pair listed in `.github/sibling-paths.yml`
+- `.github/lint/via-structural/ast-grep/rules/` or `.github/scripts/check-via-structural-rules.sh`
 
-For runtime, protocol, database, deployment, L1/BTC/reorg, verifier,
-external-node, or operator-evidence issues, do not create free-form issues.
-Include raw values, value provenance, facts versus hypotheses, the suspected
-invariant, ordering/identity assumptions, a regression-test expectation, and
-live-read/write boundaries.
+`just via-check` (and `just via-check-strict` for sibling-paired paths) runs structural lint rules that catch common duplication, ordering, and identity anti-patterns across main-node and verifier code. These rules are maintained in `.github/lint/via-structural/ast-grep/rules/`. `zkstack dev lint` does not cover them.
 
-## PR descriptions
+A pre-push hook runs these rules in advisory mode for reorg detector paths as a safety net, but do not rely on it — run the command yourself.
 
-Use `.github/pull_request_template.md` for PR bodies.
+If a rule fires and you believe it is a false positive, document the reasoning in the PR description. Do not silence rules without justification. Rule sources live in `.github/lint/via-structural/ast-grep/rules/`.
 
-Write PR descriptions for a human reviewer/operator, not as an agent/tool audit
-log. Explain why the change exists, what behavior changes, what intentionally did
-not change, how to review the risk, which checks ran, and whether any live
-infrastructure action occurred.
+## GitHub issues and PRs
 
-Use impersonal, operator-facing wording. Avoid first-person singular or plural
-phrasing. Name the component, crate, runtime invariant, config key, deployment
-boundary, or operator action instead.
+Use the appropriate issue template. For runtime, protocol, L1/BTC/reorg, verifier, or external-node issues, do not use free-form issues.
 
-For runtime/safety PRs, the `Why` section should be a real reviewer/operator-facing
-explanation, not a bullet-only summary. It should describe the observed failure
-mode or process gap, why the existing source/process state was unsafe,
-misleading, incomplete, or hard to review, what future maintainer, release, or
-incident path could be harmed, and the invariant the repo should enforce.
+All PRs must follow `.github/pull_request_template.md`. Write descriptions for human reviewers and operators, not as an agent/tool audit log. Focus on the “Why”, what actually changed, what did not change, the risk, and the checks that were run. Use impersonal, operator-facing wording and name the component, crate, runtime invariant, config key, deployment boundary, or operator action instead.
 
-For process/tooling PRs, explain the reviewer or maintainer failure mode the
-process change prevents and the boundary between advisory guidance and enforced
-checks.
+## Tooling and cross-repo notes
 
-The `What did not change` section should prevent unsafe assumptions, especially
-around live rollout, database mutation, secrets, deployment desired state, and
-follow-up infra work.
+- Use GitNexus for non-trivial cross-repo impact analysis.
+- Treat `kube-state` and `helm-charts` as deployment context, not runtime proof.
+- CodeRabbit reviews are advisory. Verify suggestions against source and tests.
+
+## Directory-level guidance
+
+High-risk directories should contain a small `AGENTS.md` that points back to this section. This is often the most effective way to ensure agents encounter the relevant rules at the point of use.

--- a/core/lib/AGENTS.md
+++ b/core/lib/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md — core/lib/
+
+This directory (and its sub-crates) is the preferred home for logic that should be shared between main-node and verifier.
+
+Before duplicating detector, poller, watcher, client, or similar logic in `core/node/` or `via_verifier/node/`, check whether it belongs here.
+
+See root `AGENTS.md` → *Reuse and duplication discipline*.

--- a/core/lib/via_da_clients/AGENTS.md
+++ b/core/lib/via_da_clients/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md — via_da_clients (core)
+
+This directory is **sibling-paired** with `via_verifier/lib/via_da_client/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `via_verifier/lib/via_da_client/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` (or keep here if this is the right shared home) rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.
+
+Note: Naming differs between sides (via_da_clients vs via_da_client). Keep this in mind when searching.

--- a/core/lib/via_da_clients/rustfmt.toml
+++ b/core/lib/via_da_clients/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/core/node/AGENTS.md
+++ b/core/node/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — core/node/
+
+STOP before adding or changing any detector, poller, watcher, client,
+DAL method, parser, conversion, or fetch/compare logic in this tree.
+
+Required actions before writing implementation code:
+
+1. Run a search across the sibling tree (via_verifier/node/). Example:
+   rg -n 'fn |struct ' via_verifier/node/ | rg -i '<your_keyword>'
+
+2. Read at least one matching file in via_verifier/node/ before proceeding.
+   For reorg-related work, this MUST include via_verifier/node/via_reorg_detector/.
+
+3. If shared logic exists or could exist, extract it to core/lib/ (or the most appropriate shared crate) rather than duplicating here. Shared logic does **not** belong in core/node/.
+
+4. In your PR's "Reuse & Duplication" section, record:
+   - Sibling paths inspected
+   - Closest existing owner considered
+   - Search command run
+   - If not shared: the exact invariant or execution-context difference that prevents extraction
+
+If you cannot complete steps 1–3, do not write the implementation. Search first.
+
+Canonical anti-pattern this prevents: logic duplicated between main-node and verifier instead of being extracted to a shared location.

--- a/core/node/via_btc_sender/AGENTS.md
+++ b/core/node/via_btc_sender/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — main-node btc sender
+
+This directory is **sibling-paired** with `via_verifier/node/via_btc_sender/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `via_verifier/node/via_btc_sender/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.

--- a/core/node/via_btc_sender/rustfmt.toml
+++ b/core/node/via_btc_sender/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/core/node/via_btc_watch/AGENTS.md
+++ b/core/node/via_btc_watch/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — main-node btc watch
+
+This directory is **sibling-paired** with `via_verifier/node/via_btc_watch/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `via_verifier/node/via_btc_watch/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.

--- a/core/node/via_btc_watch/rustfmt.toml
+++ b/core/node/via_btc_watch/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/core/node/via_da_dispatcher/rustfmt.toml
+++ b/core/node/via_da_dispatcher/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/core/node/via_main_node_reorg_detector/AGENTS.md
+++ b/core/node/via_main_node_reorg_detector/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — main-node reorg detector
+
+This directory is **sibling-paired** with `via_verifier/node/via_reorg_detector/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `via_verifier/node/via_reorg_detector/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.

--- a/core/node/via_main_node_reorg_detector/rustfmt.toml
+++ b/core/node/via_main_node_reorg_detector/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -1,0 +1,91 @@
+# Formatting Changed Files (Experimental)
+
+This script formats only the files you changed. It is designed to support more compact formatting in `via_*` paths while still respecting the project's standard formatting for upstream code.
+
+**Status**: Experimental. Use for testing and feedback before wider adoption.
+
+## Why this exists
+
+- Auditors charge per line of production code in `via_*` areas.
+- The default rustfmt style (used by zkstack dev fmt) produces very vertical code, increasing billable LOC.
+- We want the ability to use more compact formatting in Via-specific code without fighting the formatter on every change.
+
+## Usage
+
+```bash
+# Format files changed since last commit
+scripts/format-changed.sh
+
+# Format only files that are currently staged
+scripts/format-changed.sh staged
+
+# Check mode (useful in CI or before pushing)
+scripts/format-changed.sh --check
+```
+
+## How it works
+
+- It looks at files changed in the current branch / working tree.
+- For files under `via_*` paths -> uses a more compact formatting configuration.
+- For other (non-`via_*`) Rust files -> uses `rustfmt` directly on only the changed files.
+- Non-Rust files are currently ignored (extend the script if needed).
+
+## Recommended workflow (for testing)
+
+1. Make your changes (or let an LLM make them).
+2. Run:
+
+   ```bash
+   scripts/format-changed.sh
+   ```
+
+3. Review the diff.
+4. Commit.
+
+## Adding as a Pre-Commit Hook (Optional)
+
+If you want to try it as a pre-commit hook later:
+
+```bash
+# From the repo root
+mkdir -p .git/hooks
+cat > .git/hooks/pre-commit << 'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+staged_files=$(mktemp)
+trap 'rm -f "$staged_files"' EXIT
+
+# Only re-stage files that were originally staged. Keep the NUL-delimited list
+# in a file; shell variables cannot safely store NUL bytes.
+git diff --cached --name-only -z --diff-filter=ACMR > "$staged_files"
+
+scripts/format-changed.sh staged
+
+# Re-stage only the files that were originally staged
+if [ -s "$staged_files" ]; then
+  xargs -0 git add -- < "$staged_files"
+fi
+EOF
+
+chmod +x .git/hooks/pre-commit
+```
+
+**Warning**: Do not enable this repo-wide until the script has been tested for a while. It is easy to accidentally reformat more than intended during the early phase.
+
+## Current limitations
+
+- Only handles Rust files for now.
+- The compact style for `via_*` paths depends on local per-directory `rustfmt.toml` files in those paths.
+- Working-tree mode includes untracked files; staged mode formats only staged files.
+- zkstack dev fmt is still the recommended command for full workspace formatting.
+
+## Feedback
+
+Please report issues, especially around:
+
+- Whether compact formatting is being applied correctly in `via_*` files.
+- Any files that should be formatted but aren't.
+- Friction when using it day-to-day.
+
+This is intentionally being introduced gradually. We are not yet requiring it for all contributors.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+# justfile for via-core
+# https://github.com/casey/just
+#
+# Install just:
+#   macOS:   brew install just
+#   Linux:   curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+#   Windows: winget install --id Casey.Just -e
+#
+# Usage examples:
+#   just fmt
+#   just check
+#   just via-check
+#   just via-check-strict
+
+# Format code using zkstack
+fmt:
+    zkstack dev fmt
+
+# Run general linting
+check:
+    zkstack dev lint
+
+# Run Via-specific structural rules (advisory mode by default)
+via-check:
+    VIA_STRUCTURAL_RULES_MODE=advisory .github/scripts/check-via-structural-rules.sh
+
+# Run Via-specific structural rules in strict (blocking) mode
+via-check-strict:
+    VIA_STRUCTURAL_RULES_MODE=strict .github/scripts/check-via-structural-rules.sh

--- a/scripts/format-changed.sh
+++ b/scripts/format-changed.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   scripts/format-changed.sh              # format files changed vs HEAD
+#   scripts/format-changed.sh staged       # format only staged files
+#   scripts/format-changed.sh --check      # CI-style: exit 1 if formatting needed
+
+MODE="working"
+CHECK=false
+RUST_EDITION="2021"
+
+for arg in "$@"; do
+  case "$arg" in
+    staged)  MODE="staged" ;;
+    --check) CHECK=true ;;
+  esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v rustfmt >/dev/null 2>&1; then
+  echo "Error: rustfmt is not installed or not on PATH." >&2
+  exit 127
+fi
+
+get_changed_files() {
+  if [[ "$MODE" == "staged" ]]; then
+    git diff --cached --name-only -z --diff-filter=ACMR
+  else
+    git diff HEAD --name-only -z --diff-filter=ACMR
+    git ls-files --others --exclude-standard -z
+  fi
+}
+
+via_rust_files=()
+non_via_rust_files=()
+
+while IFS= read -r -d '' file; do
+  [[ -f "$file" ]] || continue
+
+  if [[ "$file" == *.rs ]]; then
+    basename="${file##*/}"
+
+    # Detect any via_* path segment or Rust basename.
+    if [[ "$file" == via_*/* || "$file" == */via_*/* || "$basename" == via_*.rs ]]; then
+      via_rust_files+=("$file")
+    else
+      non_via_rust_files+=("$file")
+    fi
+  fi
+done < <(get_changed_files)
+
+run_rustfmt() {
+  local files=("$@")
+  local rustfmt_args=("--skip-children" "--edition" "$RUST_EDITION")
+
+  # Via files use their local per-directory rustfmt.toml (if present).
+  # rustfmt discovers these automatically when run on the files. The explicit
+  # edition matches the Via rustfmt.toml files and keeps direct rustfmt calls
+  # aligned with modern Rust syntax when no crate metadata is consulted.
+
+  if $CHECK; then
+    rustfmt_args=("--check" "${rustfmt_args[@]}")
+  fi
+
+  printf '%s\0' "${files[@]}" | xargs -0 rustfmt "${rustfmt_args[@]}" --
+}
+
+echo "=== Formatting changed files ==="
+
+if ((${#via_rust_files[@]})); then
+  echo "→ Via Rust files (compact style)"
+  run_rustfmt "${via_rust_files[@]}"
+fi
+
+if ((${#non_via_rust_files[@]})); then
+  echo "→ Non-Via Rust files (targeted only — never full workspace from this script)"
+  # Format only the specific changed files using rustfmt directly.
+  # This avoids accidentally triggering workspace-wide formatting.
+  run_rustfmt "${non_via_rust_files[@]}"
+fi
+
+if ((${#via_rust_files[@]} == 0 && ${#non_via_rust_files[@]} == 0)); then
+  echo "No Rust files to format."
+fi
+
+echo "✅ Done."

--- a/via_verifier/lib/via_da_client/AGENTS.md
+++ b/via_verifier/lib/via_da_client/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md — via_da_client (verifier)
+
+This directory is **sibling-paired** with `core/lib/via_da_clients/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `core/lib/via_da_clients/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.
+
+Note: Naming differs between sides (via_da_client vs via_da_clients). Keep this in mind when searching.

--- a/via_verifier/lib/via_da_client/rustfmt.toml
+++ b/via_verifier/lib/via_da_client/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/via_verifier/node/AGENTS.md
+++ b/via_verifier/node/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md — via_verifier/node/
+
+STOP before adding or changing any detector, poller, watcher, client,
+DAL method, parser, conversion, or fetch/compare logic in this tree.
+
+Required actions before writing implementation code:
+
+1. Run a search across the sibling tree (core/node/). Example:
+   rg -n 'fn |struct ' core/node/ | rg -i '<your_keyword>'
+
+2. Read at least one matching file in core/node/ before proceeding.
+   For reorg-related work, this MUST include core/node/via_main_node_reorg_detector/.
+
+3. If shared logic exists or could exist, extract it to core/lib/ (or the most appropriate shared crate) rather than duplicating here. Shared logic does **not** belong in via_verifier/node/.
+
+4. In your PR's "Reuse & Duplication" section, record:
+   - Sibling paths inspected
+   - Closest existing owner considered
+   - Search command run
+   - If not shared: the exact invariant or execution-context difference that prevents extraction
+
+If you cannot complete steps 1–3, do not write the implementation. Search first.
+
+Canonical anti-pattern this prevents: logic duplicated between main-node and verifier instead of being extracted to a shared location.

--- a/via_verifier/node/via_btc_sender/AGENTS.md
+++ b/via_verifier/node/via_btc_sender/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — verifier btc sender
+
+This directory is **sibling-paired** with `core/node/via_btc_sender/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `core/node/via_btc_sender/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.

--- a/via_verifier/node/via_btc_sender/rustfmt.toml
+++ b/via_verifier/node/via_btc_sender/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/via_verifier/node/via_btc_watch/AGENTS.md
+++ b/via_verifier/node/via_btc_watch/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — verifier btc watch
+
+This directory is **sibling-paired** with `core/node/via_btc_watch/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `core/node/via_btc_watch/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.

--- a/via_verifier/node/via_btc_watch/rustfmt.toml
+++ b/via_verifier/node/via_btc_watch/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+# Via-specific formatting rules
+# Favors a more compact 1-2 line style for method chains and function calls.
+
+max_width = 120
+use_small_heuristics = "Max"
+fn_params_layout = "Compressed"

--- a/via_verifier/node/via_reorg_detector/AGENTS.md
+++ b/via_verifier/node/via_reorg_detector/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — verifier reorg detector
+
+This directory is **sibling-paired** with `core/node/via_main_node_reorg_detector/`.
+
+Before pushing changes to this directory:
+
+1. Inspect `core/node/via_main_node_reorg_detector/` for parallel behavior.
+2. If logic is shared, extract to `core/lib/` rather than duplicating.
+3. Run `just via-check-strict` and ensure it passes.
+
+See root `AGENTS.md` → *Reuse and duplication discipline* for the rationale and mandatory checks.


### PR DESCRIPTION
## Why

Via-specific runtime paths now span main-node, verifier, Bitcoin, DA, and reorg components where small ordering or duplication mistakes can create high audit cost and difficult reviews. The repository already has multiple sibling implementations whose safety depends on reviewers comparing both sides of a core ↔ verifier boundary, but that expectation was mostly implicit.

This PR makes those review boundaries explicit. It adds structural linting and repository metadata so recurring high-risk patterns are easier to detect, explain, and review before they become duplicated detector, watcher, fetch/compare, or dispatch logic. The initial rules focus on patterns that are especially risky for Via: async reorg ordering after unordered fetches, positional height/hash association, duplicate public paths, and DA batch-before-proof sequencing.

The formatting tooling addresses a separate review-cost issue in `via_*` paths. Compact formatting is introduced as an experimental changed-files-only workflow so Via-specific code can reduce avoidable line churn without changing the repository-wide `zkstack dev fmt` expectation.

## What changed

- Added Via structural linting under `.github/lint/via-structural/` with ast-grep rules for reorg ordering, positional zip usage in reorg detectors, duplicate module/re-export paths, and DA proof dispatch ordering.
- Added `.github/scripts/check-via-structural-rules.sh`, `just via-check`, `just via-check-strict`, and a PR workflow for running the structural rules.
- Scoped structural rule execution through explicit `ast-grep --filter` and `--globs` calls so rules do not leak into upstream-heavy crates such as `core/lib/multivm`.
- Added `baseline.txt` for known structural findings during rollout. Strict mode still prints known findings, but fails only on new unbaselined findings or scanner errors.
- Added `.github/sibling-paths.yml`, `.github/via-areas.yml`, and `.github/via-scopes.yml` metadata for path-aware review and commit scope classification.
- Added directory-level `AGENTS.md` files for high-risk Via sibling paths and expanded the root reuse/duplication guidance.
- Added `scripts/format-changed.sh` and `docs/formatting.md` for experimental changed-files-only Rust formatting, including compact formatting via local per-directory `rustfmt.toml` files in selected `via_*` paths.
- Updated PR template checks to paginate PR files and avoid false warnings for explicit `Not applicable` reuse sections.

## Reuse & Duplication

Not applicable — this PR changes governance, linting, metadata, workflows, hooks, docs, and formatting configuration; it does not add new Via runtime detector/client/poller/watcher logic.

Closest existing implementation considered: `.github/scripts/check-via-structural-rules.sh`, `.github/lint/via-structural/ast-grep/sgconfig.yml`, `justfile`, and `.githooks/pre-push` are the existing owners for structural lint execution and local hook integration.

Sibling paths inspected: `core/node/via_main_node_reorg_detector/`, `via_verifier/node/via_reorg_detector/`, `core/node/via_btc_watch/`, `via_verifier/node/via_btc_watch/`, `core/node/via_btc_sender/`, `via_verifier/node/via_btc_sender/`, `core/lib/via_da_clients/`, and `via_verifier/lib/via_da_client/` are represented in `.github/sibling-paths.yml` and directory-level `AGENTS.md` guidance.

Shared extraction decision: no production shared logic was introduced. Structural lint behavior remains centralized in `.github/lint/via-structural/` and `.github/scripts/check-via-structural-rules.sh`; node-specific runtime paths remain unchanged.

## Performance, Complexity, and Resource Impact

No Via runtime path changes are introduced by this PR. There are no new runtime RPCs, DB calls, locks, serialization paths, background workers, migrations, or deployed services.

| Dimension | Before | After | Notes |
|---|---|---|---|
| Runtime work | No change | No change | Source/runtime behavior is unchanged. |
| Local structural check work | No Via structural scan | Four scoped ast-grep scans | One scoped scan per active rule family. |
| CI work | No Via structural workflow | Advisory structural workflow | Installs pinned ast-grep and runs checker. |
| Formatting work | Full-workspace formatting via `zkstack dev fmt` | Optional changed-files-only script | Experimental; not a required hook. |
| Net production LOC | 0 | 0 | Changes are tooling, docs, config, metadata, and workflows. |

## Boundaries and non-goals

This PR updates repository source, CI/workflow files, lint rules, metadata, docs, and local hook behavior only. No live infrastructure actions were run. No migrations, deployments, restarts, wallet actions, Kubernetes changes, Helm changes, DNS changes, cloud resources, or secret changes are included.

The structural rules are review aids. They do not prove that live deployments have a given behavior, and they do not replace source review of high-risk runtime changes. Existing baseline entries remain visible so follow-up work can remove them deliberately.

The formatting script is experimental and not enabled as a required pre-commit hook or CI gate. Repository-wide formatting through `zkstack dev fmt` remains the standard full-workspace formatter.

## How to review

Focus review on the tooling boundaries and signal quality:

- Check `.github/scripts/check-via-structural-rules.sh` for scanner error handling, scoped rule execution, baseline behavior, and strict/advisory exit semantics.
- Check `.github/lint/via-structural/ast-grep/` for rule intent, fixtures, scoping comments, and the known-findings baseline.
- Check `.github/workflows/via-structural-rules.yml` for pinned ast-grep installation and advisory CI behavior.
- Check `.github/workflows/pr-template-check.yml` for PR body parsing, pagination, sibling-path awareness, and false-positive handling for `Not applicable` sections.
- Check `.github/sibling-paths.yml`, `.github/via-areas.yml`, and `.github/via-scopes.yml` for path coverage and whether the `via-structural` area/scope mapping is sufficient.
- Check `scripts/format-changed.sh` and `docs/formatting.md` for changed-files-only behavior and consistency with local per-directory `rustfmt.toml` files.

For the structural rules, reviewers should compare main-node and verifier sibling paths listed in `.github/sibling-paths.yml`, especially reorg detector and DA client paths. The expected current strict result is that known baseline warnings are printed but do not fail the check; new findings should fail strict mode.

## Checks run

```bash
git diff --check
bash -n .github/scripts/check-via-structural-rules.sh .githooks/pre-push scripts/format-changed.sh
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/lint/via-structural/ast-grep/rules/via-da-batch-before-proof.yml .github/lint/via-structural/ast-grep/sgconfig.yml .github/via-areas.yml
just via-check-strict
```

Additional validation performed for the ast-grep workflow install path:

```bash
sha256sum /tmp/ast-grep-0.42.0.zip
unzip -l /tmp/ast-grep-0.42.0.zip
unzip -o /tmp/ast-grep-0.42.0.zip ast-grep -d /tmp/ast-grep-install-test
/tmp/ast-grep-install-test/ast-grep --version
```

Not run: `zkstack dev fmt`, `zkstack dev lint`, and `cargo test -p <crate>`. This PR does not change Rust production runtime code; validation focused on shell syntax, YAML parsing, ast-grep execution, changed structural rule behavior, and workflow install correctness.

## Live Infrastructure And Deployment Impact

No live infrastructure actions were run.

Merging this PR changes source-controlled governance, linting, workflow, metadata, docs, and local developer tooling only. Any future enforcement change from advisory linting to a blocking CI policy remains a separate review decision.