### PR TITLE
ci(via): audit core workflows with zizmor

### DIFF
--- a/.github/workflows/zizmor-audit.yml
+++ b/.github/workflows/zizmor-audit.yml
@@ -1,0 +1,110 @@
+name: Zizmor
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Audit core workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine audit scope
+        id: audit-scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          should_run=false
+          changed_files=""
+
+          list_changed_paths() {
+            git diff --name-status --find-renames "$1" "$2" | awk '
+              $1 ~ /^R/ || $1 ~ /^C/ { print $2; print $3; next }
+              NF >= 2 { print $2 }
+            '
+          }
+
+          case "${EVENT_NAME}" in
+            push)
+              if [[ -z "${BASE_SHA}" || "${BASE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+                should_run=true
+              elif ! changed_files="$(list_changed_paths "${BASE_SHA}" "${HEAD_SHA}")"; then
+                echo "Could not determine changed files for push; running audit."
+                should_run=true
+              fi
+              ;;
+            pull_request)
+              if ! changed_files="$(list_changed_paths "${BASE_SHA}" "${HEAD_SHA}")"; then
+                echo "Could not determine changed files for pull request; running audit."
+                should_run=true
+              fi
+              ;;
+            merge_group|workflow_dispatch)
+              should_run=true
+              ;;
+          esac
+
+          while IFS= read -r changed_file; do
+            case "${changed_file}" in
+              .github/workflows/ci.yml|\
+              .github/workflows/build-core-template.yml|\
+              .github/workflows/build-docker-from-tag.yml|\
+              .github/workflows/release-please-cargo-lock.yml|\
+              .github/workflows/zizmor-audit.yml)
+                should_run=true
+                break
+                ;;
+            esac
+          done <<< "${changed_files}"
+
+          echo "should_run=${should_run}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${should_run}" == "true" ]]; then
+            echo "Zizmor audit will run."
+          else
+            echo "No audited workflow files changed; skipping scan."
+          fi
+
+      - name: Run zizmor
+        if: steps.audit-scope.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          docker run \
+            --rm \
+            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+            --workdir /workspace \
+            --env GH_TOKEN \
+            ghcr.io/zizmorcore/zizmor:1.25.2@sha256:14ea7f5cc7c67933394a35b5a38a277397818d232602635edb2010b313afb110 \
+            --no-config \
+            --strict-collection \
+            --format=plain \
+            -- \
+            .github/workflows/ci.yml \
+            .github/workflows/build-core-template.yml \
+            .github/workflows/build-docker-from-tag.yml \
+            .github/workflows/release-please-cargo-lock.yml \
+            .github/workflows/zizmor-audit.yml


### PR DESCRIPTION
## Why

The hardened core workflow path has been manually checked with zizmor during recent CI build work, but there is no repository check that keeps those workflows clean when they change. That leaves regressions in permissions, action pinning, credential persistence, unsafe triggers, and shell template expansion to be caught only by manual review.

This PR adds a narrow, blocking zizmor check for the workflows that are already clean under the current local baseline. The scope is intentionally phased: the full `.github/workflows` directory still has existing zizmor findings in older/manual self-hosted workflows, so gating every workflow at once would mix scanner introduction with broad workflow remediation.

The check uses plain CLI output as the blocking signal. SARIF/code-scanning output is useful for triage, but zizmor SARIF mode exits successfully when findings exist unless repository code-scanning rulesets are configured to block merges. This workflow therefore keeps enforcement in the GitHub Actions check itself.

## What changed

- Added `.github/workflows/zizmor-audit.yml`.
- The workflow runs on pull requests, merge groups, pushes to `main`, and manual dispatch.
- The workflow intentionally does not use top-level `paths:` filters. If this check becomes required, path-filtered workflow skips can leave required checks pending on unrelated PRs; running the workflow on every PR gives GitHub a stable required-check result.
- The job determines audit scope internally:
  - PR and `main` push runs compute changed paths from the checked-out repository with `git diff --name-status --find-renames`, including old and new paths for renames.
  - If no audited workflow file changed, the job exits successfully without running the Dockerized scan.
  - `merge_group` and manual runs execute the audit directly.
