### PR TITLE
perf(via): cache core Docker dependencies

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -59,11 +59,12 @@ jobs:
             ./contracts
 
   build-images:
-    name: Build and Push Docker Images
+    name: Build Docker Images
     needs: prepare-contracts
+    if: ${{ inputs.action != 'push' }}
     env:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
-    runs-on: ${{ fromJSON('["ubuntu-24.04", "ubuntu-24.04-arm"]')[contains(matrix.platforms, 'arm')] }}
+    runs-on: ${{ contains(matrix.platforms, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         components:
@@ -114,8 +115,87 @@ jobs:
           path: |
             ./contracts
 
+      - name: Build docker image
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        with:
+          context: .
+          load: true
+          platforms: ${{ matrix.platforms }}
+          file: docker/${{ matrix.components }}/Dockerfile
+          tags: |
+            europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+            vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+          cache-from: type=gha,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
+          cache-to: type=gha,mode=max,ignore-error=true,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
+
+  build-and-push-images:
+    name: Build and Push Docker Images
+    needs: prepare-contracts
+    if: ${{ inputs.action == 'push' }}
+    env:
+      IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
+    runs-on: ${{ contains(matrix.platforms, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    strategy:
+      matrix:
+        components:
+          - via-server
+          - via-external-node
+          - snapshots-creator
+        platforms:
+          - linux/amd64
+        include:
+          - components: via-external-node
+            platforms: linux/arm64
+
+    steps:
+      - name: Validate publish tag input
+        shell: bash
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
+        run: |
+          if [ -z "$IMAGE_TAG_SUFFIX" ]; then
+            echo "inputs.image_tag_suffix is required when inputs.action is 'push'" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: "recursive"
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Setup env
+        shell: bash
+        run: |
+          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
+          echo CI=1 >> $GITHUB_ENV
+          echo $(pwd)/bin >> $GITHUB_PATH
+          echo CI=1 >> .env
+          echo IN_DOCKER=1 >> .env
+
+      - name: Set env vars
+        shell: bash
+        env:
+          MATRIX_PLATFORM: ${{ matrix.platforms }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
+        run: |
+          echo PLATFORM=$(echo "$MATRIX_PLATFORM" | tr '/' '-') >> $GITHUB_ENV
+          if [ -n "$IMAGE_TAG_SUFFIX" ]; then
+            echo IMAGE_TAG_SHA_TS="$IMAGE_TAG_SUFFIX" >> $GITHUB_ENV
+          else
+            echo IMAGE_TAG_SHA_TS=$(git rev-parse --short HEAD)-$(date +%s) >> $GITHUB_ENV
+          fi
+
+      - name: Download contracts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: contacts
+          path: |
+            ./contracts
+
       - name: login to Docker registries
-        if: ${{ inputs.action == 'push' }}
         shell: bash
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -129,21 +209,7 @@ jobs:
           printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
           printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
 
-      - name: Build docker image
-        if: ${{ inputs.action != 'push' }}
-        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
-        with:
-          context: .
-          load: true
-          platforms: ${{ matrix.platforms }}
-          file: docker/${{ matrix.components }}/Dockerfile
-          tags: |
-            europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
-            vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
-          cache-from: type=gha,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
-
       - name: Build and push docker image
-        if: ${{ inputs.action == 'push' }}
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
           context: .
@@ -165,7 +231,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    needs: build-images
+    needs: build-and-push-images
     if: ${{ inputs.action == 'push' }}
     strategy:
       matrix:

--- a/docker/snapshots-creator/Dockerfile
+++ b/docker/snapshots-creator/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:experimental
-FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
+FROM lukemathwalker/cargo-chef:0.1.77-rust-bookworm AS cargo-chef
+
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS chef
 
 # set of args for use of sccache
 ARG SCCACHE_GCS_BUCKET=""
@@ -13,8 +15,23 @@ ENV SCCACHE_GCS_RW_MODE=${SCCACHE_GCS_RW_MODE}
 ENV RUSTC_WRAPPER=${RUSTC_WRAPPER}
 
 WORKDIR /usr/src/zksync
-COPY . .
 
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev git && rm -rf /var/lib/apt/lists/*
+
+COPY --from=cargo-chef /usr/local/cargo/bin/cargo-chef /usr/local/cargo/bin/cargo-chef
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS cacher
+COPY --from=planner /usr/src/zksync/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin snapshots_creator
+
+FROM chef AS builder
+COPY . .
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+COPY --from=cacher /usr/src/zksync/target target
 RUN cargo build --release --bin snapshots_creator
 
 FROM debian:bookworm-slim

--- a/docker/via-external-node/Dockerfile
+++ b/docker/via-external-node/Dockerfile
@@ -1,6 +1,8 @@
 # Will work locally only after prior contracts build
 
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM lukemathwalker/cargo-chef:0.1.77-rust-bookworm AS cargo-chef
+
+FROM matterlabs/zksync-build-base:latest AS chef
 
 # set of args for use of sccache
 ARG SCCACHE_GCS_BUCKET=""
@@ -14,8 +16,22 @@ ENV SCCACHE_GCS_RW_MODE=${SCCACHE_GCS_RW_MODE}
 ENV RUSTC_WRAPPER=${RUSTC_WRAPPER}
 
 WORKDIR /usr/src/via
-RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev git && rm -rf /var/lib/apt/lists/*
+
+COPY --from=cargo-chef /usr/local/cargo/bin/cargo-chef /usr/local/cargo/bin/cargo-chef
+
+FROM chef AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS cacher
+COPY --from=planner /usr/src/via/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin via_external_node
+
+FROM chef AS builder
+COPY . .
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+COPY --from=cacher /usr/src/via/target target
 RUN cargo build --release --bin via_external_node
 
 FROM debian:bookworm-slim

--- a/docker/via-server/Dockerfile
+++ b/docker/via-server/Dockerfile
@@ -1,6 +1,8 @@
-# Will work locally only after prior contracts build
 # syntax=docker/dockerfile:experimental
-FROM matterlabs/zksync-build-base:latest AS builder
+# Will work locally only after prior contracts build
+FROM lukemathwalker/cargo-chef:0.1.77-rust-bookworm AS cargo-chef
+
+FROM matterlabs/zksync-build-base:latest AS chef
 
 # set of args for use of sccache
 ARG SCCACHE_GCS_BUCKET=""
@@ -16,8 +18,21 @@ ENV RUSTC_WRAPPER=${RUSTC_WRAPPER}
 WORKDIR /usr/src/via
 
 RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev git && rm -rf /var/lib/apt/lists/*
-COPY . .
 
+COPY --from=cargo-chef /usr/local/cargo/bin/cargo-chef /usr/local/cargo/bin/cargo-chef
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS cacher
+COPY --from=planner /usr/src/via/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin via_server --bin via_block_reverter_cli --bin merkle_tree_consistency_checker
+
+FROM chef AS builder
+COPY . .
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+COPY --from=cacher /usr/src/via/target target
 RUN cargo build --release --bin via_server --bin via_block_reverter_cli --bin merkle_tree_consistency_checker
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Why

Core image builds now run on GitHub-hosted runners, and the slowest PR checks are still the Rust image builds. The previous Buildx cache PR proved the workflow can import cache, but the core Dockerfiles still copied the full source tree before `cargo build`, so normal source edits invalidated the Rust dependency compile layer.

This PR adds a dependency-layer cache for the core Docker images. The goal is to make warm-cache PR reruns and follow-up commits avoid recompiling the full Rust dependency graph for every image.

## What changed

- Split the reusable core image workflow into separate build-only and push-only matrix jobs.
- Kept PR builds on the build-only job with `cache-from`, `cache-to`, and `load: true`.
- Kept release/tag image publishing on the push-only job with direct Buildx push.
- Restored best-effort release/tag `cache-to: type=gha` export on the push-only job with `ignore-error=true`.
- Added a guard that fails push flows early if `image_tag_suffix` is empty.
- Refactored `docker/via-server/Dockerfile`, `docker/via-external-node/Dockerfile`, and `docker/snapshots-creator/Dockerfile` to use cargo-chef planner/cacher/builder stages.
- Copied a pinned prebuilt `cargo-chef` binary from `lukemathwalker/cargo-chef:0.1.77-rust-bookworm` instead of compiling cargo-chef during each cold Docker build.
- Copied Cargo home and cooked `target` output from the cacher stage into the final builder stage so final source builds can reuse registry/git state and compiled dependency artifacts.
- Installed protobuf and git build dependencies explicitly in the chef stages that need them.
- Replaced the workflow runner-selection array indexing expression with a direct `contains(...) && ... || ...` expression.
- Moved the via-server Dockerfile syntax directive to the first line so Docker recognizes it.

## Reuse & Duplication

Not applicable — this changes CI workflow structure and Docker build stages only. No production runtime logic in a `via_*` path is added or changed.

## Performance, Complexity, and Resource Impact

Measured on PR #370 after raising the repository Actions cache cap to 20 GiB.

| Path | Before cargo-chef baseline | Cold cargo-chef run | Warm cargo-chef run |
|---|---:|---:|---:|
| `via-server`, linux/amd64 | ~24m14s-24m24s | 33m01s | 14m01s |
| `via-external-node`, linux/amd64 | ~24m04s-24m08s | 31m17s | 14m34s |
| `via-external-node`, linux/arm64 | ~21m57s-22m39s | 33m34s | 14m42s |
| `snapshots-creator`, linux/amd64 | ~8m02s-8m19s | 16m59s | 5m46s |

The warm run completed the full PR critical path in about 19m35s, including `Get changed files`, `Prepare contracts`, the Docker matrix, and the final status check.

The via-server warm-run log confirms the mechanism:

- BuildKit imported the GitHub Actions cache.
- `cargo chef cook` restored the cooked dependency layer in about 59s instead of recompiling dependencies for about 15m.
- The final source `cargo build` still ran and took about 8m09s.
- Exporting the updated GHA cache still took about 2m40s for via-server.

The current PR merge-ref cache footprint is about 15.18 GiB. This PR therefore depends on a cache cap above the default 10 GiB for stable warm-cache behavior. Warm-cache savings are real, but they are contingent on cache retention and available repo cache headroom.

## Boundaries and non-goals

This does not introduce sccache, larger runners, remote builders, base image digest pinning, PR matrix narrowing, or a faster linker.

This intentionally keeps the existing `zksync-build-base:latest` policy. Pinning those base images would be a separate reproducibility/update-policy decision, not a requirement for cargo-chef correctness.

This does not prove production image publishing. The release/tag push path is adjusted in source, but live publishing remains a separate workflow run.

This does not yet change PR cache policy to import-only. A follow-up can move cache export to trusted main/tag/scheduled builds if multiple active PRs start competing for the repo-wide GHA cache budget.

## How to review

Review `.github/workflows/build-core-template.yml` for the separation between PR build jobs and release push jobs. The PR path should load local images for validation and refresh the PR-scoped BuildKit cache on a best-effort basis. The release path should direct-push images and refresh its BuildKit cache on a best-effort basis.

Review the three core Dockerfiles for cargo-chef stage ordering: dependencies are cooked from `recipe.json`, the full source tree is copied into the final builder, the cooked Cargo home and `target` directory are overlaid, and each final `cargo build` still builds the same image binaries.

## Checks run

```bash
git diff --check

zizmor --format plain \
  .github/workflows/build-core-template.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/ci.yml

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/build-core-template.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/ci.yml
```

Docker was not run locally because the local Docker daemon is unavailable in this environment; the PR image build matrix is the validation for the cargo-chef Dockerfile changes.