### PR TITLE
ci(via): harden legacy image workflows

### DIFF
--- a/.github/lint/via-structural/ast-grep/baseline.txt
+++ b/.github/lint/via-structural/ast-grep/baseline.txt
@@ -11,3 +11,6 @@ via-da-batch-before-proof|core/node/via_da_dispatcher/src/da_dispatcher.rs
 via-avoid-duplicate-export|core/lib/types/src/lib.rs
 via-avoid-duplicate-export|core/lib/types/src/lib.rs
 via-avoid-duplicate-export|core/lib/types/src/lib.rs
+via-workflow-ref-env-write-validation|.github/workflows/build-prover-components.yml
+via-workflow-ref-env-write-validation|.github/workflows/tests-via.yml
+via-workflow-docker-tag-validation|.github/workflows/build-prover-components.yml

--- a/.github/lint/via-structural/ast-grep/rules/via-workflow-docker-tag-validation.yml
+++ b/.github/lint/via-structural/ast-grep/rules/via-workflow-docker-tag-validation.yml
@@ -1,0 +1,28 @@
+id: via-workflow-docker-tag-validation
+language: Yaml
+severity: warning
+message: |
+  Manual workflow image tag input reaches a Docker tag exported through GITHUB_ENV.
+
+  Validate workflow-dispatch image tag input before writing the resulting Docker tag
+  to GITHUB_ENV. Docker tags should reject environment-file control characters and
+  stay within the Docker tag character set before later docker build/tag/push steps
+  consume them.
+note: |
+  This rule is scoped to GitHub Actions workflow YAML. It is intentionally narrow:
+  it targets run blocks that combine image_tag_suffix input with a DOCKER_TAG write
+  to GITHUB_ENV and do not include the local Docker tag validation pattern.
+rule:
+  all:
+    - pattern: |
+        run: |
+          $$$BODY
+    - regex: '(?s)((IMAGE_TAG_SUFFIX|\$\{\{[[:space:]]*(github\.event\.)?inputs\.image_tag_suffix[[:space:]]*\}\}).*DOCKER_TAG=.*>>[[:space:]]*"?\$GITHUB_ENV"?|DOCKER_TAG=.*(IMAGE_TAG_SUFFIX|\$\{\{[[:space:]]*(github\.event\.)?inputs\.image_tag_suffix[[:space:]]*\}\}).*>>[[:space:]]*"?\$GITHUB_ENV"?)'
+    - not:
+        regex: '(A-Za-z0-9_|a-zA-Z0-9_).*0,127'
+metadata:
+  category: ci-security
+  related:
+    - github-actions
+    - environment-files
+    - docker-tags

--- a/.github/lint/via-structural/ast-grep/rules/via-workflow-ref-env-write-validation.yml
+++ b/.github/lint/via-structural/ast-grep/rules/via-workflow-ref-env-write-validation.yml
@@ -1,0 +1,29 @@
+id: via-workflow-ref-env-write-validation
+language: Yaml
+severity: warning
+message: |
+  Manual workflow ref input reaches GITHUB_ENV without local git-ref validation.
+
+  Validate workflow-dispatch ref input before writing the selected ref to GITHUB_ENV.
+  Ref validation prevents environment-file injection through newlines and rejects
+  unexpected ref syntax before actions/checkout consumes the value.
+note: |
+  This rule is scoped to GitHub Actions workflow YAML. It is intentionally narrow:
+  it targets run blocks that combine ref input with a REF write to GITHUB_ENV and
+  either do not run git check-ref-format or write REF before that validation.
+rule:
+  all:
+    - pattern: |
+        run: |
+          $$$BODY
+    - regex: '(?s)((INPUT_REF|\$\{\{[[:space:]]*(github\.event\.)?inputs\.ref[[:space:]]*\}\}).*REF=.*>>[[:space:]]*"?\$GITHUB_ENV"?|REF=.*(INPUT_REF|\$\{\{[[:space:]]*(github\.event\.)?inputs\.ref[[:space:]]*\}\}).*>>[[:space:]]*"?\$GITHUB_ENV"?)'
+    - any:
+        - not:
+            regex: 'git check-ref-format'
+        - regex: '(?s)REF=.*>>[[:space:]]*"?\$GITHUB_ENV"?.*git check-ref-format'
+metadata:
+  category: ci-security
+  related:
+    - github-actions
+    - environment-files
+    - git-refs

