### PR TITLE
ci(via): use buildx direct push for core images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
 *
+# Keep the Docker build context as an allowlist. Core image builds copy broad
+# repository paths, so add only files and directories required by Dockerfiles.
 !docker/prover/prover-entry.sh
 !docker/local-node/entrypoint.sh
 !docker/external-node/entrypoint.sh
 !docker/contract-verifier/install-all-solc.sh
+!docker/via-server/Dockerfile
+!docker/via-external-node/Dockerfile
+!docker/snapshots-creator/Dockerfile
 !etc/test_config
 !etc/env/target/dev.env.example
 !etc/env/target/docker.env

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -22,6 +22,9 @@ on:
         required: false
         default: "do nothing"
 
+permissions:
+  contents: read
+
 jobs:
   prepare-contracts:
     name: Prepare contracts
@@ -127,6 +130,7 @@ jobs:
           printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
 
       - name: Build docker image
+        if: ${{ inputs.action != 'push' }}
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
           context: .
@@ -136,18 +140,31 @@ jobs:
           tags: |
             europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
             vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+          cache-from: type=gha,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
 
-      - name: Push docker image
+      - name: Build and push docker image
         if: ${{ inputs.action == 'push' }}
-        env:
-          COMPONENT: ${{ matrix.components }}
-        run: |
-          docker push "europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}"
-          docker push "vianetwork/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}"
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        with:
+          context: .
+          push: true
+          platforms: ${{ matrix.platforms }}
+          file: docker/${{ matrix.components }}/Dockerfile
+          tags: |
+            europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+            vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+          # Release manifests are assembled from these platform tags with
+          # `docker manifest create`; keep tags free of Buildx attestation
+          # descriptors. SBOM generation is controlled separately.
+          provenance: false
+          cache-from: type=gha,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
+          cache-to: type=gha,mode=max,ignore-error=true,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
 
   create_manifest:
     name: Create release manifest
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: build-images
     if: ${{ inputs.action == 'push' }}
     strategy:

--- a/docker/via-server/Dockerfile
+++ b/docker/via-server/Dockerfile
@@ -15,9 +15,9 @@ ENV RUSTC_WRAPPER=${RUSTC_WRAPPER}
 
 WORKDIR /usr/src/via
 
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev git && rm -rf /var/lib/apt/lists/*
 COPY . .
 
-RUN apt-get update && apt-get install -y protobuf-compiler git && rm -rf /var/lib/apt/lists/*
 RUN cargo build --release --bin via_server --bin via_block_reverter_cli --bin merkle_tree_consistency_checker
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Why

Core image builds now run on GitHub-hosted runners. The first BuildKit cache run proved the workflow still builds, but it also showed that exporting large `mode=max` caches from PR builds is currently expensive: roughly 2-5.5 minutes per image on the first successful run.

This PR keeps the low-risk Buildx plumbing and direct release push path, but avoids making every PR image build pay the cache export cost. PR builds now import any available BuildKit cache and load the image locally. Release/tag builds push directly with Buildx and export cache for later reuse.

This PR intentionally does not add `cargo-chef`, `sccache`, larger runners, matrix narrowing, remote builders, or base-image digest pinning. Those remain separate decisions with larger review surfaces.

## What changed

- Switched release image publishing from `load: true` plus separate `docker push` commands to Buildx direct push when `action: "push"`.
- Kept PR builds loading images locally with `load: true` when `action != "push"`.
- Split the Buildx step so PR builds use `cache-from` only and do not export cache.
- Kept release/tag builds using `cache-from` and `cache-to: type=gha,mode=max,ignore-error=true` while pushing directly.
- Added explicit workflow permissions so the reusable workflow defaults to read-only `contents: read`.
- Kept Buildx provenance disabled for this manifest assembly path because release manifests are still built with `docker manifest create` from the platform tags; SBOM generation remains separate and is not enabled by this workflow.
- Moved the `via-server` builder package install before `COPY . .` so the package layer is not invalidated by source changes.
- Documented the existing `.dockerignore` allowlist model and explicitly whitelisted the core image Dockerfiles.

## Reuse & Duplication

Not applicable — this is a CI/Docker build plumbing change and does not add or change production runtime logic in a `via_*` path.

## Performance, Complexity, and Resource Impact

The previous PR run showed that `mode=max` cache export works but adds a large first-run cost on PR builds. This version removes PR cache export, so PR builds should avoid that export tax while still consuming any available cache.

Warm-cache impact is still expected to be modest until a later `cargo-chef` change separates dependency compilation from source compilation. The main Rust compile layer still rebuilds on source changes because the Dockerfiles still use `COPY . .` before `cargo build`.

Release/tag builds may spend extra time exporting cache. That is acceptable for the publishing path because it can seed cache for later reuse and no longer relies on local image load plus separate shell `docker push` commands. Cache export uses the GitHub Actions runtime cache token provided to the runner, and `ignore-error=true` keeps cache upload failures from failing a successful image push.

## Boundaries and non-goals

This does not change runtime image contents intentionally.

This does not pin base images by digest.

This does not add `cargo-chef`, `sccache`, larger runners, remote builders, self-hosted runners, or matrix narrowing.

This does not run or prove production image publishing. The release path now uses Buildx direct push when `action: "push"`, while PR validation still uses `action: "build"`.

## How to review

Review `.github/workflows/build-core-template.yml` for the split Buildx behavior: PR builds import cache only and load locally; release builds push directly and export cache. Review `docker/via-server/Dockerfile` to confirm the package-install layer moved before source copy without changing the build command. Review `.dockerignore` as an allowlist; this PR does not replace it with a broad denylist.

## Checks run

```bash
git diff --check

zizmor --format plain \
  .github/workflows/build-core-template.yml \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/release-please-cargo-lock.yml

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/build-core-template.yml \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/release-please-cargo-lock.yml
```

Earlier PR run evidence before disabling PR cache export:

- Buildx cache import/export was active.
- `via-server` Rust compile still took about 24m04s, and cache export added about 4m36s.
- `via-external-node` Rust compile still took about 22m35s, and cache export added about 5m36s.
- This is why PR builds now avoid `cache-to`.
