### PR TITLE
ci(via): restrict core build cache exports

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -21,6 +21,11 @@ on:
         type: string
         required: false
         default: "do nothing"
+      export_build_cache:
+        description: "Export BuildKit cache from trusted build-only callers"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -116,6 +121,20 @@ jobs:
             ./contracts
 
       - name: Build docker image
+        if: ${{ !inputs.export_build_cache }}
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        with:
+          context: .
+          load: true
+          platforms: ${{ matrix.platforms }}
+          file: docker/${{ matrix.components }}/Dockerfile
+          tags: |
+            europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+            vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+          cache-from: type=gha,scope=core-${{ matrix.components }}-${{ env.PLATFORM }}
+
+      - name: Build docker image and refresh cache
+        if: ${{ inputs.export_build_cache }}
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   merge_group:
   push:
     branches:
+      - main
       - staging
       - trying
       - '!release-please--branches--**'
@@ -34,7 +35,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@48566bbcc22ceb7c5809ebdd27377309f2c3de8c # v39
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files_yaml: |
             prover:
@@ -123,8 +124,8 @@ jobs:
     if: ${{ (needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true') && !contains(github.ref_name, 'release-please--branches') }}
     uses: ./.github/workflows/build-core-template.yml
     with:
-      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       action: "build"
+      export_build_cache: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/warm-core-build-cache.yml
+++ b/.github/workflows/warm-core-build-cache.yml
@@ -1,0 +1,25 @@
+name: Warm core image build cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+concurrency:
+  group: warm-core-image-build-cache
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  warm-core-build-cache:
+    name: Warm core build cache
+    if: ${{ github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/build-core-template.yml
+    with:
+      action: "build"
+      export_build_cache: true
+    secrets:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Why

PR #370 proved that cargo-chef materially improves warm-cache core image builds, but it also showed the BuildKit cache is large: the PR merge-ref cache reached about 15.18 GiB. Letting every pull request export `type=gha,mode=max` cache writes spends 2-3 minutes per Docker job exporting cache and can churn the repo-wide Actions cache budget when multiple PRs are active.

PR builds should read the shared core image cache, while only default-branch and explicitly scheduled repository-owned runs should refresh the cache that normal PRs can read.

## What changed

- Add an `export_build_cache` input to the reusable core image workflow.
- Keep build-only PR, merge-queue, staging, and trying jobs import-only by default with `cache-from` and no `cache-to`.
- Allow trusted build-only callers to opt into `cache-to` export.
- Set CI push builds to export cache only when the push ref is `refs/heads/main`.
- Add `main` to the CI push branches so merges to `main` refresh the shared core image cache.
- Remove the stale `needs.setup.outputs.image_tag_suffix` input from the CI build-only caller; the reusable workflow already generates a local SHA/timestamp tag when no suffix is provided.
- Update `tj-actions/changed-files` from the vulnerable pinned v39 commit to the pinned v47.0.6 commit after an online zizmor audit reported known vulnerable action advisories.
- Add a manual/weekly cache warmer workflow that runs every Monday at 03:17 UTC and exports the same core image cache scopes only when the workflow ref is `refs/heads/main`.

## Reuse & Duplication

Not applicable — this changes GitHub Actions workflow policy only. No production runtime logic in a `via_*` path is added or changed.

## Performance, Complexity, and Resource Impact

PR image builds still import the shared BuildKit cache via the existing `core-${component}-${platform}` scopes. They no longer export the full cache on every pull request run, avoiding the per-PR export tax and reducing churn against the repo-wide Actions cache cap.

Trusted refresh paths now own shared cache writes:

- `ci.yml` push runs on `main` export cache.
- `build-docker-from-tag.yml` publishing still exports cache through the push-only job.
- `warm-core-build-cache.yml` runs weekly at 03:17 UTC on Mondays and can be run manually, but the reusable workflow call is skipped unless the workflow ref is `refs/heads/main`.

Pushes to `staging` and `trying` still run CI, but they stay import-only because caches written from those refs are not useful to ordinary PRs targeting `main`.

The tradeoff is intentional: a PR that changes dependency metadata may have repeated cold `cargo chef cook` work until `main`, a tag-publish run, or the scheduled warmer refreshes the shared cache. That is preferable to every PR writing large `mode=max` caches.

## Boundaries and non-goals

This does not change Dockerfile contents, cargo-chef behavior, cache backend, Actions cache size limits, runner sizes, or linker settings.

This does not move cache storage to registry-backed cache. GitHub Actions cache remains the backend for this PR.

This does not add a repo-wide zizmor GitHub Actions integration. A repo-wide online scan currently reports unrelated findings in legacy/manual/self-hosted workflows, so that should be handled as a separate workflow-hardening PR before making zizmor a blocking CI check.

## Checks run

```bash
git diff --check

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/build-core-template.yml \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/warm-core-build-cache.yml

zizmor --gh-token "$(gh auth token)" --format plain \
  .github/workflows/build-core-template.yml \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/warm-core-build-cache.yml

zizmor --gh-token "$(gh auth token)" --format plain --persona=auditor \
  .github/workflows/build-core-template.yml \
  .github/workflows/ci.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/warm-core-build-cache.yml
```

The regular online zizmor audit passes. Auditor mode reports five low-severity help findings that are pre-existing or outside this PR's behavior change.

Docker was not run locally because this change only controls which GitHub Actions callers export BuildKit cache.