--- a/.github/lint/via-structural/ast-grep/sgconfig.yml
+++ b/.github/lint/via-structural/ast-grep/sgconfig.yml
@@ -35,3 +35,13 @@ rules:
       - "via_verifier/**/*.rs"
       - "core/lib/via_*/**/*.rs"
       - "core/lib/types/src/**/*.rs"
+
+  - include: "via-workflow-ref-env-write-validation"
+    glob:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+
+  - include: "via-workflow-docker-tag-validation"
+    glob:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"

--- a/.github/scripts/check-via-structural-rules.sh
+++ b/.github/scripts/check-via-structural-rules.sh
@@ -110,7 +110,7 @@ run_scoped_rule() {
     local rule_id="$1"
     shift
 
-    local args=("scan" "--config" "$SGCONFIG" "--filter" "$rule_id" "--report-style" "short" "--color=never")
+    local args=("scan" "--no-ignore" "hidden" "--config" "$SGCONFIG" "--filter" "$rule_id" "--report-style" "short" "--color=never")
     local glob
     for glob in "$@"; do
         args+=("--globs" "$glob")
@@ -181,6 +181,14 @@ run_scoped_rule "via-avoid-duplicate-export" \
     "via_verifier/**/*.rs" \
     "core/lib/via_*/**/*.rs" \
     "core/lib/types/src/**/*.rs"
+
+run_scoped_rule "via-workflow-ref-env-write-validation" \
+    ".github/workflows/*.yml" \
+    ".github/workflows/*.yaml"
+
+run_scoped_rule "via-workflow-docker-tag-validation" \
+    ".github/workflows/*.yml" \
+    ".github/workflows/*.yaml"
 
 if [[ -n "$OUTPUT" ]]; then
     echo "$OUTPUT"

--- a/.github/workflows/build-snapshots-creator.yml
+++ b/.github/workflows/build-snapshots-creator.yml
@@ -10,6 +10,10 @@ on:
         description: "Optional suffix to override tag name generation"
         type: string
         required: false
+
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -17,41 +21,58 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
           else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
-          fi  
+            REF="${DEFAULT_REF}"
+          fi
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+          printf 'REF=%s\n' "${REF}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
+          persist-credentials: false
           submodules: 'recursive'
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ inputs.image_tag_suffix }}"
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "$GITHUB_ENV"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          echo "VIA_HOME=$(pwd)" >> "$GITHUB_ENV"
+          echo "CI=1" >> "$GITHUB_ENV"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
       - name: Build image
         run: |
-          docker buildx build -t snapshots-creator:${{ env.DOCKER_TAG }} -f docker/snapshots-creator/Dockerfile .       
+          docker buildx build -t "snapshots-creator:${DOCKER_TAG}" -f docker/snapshots-creator/Dockerfile .
 
       - name: Publish image to registry
-        run: | 
-          docker tag snapshots-creator:${{ env.DOCKER_TAG }} europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/snapshots-creator:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/snapshots-creator:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/snapshots-creator:${{ env.DOCKER_TAG }}"
+        env:
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/snapshots-creator
+        run: |
+          docker tag "snapshots-creator:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          echo "Image: ${REMOTE_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/build-via-da-proxy.yml
+++ b/.github/workflows/build-via-da-proxy.yml
@@ -11,6 +11,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -18,41 +21,58 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
           else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
+            REF="${DEFAULT_REF}"
           fi
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+          printf 'REF=%s\n' "${REF}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
+          persist-credentials: false
           submodules: 'recursive'
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ inputs.image_tag_suffix }}"
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "$GITHUB_ENV"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          echo "VIA_HOME=$(pwd)" >> "$GITHUB_ENV"
+          echo "CI=1" >> "$GITHUB_ENV"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
       - name: Build image
         run: |
-          docker buildx build -t via-da-proxy:${{ env.DOCKER_TAG }} -f via-core-ext/Dockerfile via-core-ext
+          docker buildx build -t "via-da-proxy:${DOCKER_TAG}" -f via-core-ext/Dockerfile via-core-ext
 
       - name: Publish image to registry
