### PR TITLE
fix(reorg-detector): tolerate sparse via_l1_blocks during bootstrap

### DIFF
--- a/core/node/via_main_node_reorg_detector/src/compare.rs
+++ b/core/node/via_main_node_reorg_detector/src/compare.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+/// Returns the lowest height in `start_height..start_height + chain_hashes.len()` where
+/// `db_blocks` records a block hash that differs from the canonical chain hash.
+///
+/// `db_blocks` is allowed to be sparse: heights present on the canonical chain but absent
+/// in `db_blocks` are ignored instead of being treated as divergences. This keeps a
+/// freshly-bootstrapped detector (whose `via_l1_blocks` may only hold the wallet bootstrap
+/// row) from falsely reporting a reorg by comparing rows positionally.
+pub(crate) fn find_reorg_start_height(
+    start_height: i64,
+    chain_hashes: &[String],
+    db_blocks: &[(i64, String)],
+) -> Option<i64> {
+    let db: HashMap<i64, &str> = db_blocks.iter().map(|(n, h)| (*n, h.as_str())).collect();
+    for (i, chain_hash) in chain_hashes.iter().enumerate() {
+        let height = start_height + i as i64;
+        if let Some(db_hash) = db.get(&height) {
+            if chain_hash != db_hash {
+                return Some(height);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(s: &str) -> String {
+        s.to_string()
+    }
+
+    #[test]
+    fn sparse_db_with_only_bootstrap_row_does_not_trigger_reorg() {
+        // Reproduces the Hetzner false-positive: only the wallet bootstrap row is present
+        // in `via_l1_blocks`, but `list_l1_blocks(start, window)` returns it and
+        // `fetch_blocks(start..=end)` returns the dense canonical window.
+        let start_height = 100_792;
+        let chain_hashes: Vec<String> = (start_height..=100_891)
+            .map(|n| format!("canonical-{n}"))
+            .collect();
+        let db_blocks = vec![(100_891, h("canonical-100891"))];
+
+        assert_eq!(
+            find_reorg_start_height(start_height, &chain_hashes, &db_blocks),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_db_does_not_trigger_reorg() {
+        let chain_hashes = vec![h("a"), h("b"), h("c")];
+        assert_eq!(find_reorg_start_height(10, &chain_hashes, &[]), None);
+    }
+
+    #[test]
+    fn matching_dense_window_does_not_trigger_reorg() {
+        let chain_hashes = vec![h("a"), h("b"), h("c")];
+        let db_blocks = vec![(10, h("a")), (11, h("b")), (12, h("c"))];
+        assert_eq!(find_reorg_start_height(10, &chain_hashes, &db_blocks), None);
+    }
+
+    #[test]
+    fn divergence_is_reported_by_height_not_position() {
+        // DB row at 12 disagrees with canonical chain; 10 and 11 absent in DB.
+        let chain_hashes = vec![h("a"), h("b"), h("c")];
+        let db_blocks = vec![(12, h("c-other"))];
+        assert_eq!(
+            find_reorg_start_height(10, &chain_hashes, &db_blocks),
+            Some(12)
+        );
+    }
+
+    #[test]
+    fn earliest_divergent_height_is_returned() {
+        let chain_hashes = vec![h("a"), h("b"), h("c"), h("d")];
+        let db_blocks = vec![
+            (10, h("a")),
+            (11, h("b-other")),
+            (12, h("c")),
+            (13, h("d-other")),
+        ];
+        assert_eq!(
+            find_reorg_start_height(10, &chain_hashes, &db_blocks),
+            Some(11)
+        );
+    }
+}

--- a/core/node/via_main_node_reorg_detector/src/lib.rs
+++ b/core/node/via_main_node_reorg_detector/src/lib.rs
@@ -7,8 +7,12 @@ use via_btc_client::{client::BitcoinClient, traits::BitcoinOps};
 use zksync_config::configs::via_reorg_detector::ViaReorgDetectorConfig;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 
-use crate::metrics::{ReorgType, METRICS};
+use crate::{
+    compare::find_reorg_start_height,
+    metrics::{ReorgType, METRICS},
+};
 
+mod compare;
 mod metrics;
 
 #[derive(Debug)]
@@ -104,17 +108,26 @@ impl ViaMainNodeReorgDetector {
         match storage.via_l1_block_dal().get_last_l1_block().await? {
             Some(_) => {}
             None => {
-                let block_height = storage
+                let bootstrap_height = storage
                     .via_indexer_dal()
                     .get_last_processed_l1_block("via_btc_watch")
                     .await? as i64;
 
-                let block = self.btc_client.fetch_block(block_height as u128).await?;
+                // Seed a coherent reorg-window-sized prefix ending at the wallet bootstrap
+                // block so subsequent `detect_reorg()` calls have dense local state and
+                // cannot misalign DB rows against canonical chain rows by zip position.
+                let window = self.config.reorg_window();
+                let from_height = (bootstrap_height - window + 1).max(1);
+                let blocks = self.fetch_blocks(from_height, bootstrap_height).await?;
 
-                storage
-                    .via_l1_block_dal()
-                    .insert_l1_block(block_height, block.block_hash().to_string())
-                    .await?;
+                let mut transaction = storage.start_transaction().await?;
+                for (height, block) in (from_height..=bootstrap_height).zip(blocks) {
+                    transaction
+                        .via_l1_block_dal()
+                        .insert_l1_block(height, block.block_hash().to_string())
+                        .await?;
+                }
+                transaction.commit().await?;
             }
         };
 
@@ -198,24 +211,20 @@ impl ViaMainNodeReorgDetector {
 
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+        let chain_hashes: Vec<String> = chain_blocks
+            .iter()
+            .map(|b| b.block_hash().to_string())
+            .collect();
 
-        let mut reorg_start_block_height_opt = None;
-
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
-        }
-
-        if reorg_start_block_height_opt.is_none() {
+        // Compare by explicit block height to stay correct when `db_blocks` is sparse
+        // (e.g. a freshly bootstrapped external node where `via_l1_blocks` only holds the
+        // wallet bootstrap row); zip-by-position would otherwise pair mismatched heights.
+        let Some(mut reorg_start_block_height) =
+            find_reorg_start_height(start_height, &chain_hashes, &db_blocks)
+        else {
             return Ok(());
-        }
-
-        let Some(mut reorg_start_block_height) = reorg_start_block_height_opt else {
-            anyhow::bail!("Reorg start block height not found");
         };
+        tracing::warn!("Reorg detected at block {}", reorg_start_block_height);
 
         let last_processed_l1_block = storage
             .via_indexer_dal()

--- a/via_verifier/node/via_reorg_detector/src/compare.rs
+++ b/via_verifier/node/via_reorg_detector/src/compare.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+/// Returns the lowest height in `start_height..start_height + chain_hashes.len()` where
+/// `db_blocks` records a block hash that differs from the canonical chain hash.
+///
+/// `db_blocks` is allowed to be sparse: heights present on the canonical chain but absent
+/// in `db_blocks` are ignored instead of being treated as divergences. This keeps a
+/// freshly-bootstrapped detector (whose `via_l1_blocks` may only hold the wallet bootstrap
+/// row) from falsely reporting a reorg by comparing rows positionally.
+pub(crate) fn find_reorg_start_height(
+    start_height: i64,
+    chain_hashes: &[String],
+    db_blocks: &[(i64, String)],
+) -> Option<i64> {
+    let db: HashMap<i64, &str> = db_blocks.iter().map(|(n, h)| (*n, h.as_str())).collect();
+    for (i, chain_hash) in chain_hashes.iter().enumerate() {
+        let height = start_height + i as i64;
+        if let Some(db_hash) = db.get(&height) {
+            if chain_hash != db_hash {
+                return Some(height);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(s: &str) -> String {
+        s.to_string()
+    }
+
+    #[test]
+    fn sparse_db_with_only_bootstrap_row_does_not_trigger_reorg() {
+        let start_height = 100_792;
+        let chain_hashes: Vec<String> = (start_height..=100_891)
+            .map(|n| format!("canonical-{n}"))
+            .collect();
+        let db_blocks = vec![(100_891, h("canonical-100891"))];
+
+        assert_eq!(
+            find_reorg_start_height(start_height, &chain_hashes, &db_blocks),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_db_does_not_trigger_reorg() {
+        let chain_hashes = vec![h("a"), h("b"), h("c")];
+        assert_eq!(find_reorg_start_height(10, &chain_hashes, &[]), None);
+    }
+
+    #[test]
+    fn matching_dense_window_does_not_trigger_reorg() {
+        let chain_hashes = vec![h("a"), h("b"), h("c")];
+        let db_blocks = vec![(10, h("a")), (11, h("b")), (12, h("c"))];
+        assert_eq!(find_reorg_start_height(10, &chain_hashes, &db_blocks), None);
+    }
+
+    #[test]
+    fn divergence_is_reported_by_height_not_position() {
+        let chain_hashes = vec![h("a"), h("b"), h("c")];
+        let db_blocks = vec![(12, h("c-other"))];
+        assert_eq!(
+            find_reorg_start_height(10, &chain_hashes, &db_blocks),
+            Some(12)
+        );
+    }
+
+    #[test]
+    fn earliest_divergent_height_is_returned() {
+        let chain_hashes = vec![h("a"), h("b"), h("c"), h("d")];
+        let db_blocks = vec![
+            (10, h("a")),
+            (11, h("b-other")),
+            (12, h("c")),
+            (13, h("d-other")),
+        ];
+        assert_eq!(
+            find_reorg_start_height(10, &chain_hashes, &db_blocks),
+            Some(11)
+        );
+    }
+}

--- a/via_verifier/node/via_reorg_detector/src/lib.rs
+++ b/via_verifier/node/via_reorg_detector/src/lib.rs
@@ -8,8 +8,12 @@ use via_verifier_dal::{Verifier, VerifierDal};
 use zksync_config::configs::via_reorg_detector::ViaReorgDetectorConfig;
 use zksync_dal::{Connection, ConnectionPool};
 
-use crate::metrics::{ReorgInfo, METRICS};
+use crate::{
+    compare::find_reorg_start_height,
+    metrics::{ReorgInfo, METRICS},
+};
 
+mod compare;
 mod metrics;
 
 #[derive(Debug)]
@@ -91,17 +95,26 @@ impl ViaVerifierReorgDetector {
         match storage.via_l1_block_dal().get_last_l1_block().await? {
             Some(_) => {}
             None => {
-                let block_height = storage
+                let bootstrap_height = storage
                     .via_indexer_dal()
                     .get_last_processed_l1_block("via_btc_watch")
                     .await? as i64;
 
-                let block = self.btc_client.fetch_block(block_height as u128).await?;
+                // Seed a coherent reorg-window-sized prefix ending at the wallet bootstrap
+                // block so subsequent `detect_reorg()` calls have dense local state and
+                // cannot misalign DB rows against canonical chain rows by zip position.
+                let window = self.config.reorg_window();
+                let from_height = (bootstrap_height - window + 1).max(1);
+                let blocks = self.fetch_blocks(from_height, bootstrap_height).await?;
 
-                storage
-                    .via_l1_block_dal()
-                    .insert_l1_block(block_height, block.block_hash().to_string())
-                    .await?;
+                let mut transaction = storage.start_transaction().await?;
+                for (height, block) in (from_height..=bootstrap_height).zip(blocks) {
+                    transaction
+                        .via_l1_block_dal()
+                        .insert_l1_block(height, block.block_hash().to_string())
+                        .await?;
+                }
+                transaction.commit().await?;
             }
         };
 
@@ -205,26 +218,20 @@ impl ViaVerifierReorgDetector {
 
         // Fetch chain blocks in batch
         let chain_blocks = self.fetch_blocks(start_height, block_height).await?;
+        let chain_hashes: Vec<String> = chain_blocks
+            .iter()
+            .map(|b| b.block_hash().to_string())
+            .collect();
 
-        // let mut reorg_found = false;
-        let mut reorg_start_block_height_opt = None;
-
-        for ((db_number, db_hash), chain_block) in db_blocks.iter().zip(chain_blocks.iter()) {
-            if chain_block.block_hash().to_string() != *db_hash {
-                tracing::warn!("Reorg detected at block {}", db_number);
-                // reorg_found = true;
-                reorg_start_block_height_opt = Some(*db_number);
-                break;
-            }
-        }
-
-        if reorg_start_block_height_opt.is_none() {
+        // Compare by explicit block height to stay correct when `db_blocks` is sparse
+        // (e.g. a freshly bootstrapped verifier where `via_l1_blocks` only holds the
+        // wallet bootstrap row); zip-by-position would otherwise pair mismatched heights.
+        let Some(mut reorg_start_block_height) =
+            find_reorg_start_height(start_height, &chain_hashes, &db_blocks)
+        else {
             return Ok(false);
-        }
-
-        let Some(mut reorg_start_block_height) = reorg_start_block_height_opt else {
-            anyhow::bail!("Reorg start block height not found");
         };
+        tracing::warn!("Reorg detected at block {}", reorg_start_block_height);
 
         let last_processed_l1_block = storage
             .via_indexer_dal()


### PR DESCRIPTION
## Why

A freshly bootstrapped Via external node (and the verifier replica) can have system wallet rows and `via_btc_watch` metadata while `via_l1_blocks` is empty or sparse. The previous reorg-detector bootstrap path seeded **one** L1 block in `init()` when `via_l1_blocks` was empty, and then `detect_reorg()` compared a fixed `reorg_window` (100) of canonical chain blocks against the DB window using `db_blocks.iter().zip(chain_blocks.iter())`.

With a single DB row at the wallet bootstrap height (e.g. `100891`) and 100 canonical rows for `100792..=100891`, the zip paired DB row `100891` against canonical `100792`, producing:

```
Reorg detected at block 100891
```

Soft-reorg handling then rewound `via_btc_watch` to `100890`, hiding the wallet bootstrap row on the next restart and causing wallet-resource startup failures during the Hetzner private external-node rehearsal.

The unsafe invariant in this repo was that `list_l1_blocks(start_height, window)` does not assert dense coverage, but the comparison loop assumed dense, positionally-aligned rows. A freshly-bootstrapped detector therefore could not safely run a single iteration. The runtime correctness issue exists even though infra-side recovery automation was added separately.

## What changed

- `ViaMainNodeReorgDetector::init()` and `ViaVerifierReorgDetector::init()` now seed a coherent reorg-window-sized prefix ending at the wallet bootstrap block (`via_btc_watch` last processed) inside a single DB transaction, so subsequent detector iterations always run against dense local state.
- `detect_reorg()` in both detectors no longer zips DB rows against canonical rows. A new per-crate helper `find_reorg_start_height(start_height, chain_hashes, db_blocks)` compares by explicit block height; heights present on the canonical chain but absent in the DB window are ignored instead of being treated as divergences.
- The same fix is applied to both `core/node/via_main_node_reorg_detector` and `via_verifier/node/via_reorg_detector`, which share the same invariant (and the same bug).
- Added five unit tests per crate covering: sparse-bootstrap-only window (the `100792..=100891` regression case), empty DB, dense match, divergence reported by height (not position), and earliest-of-multiple divergences.

## Performance / Complexity Impact

`detect_reorg()` work is unchanged asymptotically. The new comparison builds a `HashMap<i64, &str>` over at most `reorg_window` (100) DB rows once per iteration and then iterates the canonical hashes linearly. `init()` now performs `reorg_window` concurrent block fetches in the empty-DB case (still bounded by `max_concurrent_fetches`, default 10) and one batched insert transaction.

| Operation                          | Before              | After                  | Notes |
|------------------------------------|---------------------|------------------------|-------|
| `init()` seed (empty DB)           | 1 fetch + 1 insert  | up to `window` fetches + 1 tx | One-time per bootstrap. |
| `detect_reorg()` window comparison | O(window) zip       | O(window) HashMap lookup | Same complexity; one extra small allocation per iteration. |
| `detect_reorg()` correctness       | Sparse DB → false reorg | Sparse DB → safe no-reorg | Behavior fix. |

No hot-path allocations beyond the window size were added. No DAL signatures, schema, metrics, or config keys changed.

## Boundaries and non-goals

- This PR updates source code and unit tests only; no live deployment, database mutation, secret access, or infra change was run from this branch.
- The reorg window size remains hardcoded at 100 in `via_reorg_detector::reorg_window()`; this PR does not retune it.
- Downstream soft/hard reorg recovery logic is unchanged. The fix prevents triggering it falsely; it does not alter how a real reorg is handled.
- No upstream-derived ZKsync paths were touched; both detectors are Via-specific (`via_main_node_reorg_detector`, `via_verifier_reorg_detector`).
- `list_l1_blocks` in `core/lib/dal/src/via_l1_block_dal.rs` and `via_verifier/lib/verifier_dal/src/via_l1_block_dal.rs` is left as-is; sparsity is now an expected input to the detector rather than something the DAL asserts away.
- The two compare helpers are duplicated per crate (one for `Core`, one for `Verifier`) instead of being shared because the surrounding code bases use different DAL types; a new shared workspace crate solely for a 15-line pure helper was deemed less reviewable than the per-crate duplicate. See AGENTS.md `Reuse-first` note on non-reuse decisions.
- Reviewers should compare the behavior against the new unit tests and the real `list_l1_blocks` semantics; no live cluster, kube-state, or helm-charts change is required to land this PR.

## Checks run

```bash
cargo build -p via_main_node_reorg_detector -p via_verifier_reorg_detector
cargo test  -p via_main_node_reorg_detector -p via_verifier_reorg_detector
cargo fmt   -p via_main_node_reorg_detector -p via_verifier_reorg_detector -- --check
cargo clippy -p via_main_node_reorg_detector -p via_verifier_reorg_detector --all-targets
```

All ten new unit tests pass. `cargo fmt --check` is clean on the touched crates. `cargo clippy --all-targets` is clean on the touched crates; pre-existing clippy diagnostics in `zksync_types` and `zksync_dal` reproduce on `main` and are out of scope here.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.

## Live infrastructure and deployment impact

- No live infrastructure actions were run.
- Merging this PR changes Rust source and unit tests only and is not expected to deploy live services by itself. It can affect future images built from `main`; rollout to a live environment remains a separate deployment approval and verification step, and the infra-side recovery automation referenced in the issue continues to apply to any pre-existing fresh/sparse external-node DBs.