- The workflow audits only the clean hardened subset plus itself:
  - `.github/workflows/ci.yml`
  - `.github/workflows/build-core-template.yml`
  - `.github/workflows/build-docker-from-tag.yml`
  - `.github/workflows/release-please-cargo-lock.yml`
  - `.github/workflows/zizmor-audit.yml`
- The workflow filename avoids `.github/workflows/zizmor.yml` so zizmor does not discover the workflow itself as a local config file for sibling workflow inputs.
- The job uses read-only `contents: read` permissions.
- `actions/checkout` is SHA-pinned and uses `persist-credentials: false`.
- zizmor runs as `1.25.2` from the official container image pinned by digest, with `--no-config`, `--strict-collection`, and `--format=plain` so PR-controlled config cannot weaken the gate, input collection failures fail the job, and findings fail through normal zizmor exit codes.

## Reuse & Duplication

Not applicable — this is a CI workflow-only change. No production runtime logic, `via_*` source path, detector, poller, watcher, client, parser, or conversion is added or changed.

## Performance, Complexity, and Resource Impact

| Dimension | Before | After | Notes |
|---|---|---|---|
| Runtime behavior | unchanged | unchanged | CI workflow-only change. |
| Workflow trigger scope | no zizmor gate | every PR/merge group, `main` pushes, manual dispatch | Stable required-check behavior. |
| Audit scope | none | five workflow files when relevant files change | Unrelated PRs get a passing no-op result. |
| CI work | none | local git diff scope check; Dockerized zizmor scan only when relevant | Keeps the required check reliable without scanning on unrelated changes. |
| GitHub token permissions | no zizmor job | `contents: read` | Read-only; no SARIF upload or write permission. |
| Net production LOC | unchanged | unchanged | No production source code changed. |

## Boundaries and non-goals

This PR does not attempt to clean every existing workflow. A full `.github/workflows` zizmor run currently reports existing findings in older/manual self-hosted workflows; those should be handled in follow-up PRs with focused workflow-hardening changes.

This PR does not enable SARIF upload, GitHub Advanced Security integration, or code-scanning merge protection. The blocking signal is the normal GitHub Actions job result.

This PR does not change runtime code, Docker image build behavior, deployment desired state, secrets, cloud resources, databases, or live services.

## How to review

Review `.github/workflows/zizmor-audit.yml` for trigger scope, changed-file detection, pinned supply-chain inputs, permissions, and the exact audited file list.

The key behavior is that the workflow always reports a check result for PRs and merge groups, but only runs `zizmor --no-config --strict-collection --format=plain` through the pinned official container image when audited workflow paths changed. That keeps findings as a failing CI result without relying on SARIF/code-scanning rulesets.

Also review that the workflow remains intentionally narrow: it gates the already-clean hardened subset and leaves broad legacy workflow cleanup as follow-up work.

## Checks run

```bash
git diff --check

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/zizmor-audit.yml

zizmor --no-config --strict-collection --format plain \
  .github/workflows/ci.yml \
  .github/workflows/build-core-template.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/release-please-cargo-lock.yml \
  .github/workflows/zizmor-audit.yml

zizmor --gh-token "$(gh auth token)" --no-config --strict-collection --format plain \
  .github/workflows/ci.yml \
  .github/workflows/build-core-template.yml \
  .github/workflows/build-docker-from-tag.yml \
  .github/workflows/release-please-cargo-lock.yml \
  .github/workflows/zizmor-audit.yml

just via-check

gitleaks protect --staged --redact --no-banner
gitleaks git --log-opts="main..HEAD" --redact --no-banner
```

`just via-check` completed in advisory mode and reported pre-existing warnings in unrelated Rust source paths. The local Docker daemon is unavailable (`/var/run/docker.sock` is missing), so the Dockerized CI command was not run locally; the same scoped workflows were validated with the local `zizmor 1.25.2` binary.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.
- [x] Ran `just via-check` and recorded results in the Checks run section.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Read-only GitHub API-backed validation was run through zizmor online audits using the local GitHub CLI token. No deployments, restarts, migrations, database writes, secret changes, cloud mutations, or repository settings changes were performed.

Merging this PR adds a CI check for future workflow/config changes. It does not deploy services or change live runtime behavior by itself.