-        run: | 
-          docker tag via-da-proxy:${{ env.DOCKER_TAG }} europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-da-proxy:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-da-proxy:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-da-proxy:${{ env.DOCKER_TAG }}"
+        env:
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-da-proxy
+        run: |
+          docker tag "via-da-proxy:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          echo "Image: ${REMOTE_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/build-via-ext-node.yml
+++ b/.github/workflows/build-via-ext-node.yml
@@ -10,6 +10,10 @@ on:
         description: "Optional suffix to override tag name generation"
         type: string
         required: false
+
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -17,32 +21,47 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
           else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
-          fi  
+            REF="${DEFAULT_REF}"
+          fi
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+          printf 'REF=%s\n' "${REF}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
+          persist-credentials: false
           submodules: 'recursive'
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ inputs.image_tag_suffix }}"
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "$GITHUB_ENV"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          echo "VIA_HOME=$(pwd)" >> "$GITHUB_ENV"
+          echo "CI=1" >> "$GITHUB_ENV"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
@@ -54,10 +73,12 @@ jobs:
 
       - name: Build image
         run: |
-          docker buildx build -t via-external-node:${{ env.DOCKER_TAG }} -f docker/via-external-node/Dockerfile .       
+          docker buildx build -t "via-external-node:${DOCKER_TAG}" -f docker/via-external-node/Dockerfile .
 
       - name: Publish image to registry
-        run: | 
-          docker tag via-external-node:${{ env.DOCKER_TAG }} europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-external-node:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-external-node:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-external-node:${{ env.DOCKER_TAG }}"
+        env:
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-external-node
+        run: |
+          docker tag "via-external-node:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          echo "Image: ${REMOTE_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/build-via-indexer.yml
+++ b/.github/workflows/build-via-indexer.yml
@@ -10,6 +10,10 @@ on:
         description: "Optional suffix to override tag name generation"
         type: string
         required: false
+
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -17,41 +21,58 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
           else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
-          fi  
+            REF="${DEFAULT_REF}"
+          fi
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+          printf 'REF=%s\n' "${REF}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
+          persist-credentials: false
           submodules: 'recursive'
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ inputs.image_tag_suffix }}"
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "$GITHUB_ENV"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          echo "VIA_HOME=$(pwd)" >> "$GITHUB_ENV"
+          echo "CI=1" >> "$GITHUB_ENV"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
       - name: Build image
         run: |
-          docker buildx build -t via-l1-indexer:${{ env.DOCKER_TAG }} -f docker/via-l1-indexer/Dockerfile .       
+          docker buildx build -t "via-l1-indexer:${DOCKER_TAG}" -f docker/via-l1-indexer/Dockerfile .
 
       - name: Publish image to registry
-        run: | 
-          docker tag via-l1-indexer:${{ env.DOCKER_TAG }} europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-l1-indexer:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-l1-indexer:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-l1-indexer:${{ env.DOCKER_TAG }}"
+        env:
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-l1-indexer
+        run: |
+          docker tag "via-l1-indexer:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          echo "Image: ${REMOTE_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/build-via-server.yml
+++ b/.github/workflows/build-via-server.yml
@@ -10,6 +10,10 @@ on:
         description: "Optional suffix to override tag name generation"
         type: string
         required: false
+
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -17,32 +21,47 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
           else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
-          fi  
+            REF="${DEFAULT_REF}"
+          fi
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+          printf 'REF=%s\n' "${REF}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
+          persist-credentials: false
           submodules: 'recursive'
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ inputs.image_tag_suffix }}"
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "$GITHUB_ENV"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          echo "VIA_HOME=$(pwd)" >> "$GITHUB_ENV"
+          echo "CI=1" >> "$GITHUB_ENV"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
@@ -54,10 +73,12 @@ jobs:
 
       - name: Build image
         run: |
-          docker buildx build -t via-server:${{ env.DOCKER_TAG }} -f docker/via-server/Dockerfile .       
+          docker buildx build -t "via-server:${DOCKER_TAG}" -f docker/via-server/Dockerfile .
 
       - name: Publish image to registry
-        run: | 
-          docker tag via-server:${{ env.DOCKER_TAG }} europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-server:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-server:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-server:${{ env.DOCKER_TAG }}"
+        env:
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-server
+        run: |
+          docker tag "via-server:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          echo "Image: ${REMOTE_IMAGE}:${DOCKER_TAG}"

