### PR TITLE
ci(via): move core release checks to github-hosted runners

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -8,6 +8,9 @@ on:
       DOCKERHUB_TOKEN:
         description: "DOCKERHUB_TOKEN"
         required: true
+      GAR_JSON_KEY:
+        description: "Google Artifact Registry service account JSON key"
+        required: false
     inputs:
       image_tag_suffix:
         description: "Optional suffix to override tag name generation"
@@ -22,11 +25,12 @@ on:
 jobs:
   prepare-contracts:
     name: Prepare contracts
-    runs-on: [self-hosted, cpu]
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
+          persist-credentials: false
 
       - name: Prepare ENV
         shell: bash
@@ -45,7 +49,7 @@ jobs:
           yarn workspace system-contracts build
 
       - name: Upload contracts
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: contacts
           path: |
@@ -56,7 +60,7 @@ jobs:
     needs: prepare-contracts
     env:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
-    runs-on: ${{ fromJSON('["cpu", "cpu-arm"]')[contains(matrix.platforms, 'arm')] }}
+    runs-on: ${{ fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')[contains(matrix.platforms, 'arm')] }}
     strategy:
       matrix:
         components:
@@ -70,12 +74,13 @@ jobs:
             platforms: linux/arm64
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       - name: Setup env
         shell: bash
@@ -88,16 +93,19 @@ jobs:
 
       - name: Set env vars
         shell: bash
+        env:
+          MATRIX_PLATFORM: ${{ matrix.platforms }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          echo PLATFORM=$(echo ${{ matrix.platforms }} | tr '/' '-') >> $GITHUB_ENV
-          if [ -n "${{ inputs.image_tag_suffix }}" ]; then
-            echo IMAGE_TAG_SHA_TS="${{ env.IMAGE_TAG_SUFFIX }}" >> $GITHUB_ENV
+          echo PLATFORM=$(echo "$MATRIX_PLATFORM" | tr '/' '-') >> $GITHUB_ENV
+          if [ -n "$IMAGE_TAG_SUFFIX" ]; then
+            echo IMAGE_TAG_SHA_TS="$IMAGE_TAG_SUFFIX" >> $GITHUB_ENV
           else
             echo IMAGE_TAG_SHA_TS=$(git rev-parse --short HEAD)-$(date +%s) >> $GITHUB_ENV
           fi
 
       - name: Download contracts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: contacts
           path: |
@@ -106,11 +114,20 @@ jobs:
       - name: login to Docker registries
         if: ${{ inputs.action == 'push' }}
         shell: bash
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          if [ -z "$GAR_JSON_KEY" ]; then
+            echo "GAR_JSON_KEY is required when publishing images to Artifact Registry" >&2
+            exit 1
+          fi
+          printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
+          printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
 
       - name: Build docker image
-        uses: docker/build-push-action@v6.7.0
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
           context: .
           load: true
@@ -122,13 +139,15 @@ jobs:
 
       - name: Push docker image
         if: ${{ inputs.action == 'push' }}
+        env:
+          COMPONENT: ${{ matrix.components }}
         run: |
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
-          docker push vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}      
+          docker push "europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}"
+          docker push "vianetwork/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}"
 
   create_manifest:
     name: Create release manifest
-    runs-on: [self-hosted, cpu]
+    runs-on: ubuntu-24.04
     needs: build-images
     if: ${{ inputs.action == 'push' }}
     strategy:
@@ -144,11 +163,23 @@ jobs:
     env:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: login to Docker registries
+        shell: bash
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          if [ -z "$GAR_JSON_KEY" ]; then
+            echo "GAR_JSON_KEY is required when publishing manifests to Artifact Registry" >&2
+            exit 1
+          fi
+          printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
+          printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
 
       - name: Create Docker manifest
         run: |

--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -6,6 +6,16 @@ on:
         description: "Tag of an image to built"
         type: string
         required: true
+    secrets:
+      DOCKERHUB_USER:
+        description: "DOCKERHUB_USER"
+        required: true
+      DOCKERHUB_TOKEN:
+        description: "DOCKERHUB_TOKEN"
+        required: true
+      GAR_JSON_KEY:
+        description: "Google Artifact Registry service account JSON key"
+        required: false
   workflow_dispatch:
     inputs:
       tag_name:
@@ -20,6 +30,9 @@ on:
 
 concurrency: docker-build
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup
@@ -28,18 +41,23 @@ jobs:
       image_tag_suffix: ${{ steps.set.outputs.image_tag_suffix }}
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Generate output with git tag
         id: set
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
           git_tag=""
-          if [[ -z "${{ inputs.tag_name }}" ]]; then
+          if [[ -z "$INPUT_TAG_NAME" ]]; then
             git_tag="${GITHUB_REF#refs/*/}"
           else
-            git_tag="${{ inputs.tag_name }}"
+            git_tag="$INPUT_TAG_NAME"
           fi
-          version=$(cut -d "-" -f2 <<< ${git_tag})
-          echo "image_tag_suffix=${version}" >> $GITHUB_OUTPUT
+          version=$(cut -d "-" -f2 <<< "$git_tag")
+          echo "image_tag_suffix=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Generate outputs with Prover FRI setup data keys IDs
         id: extract-prover-fri-setup-key-ids
@@ -54,6 +72,7 @@ jobs:
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       action: "push"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changed_files:
     runs-on: ubuntu-latest
@@ -23,14 +26,15 @@ jobs:
       docs: ${{ steps.changed-files.outputs.docs_any_changed }}
       all: ${{ steps.changed-files.outputs.all_any_changed }}
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
           submodules: "recursive"
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@48566bbcc22ceb7c5809ebdd27377309f2c3de8c # v39
         with:
           files_yaml: |
             prover:

--- a/.github/workflows/release-please-cargo-lock.yml
+++ b/.github/workflows/release-please-cargo-lock.yml
@@ -4,12 +4,16 @@ on:
       - release-please--branches--main--components--core
 
 name: release-please-update-cargo-lock
+
+permissions:
+  contents: read
+
 jobs:
   update_cargo_lock:
-    runs-on: [self-hosted, cpu]
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: "recursive"
           persist-credentials: false


### PR DESCRIPTION
## Why

Core release checks can queue indefinitely when workflow jobs request runner labels that are not available to the repository or organization. The release-please Cargo.lock updater and the reusable core image build workflow requested self-hosted/custom runner labels, which prevented release PR checks from reaching the actual Cargo.lock update or Docker build steps.

The source workflow path should use available GitHub-hosted runners for the PR build and release-check path. This keeps CI reviewable from source and avoids treating deployment runner availability as a hidden prerequisite for ordinary release PR validation.

## What changed

- Moved the release-please Cargo.lock updater to `ubuntu-24.04`.
- Moved the reusable core image workflow's contract preparation, image build matrix, and manifest creation jobs to GitHub-hosted Linux runners, including GitHub-hosted arm64 for the arm image matrix.
- Hardened the active core CI/release workflow path with explicit read-only permissions, immutable action SHAs, `persist-credentials: false` for checkout, and shell environment indirection for workflow inputs used by `run:` blocks.
- Updated `actions/checkout` pins in the audited path to `v6.0.2`.
- Added explicit Artifact Registry Docker authentication for tag publishing through the `GAR_JSON_KEY` secret.

## Reuse & Duplication

Not applicable — this is a CI workflow change and does not add or change production runtime logic in a `via_*` path.

## Performance, Complexity, and Resource Impact

Not applicable — this changes GitHub Actions runner selection and workflow hardening only. Runtime behavior, database access, RPC behavior, image contents, and application resource usage are unchanged.

## Boundaries and non-goals

This does not provision self-hosted runners.

This does not run or prove production image publishing. The PR build path uses `action: "build"`, while tag/release publishing uses `action: "push"` and now requires the `GAR_JSON_KEY` repository secret to contain a Google Artifact Registry service account JSON key with permission to push to `europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via`.

No live deployment, migration, Kubernetes resource, Helm release, cloud resource, DNS record, host service, or secret value was changed by this PR.

## How to review

Review the active workflow path for core release PR validation:

- `.github/workflows/release-please-cargo-lock.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/build-core-template.yml`
- `.github/workflows/build-docker-from-tag.yml`

The main review points are runner availability, reusable workflow caller compatibility, checkout/action pinning, and the `GAR_JSON_KEY` secret contract for release image publishing from GitHub-hosted runners.

## Checks run

```bash
git diff --check

zizmor --format plain \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/release-please-cargo-lock.yml \
  .github/workflows/build-core-template.yml

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/release-please-cargo-lock.yml \
  .github/workflows/build-core-template.yml
```