--- a/.github/workflows/build-via-verifier.yml
+++ b/.github/workflows/build-via-verifier.yml
@@ -11,6 +11,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build and Push Docker Images
@@ -18,41 +21,58 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
           else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
-          fi  
+            REF="${DEFAULT_REF}"
+          fi
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+          printf 'REF=%s\n' "${REF}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
+          persist-credentials: false
           submodules: 'recursive'
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ inputs.image_tag_suffix }}"
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "$GITHUB_ENV"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          echo "VIA_HOME=$(pwd)" >> "$GITHUB_ENV"
+          echo "CI=1" >> "$GITHUB_ENV"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
       - name: Build image
         run: |
-          docker buildx build -t via-verifier:${{ env.DOCKER_TAG }} -f docker/via-verifier/Dockerfile .       
+          docker buildx build -t "via-verifier:${DOCKER_TAG}" -f docker/via-verifier/Dockerfile .
 
       - name: Publish image to registry
-        run: | 
-          docker tag via-verifier:${{ env.DOCKER_TAG }} europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-verifier:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-verifier:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-verifier:${{ env.DOCKER_TAG }}"
+        env:
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/via-verifier
+        run: |
+          docker tag "via-verifier:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          echo "Image: ${REMOTE_IMAGE}:${DOCKER_TAG}"


### PR DESCRIPTION
## Why

The repository now has a narrow zizmor gate for the already-clean core workflow subset, but the remaining active workflow backlog is concentrated in older manual image-build workflows. These workflows are manually dispatched and push images to the Via registry, so they should not keep broad default `GITHUB_TOKEN` permissions, persisted checkout credentials, unpinned checkout actions, or direct `${{ ... }}` template expansion inside shell blocks.

This PR handles the repeated legacy image-workflow pattern as a focused follow-up. The six workflows had the same zizmor shape before this change: `artipacked`, `excessive-permissions`, `unpinned-uses`, and `template-injection` findings. The update keeps the manual build/push flow intact while matching the stronger workflow-hardening pattern now used by the cleaned core path.

The newer ZKsync v29.15.2 build templates were checked for reference, but they still use checkout v4 pins and still report current zizmor findings in comparable build templates. This PR therefore keeps the cleaner Via-local pattern instead of copying those templates.

## What changed

- Hardened the six legacy manual image workflows:
  - `.github/workflows/build-via-server.yml`
  - `.github/workflows/build-via-ext-node.yml`
  - `.github/workflows/build-via-verifier.yml`
  - `.github/workflows/build-via-indexer.yml`
  - `.github/workflows/build-via-da-proxy.yml`
  - `.github/workflows/build-snapshots-creator.yml`
- Added explicit read-only `contents: read` workflow permissions.
- Upgraded and pinned `actions/checkout` to the same v6.0.2 commit already used by the cleaned active workflows.
- Added `persist-credentials: false` to checkout steps.
- Moved manual workflow inputs into step environment variables before shell use.
- Replaced `${{ env.DOCKER_TAG }}` shell interpolation with normal shell environment expansion.
- Quoted environment-file, path-file, Docker tag, Docker push, and image-output expansions.
- Validated selected refs with `git check-ref-format --allow-onelevel` before exporting `REF` through `$GITHUB_ENV`.
- Validated manual Docker tag suffixes against Docker tag-safe syntax before exporting `DOCKER_TAG`.
- Added Via structural ast-grep rules for workflow ref and Docker-tag env-file writes, with baselines for the older prover/test workflows left to later PRs.

## Reuse & Duplication

Not applicable — this is a CI workflow-only change. No production runtime logic, `via_*` source path, detector, poller, watcher, client, parser, or conversion is added or changed.

## Performance, Complexity, and Resource Impact

| Dimension | Before | After | Notes |
|---|---|---|---|
| Runtime behavior | unchanged | unchanged | Workflow hardening only; no Via runtime source changed. |
| GitHub token permissions | default workflow token permissions | `contents: read` | Registry pushes use existing Docker/GAR auth, not GitHub write permissions. |
| Checkout credential persistence | default checkout credential persistence | `persist-credentials: false` | Removes unnecessary persisted token material. |
| Action supply chain | `actions/checkout@v4.2.2` tag | checkout v6.0.2 pinned by SHA | Uses the same pinned checkout release as the cleaned active core workflows. |
| Shell template expansion | direct `${{ inputs.* }}` / `${{ env.DOCKER_TAG }}` in `run:` blocks | shell env vars | Removes zizmor template-injection findings in these workflows. |
| Manual input validation | unvalidated env-file writes | validated refs and Docker tags before `$GITHUB_ENV` writes | Addresses the repeated Copilot environment-file injection review comments. |
| Structural workflow guard | Rust-only Via structural rules | adds YAML ast-grep workflow rules | New findings in the same pattern are visible through `just via-check`; existing prover/test findings are baselined for later cleanup. |
| Targeted zizmor findings | 72 | 0 | For the six workflows changed in this PR. |
| Full active-workflow zizmor findings | 110 | 38 | Remaining findings are outside this PR: prover component, test, release, and issue-template workflows. |
| Net production LOC | unchanged | unchanged | CI workflow-only change. |

## Boundaries and non-goals

This PR does not change Dockerfiles, image contents, cargo-chef behavior, BuildKit cache behavior, deployment desired state, secrets, cloud resources, databases, or live services.

This PR does not clean every remaining zizmor finding. The remaining active-workflow findings are left for separate focused PRs so workflow-hardening changes stay reviewable. The new workflow structural rules also baseline existing ref/tag env-file findings in `build-prover-components.yml` and `tests-via.yml`; those workflows are not changed here.

Merging this PR changes source workflows only. Running a manual workflow, building an image, pushing an image, or deploying that image remains a separate operator action.

## How to review

Review the six changed workflow files for the repeated hardening pattern:

- checkout is SHA-pinned and uses `persist-credentials: false`
- workflow permissions are limited to `contents: read`
- manual inputs are passed through `env:` before shell use
- selected refs are validated before `REF` is written to `$GITHUB_ENV`
- Docker tag suffixes are validated before `DOCKER_TAG` is written to `$GITHUB_ENV`
- Docker tag and registry commands use quoted shell variables
- no registry name, image name, Dockerfile path, or build context changed

The useful comparison point is the old manual workflow behavior, not the newer ZKsync v29.15.2 templates: those upstream templates were checked and still report current zizmor findings in comparable build workflows.

## Checks run

```bash
git diff --check

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/build-via-server.yml \
  .github/workflows/build-via-ext-node.yml \
  .github/workflows/build-via-verifier.yml \
  .github/workflows/build-via-indexer.yml \
  .github/workflows/build-via-da-proxy.yml \
  .github/workflows/build-snapshots-creator.yml

zizmor --no-config --strict-collection --format plain \
  .github/workflows/build-via-server.yml \
  .github/workflows/build-via-ext-node.yml \
  .github/workflows/build-via-verifier.yml \
  .github/workflows/build-via-indexer.yml \
  .github/workflows/build-via-da-proxy.yml \
  .github/workflows/build-snapshots-creator.yml

zizmor --gh-token "$(gh auth token)" --no-config --strict-collection --format plain \
  .github/workflows/build-via-server.yml \
  .github/workflows/build-via-ext-node.yml \
  .github/workflows/build-via-verifier.yml \
  .github/workflows/build-via-indexer.yml \
  .github/workflows/build-via-da-proxy.yml \
  .github/workflows/build-snapshots-creator.yml

zizmor --no-config --format json $(rg --files .github/workflows -g '*.yml' -g '*.yaml') \
  > /tmp/via-core-zizmor-after-image-workflows.json

ast-grep scan --no-ignore hidden \
  --config .github/lint/via-structural/ast-grep/sgconfig.yml \
  --filter 'via-workflow-(ref-env-write|docker-tag)-validation' \
  --report-style short --color=never \
  --globs '.github/workflows/*.yml' \
  --globs '.github/workflows/*.yaml'

just via-check
just via-check-strict

gitleaks protect --staged --redact --no-banner
gitleaks git --log-opts="main..HEAD" --redact --no-banner
```

`just via-check` completed in advisory mode and reported pre-existing Rust warnings plus the newly baselined prover/test workflow warnings. `just via-check-strict` passed with only baselined findings. `actionlint` is not installed locally. Docker was not run locally.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.
- [x] Ran `just via-check` and recorded results in the Checks run section.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR updates manual image-build workflow source only. It does not build or publish images by itself, deploy services, restart workloads, mutate databases, change secrets, or modify cloud resources.

