### PR TITLE
ci(via): finish active workflow zizmor hardening

### DIFF
--- a/.github/lint/via-structural/ast-grep/baseline.txt
+++ b/.github/lint/via-structural/ast-grep/baseline.txt
@@ -11,6 +11,3 @@ via-da-batch-before-proof|core/node/via_da_dispatcher/src/da_dispatcher.rs
 via-avoid-duplicate-export|core/lib/types/src/lib.rs
 via-avoid-duplicate-export|core/lib/types/src/lib.rs
 via-avoid-duplicate-export|core/lib/types/src/lib.rs
-via-workflow-ref-env-write-validation|.github/workflows/build-prover-components.yml
-via-workflow-ref-env-write-validation|.github/workflows/tests-via.yml
-via-workflow-docker-tag-validation|.github/workflows/build-prover-components.yml

--- a/.github/workflows/build-prover-components.yml
+++ b/.github/workflows/build-prover-components.yml
@@ -30,6 +30,9 @@ on:
           - proof-fri-gpu-compressor
           - prover-autoscaler
 
+permissions:
+  contents: read
+
 jobs:
   setup-components:
     runs-on: [self-hosted, cpu]
@@ -37,13 +40,17 @@ jobs:
       components: ${{ steps.set-components.outputs.components }}
     steps:
       - id: set-components
+        env:
+          COMPONENT: ${{ inputs.component }}
         run: |
-          ALL='["witness-generator","circuit-prover-gpu","prover-fri-gateway","prover-job-monitor","proof-fri-gpu-compressor", "prover-autoscaler"]'
-          
-          if [ "${{ github.event.inputs.component }}" = "all" ]; then
-            echo "components=$ALL" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          ALL='["witness-generator","circuit-prover-gpu","prover-fri-gateway","prover-job-monitor","proof-fri-gpu-compressor","prover-autoscaler"]'
+
+          if [[ "${COMPONENT}" == "all" ]]; then
+            printf 'components=%s\n' "${ALL}" >> "${GITHUB_OUTPUT}"
           else
-            echo "components=[\"${{ github.event.inputs.component }}\"]" >> $GITHUB_OUTPUT
+            printf 'components=["%s"]\n' "${COMPONENT}" >> "${GITHUB_OUTPUT}"
           fi
 
   build-and-push:
@@ -58,33 +65,53 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ github.event.inputs.ref }}" ]]; then
-            echo "REF=${{ github.event.inputs.ref }}" >> $GITHUB_ENV
-          else
-            REF="$(git rev-parse --abbrev-ref HEAD)"
-            echo "REF=$REF" >> $GITHUB_ENV
-          fi  
+          set -euo pipefail
 
-      - uses: actions/checkout@v4.2.2
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
+          else
+            REF="${DEFAULT_REF}"
+          fi
+
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+
+          printf 'REF=%s\n' "${REF}" >> "${GITHUB_ENV}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Determine Docker tag
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
-          if [[ -n "${{ github.event.inputs.image_tag_suffix }}" ]]; then
-            TAG="${{ github.event.inputs.image_tag_suffix }}"
+          set -euo pipefail
+
+          if [[ -n "${IMAGE_TAG_SUFFIX}" ]]; then
+            if [[ ! "${IMAGE_TAG_SUFFIX}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid Docker tag suffix: ${IMAGE_TAG_SUFFIX}"
+              exit 1
+            fi
+            TAG="${IMAGE_TAG_SUFFIX}"
           else
             TAG=$(git rev-parse --short HEAD)
           fi
-          echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
+          printf 'DOCKER_TAG=%s\n' "${TAG}" >> "${GITHUB_ENV}"
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          printf 'VIA_HOME=%s\n' "$(pwd)" >> "${GITHUB_ENV}"
+          echo CI=1 >> "${GITHUB_ENV}"
+          printf '%s/bin\n' "$(pwd)" >> "${GITHUB_PATH}"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 
@@ -94,20 +121,29 @@ jobs:
           run_retried curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^24.key
 
       - name: Build image
+        env:
+          COMPONENT: ${{ matrix.component }}
         run: |
-          if [[ "${{ matrix.component }}" == "circuit-prover-gpu" || "${{ matrix.component }}" == "proof-fri-gpu-compressor" ]]; then
-            EXTRA_BUILD_ARGS="--build-arg CUDA_ARCH=${{ env.CUDA_ARCH }}"
+          set -euo pipefail
+
+          EXTRA_BUILD_ARGS=()
+          if [[ "${COMPONENT}" == "circuit-prover-gpu" || "${COMPONENT}" == "proof-fri-gpu-compressor" ]]; then
+            EXTRA_BUILD_ARGS+=(--build-arg "CUDA_ARCH=${CUDA_ARCH}")
           fi
 
           docker buildx build \
-            -t ${{ matrix.component }}:${{ env.DOCKER_TAG }} \
-            -f docker/${{ matrix.component }}/Dockerfile \
-            $EXTRA_BUILD_ARGS \
+            -t "${COMPONENT}:${DOCKER_TAG}" \
+            -f "docker/${COMPONENT}/Dockerfile" \
+            "${EXTRA_BUILD_ARGS[@]}" \
             .
 
       - name: Publish image to registry
+        env:
+          COMPONENT: ${{ matrix.component }}
+          REMOTE_IMAGE: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.component }}
         run: |
-          docker tag ${{ matrix.component }}:${{ env.DOCKER_TAG }} \
-            europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.component }}:${{ env.DOCKER_TAG }}
-          docker push europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.component }}:${{ env.DOCKER_TAG }}
-          echo "Image: europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.component }}:${{ env.DOCKER_TAG }}"
+          set -euo pipefail
+
+          docker tag "${COMPONENT}:${DOCKER_TAG}" "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          docker push "${REMOTE_IMAGE}:${DOCKER_TAG}"
+          printf 'Image: %s:%s\n' "${REMOTE_IMAGE}" "${DOCKER_TAG}"

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -14,12 +14,12 @@ jobs:
       statuses: write
       pull-requests: write
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2
+      - uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -43,7 +43,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:   
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/issue-template-lint.yml
+++ b/.github/workflows/issue-template-lint.yml
@@ -17,9 +17,11 @@ jobs:
     name: Validate issue templates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
             token: ${{ secrets.RELEASE_TOKEN }}
             config-file: .github/release-please/config.json

--- a/.github/workflows/release-stable-en.yml
+++ b/.github/workflows/release-stable-en.yml
@@ -8,44 +8,67 @@ on:
         type: string
         required: true
 
+permissions: {}
+
 jobs:
   release:
     runs-on: [matterlabs-ci-runner]
     steps:
       - name: Login to Docker registries
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
         run: |
-          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          set -euo pipefail
+
+          printf '%s' "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USER}" --password-stdin
           gcloud auth configure-docker us-docker.pkg.dev -q
 
       - name: Check if alpha image exists
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          set +e
-          docker manifest inspect matterlabs/external-node:${{ inputs.tag_name }}-alpha >/dev/null 2>&1
-          exitcode=$?
-          set -e
-          if [[ "$exitcode" -eq "1" ]]; then
-            echo "Image matterlabs/external-node:${{ inputs.tag_name }}-alpha doesn't exist"
+          set -euo pipefail
+
+          if [[ ! "${TAG_NAME}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::Invalid Docker tag name: ${TAG_NAME}"
+            exit 1
+          fi
+
+          alpha_manifest="matterlabs/external-node:${TAG_NAME}-alpha"
+          if ! docker manifest inspect "${alpha_manifest}" >/dev/null 2>&1; then
+            echo "Image ${alpha_manifest} doesn't exist"
             exit 1
           fi
 
       - name: Push stable image
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
+          set -euo pipefail
+
+          if [[ ! "${TAG_NAME}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::Invalid Docker tag name: ${TAG_NAME}"
+            exit 1
+          fi
+
           docker_repositories=("matterlabs/external-node")
           platforms=("linux/amd64" "linux/arm64")
-          tag_name="${{ inputs.tag_name }}"
+          tag_name="${TAG_NAME}"
           for repo in "${docker_repositories[@]}"; do
-            platform_tags=""
+            platform_tags=()
             for platform in "${platforms[@]}"; do
-              platform=$(echo $platform | tr '/' '-')
+              platform=$(echo "${platform}" | tr '/' '-')
+              alpha_tag="${repo}:${tag_name}-alpha-${platform}"
               tag="${repo}:${tag_name}-${platform}"
-              docker pull $alpha_tag
-              docker tag $alpha_tag $tag
-              docker push $tag
-               
-              platform_tags+=" --amend $tag"
+              docker pull "${alpha_tag}"
+              docker tag "${alpha_tag}" "${tag}"
+              docker push "${tag}"
+
+              platform_tags+=(--amend "${tag}")
             done
             for manifest in "${repo}:${tag_name}" "${repo}:2.0-${tag_name}"; do
-              docker manifest create ${manifest} ${platform_tags}
-              docker manifest push ${manifest}
+              docker manifest create "${manifest}" "${platform_tags[@]}"
+              docker manifest push "${manifest}"
             done
           done

--- a/.github/workflows/tests-via.yml
+++ b/.github/workflows/tests-via.yml
@@ -7,6 +7,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run tests
@@ -14,23 +17,36 @@ jobs:
 
     steps:
       - name: Set reference and fetch repo
+        env:
+          DEFAULT_REF: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if [[ -n "${{ inputs.ref }}" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
-          else
-            REF="$(git rev-parse --abbrev-ref HEAD)"  # Get the current branch if not provided
-          fi  
+          set -euo pipefail
 
-      - uses: actions/checkout@v4.2.2
+          if [[ -n "${INPUT_REF}" ]]; then
+            REF="${INPUT_REF}"
+          else
+            REF="${DEFAULT_REF}"
+          fi
+
+          if [[ "${REF}" == *$'\n'* || "${REF}" == *$'\r'* || "${REF}" == -* ]] || ! git check-ref-format --allow-onelevel "${REF}"; then
+            echo "::error::Invalid git ref: ${REF}"
+            exit 1
+          fi
+
+          printf 'REF=%s\n' "${REF}" >> "${GITHUB_ENV}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.REF }}
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Setup env
         run: |
-          echo VIA_HOME=$(pwd) >> $GITHUB_ENV
-          echo CI=1 >> $GITHUB_ENV
-          echo $(pwd)/bin >> $GITHUB_PATH
+          printf 'VIA_HOME=%s\n' "$(pwd)" >> "${GITHUB_ENV}"
+          echo CI=1 >> "${GITHUB_ENV}"
+          printf '%s/bin\n' "$(pwd)" >> "${GITHUB_PATH}"
           echo CI=1 >> .env
           echo IN_DOCKER=1 >> .env
 

--- a/.github/workflows/zizmor-audit.yml
+++ b/.github/workflows/zizmor-audit.yml
@@ -69,11 +69,8 @@ jobs:
 
           while IFS= read -r changed_file; do
             case "${changed_file}" in
-              .github/workflows/ci.yml|\
-              .github/workflows/build-core-template.yml|\
-              .github/workflows/build-docker-from-tag.yml|\
-              .github/workflows/release-please-cargo-lock.yml|\
-              .github/workflows/zizmor-audit.yml)
+              .github/workflows/*.yml|\
+              .github/workflows/*.yaml)
                 should_run=true
                 break
                 ;;
@@ -93,6 +90,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          mapfile -t workflows < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
           docker run \
             --rm \
             --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
@@ -103,8 +102,4 @@ jobs:
             --strict-collection \
             --format=plain \
             -- \
-            .github/workflows/ci.yml \
-            .github/workflows/build-core-template.yml \
-            .github/workflows/build-docker-from-tag.yml \
-            .github/workflows/release-please-cargo-lock.yml \
-            .github/workflows/zizmor-audit.yml
+            "${workflows[@]}"


### PR DESCRIPTION
## Why

The repository now has a zizmor CI gate, but it previously audited only the already-clean core workflow subset. Several active manual and release workflows still carried known GitHub Actions security findings, so expanding the audit to all active workflows would have failed immediately.

This PR removes the remaining active workflow findings and then broadens the zizmor gate to every active `.github/workflows/*.yml` file. The result is a repeatable CI check for workflow security issues rather than relying only on reviewer bots to rediscover template-injection, unpinned action, excessive-permission, and artifact credential-persistence patterns.

## What changed

- Hardened `build-prover-components.yml` and `tests-via.yml` manual dispatch ref handling:
  - moves dispatch inputs into step `env:` before shell use
  - validates selected refs before writing `REF` to `$GITHUB_ENV`
  - pins checkout to the repository-standard `actions/checkout` v6.0.2 SHA
  - sets `persist-credentials: false`
- Hardened `build-prover-components.yml` Docker tag handling with the same tag validation pattern used by the legacy image workflows.
- Hardened `release-stable-en.yml`:
  - removes `${{ ... }}` shell interpolation for secrets and `tag_name`
  - validates the Docker tag input before use
  - uses `docker login --password-stdin`
  - fixes the pre-existing missing `alpha_tag` assignment using the newer ZKsync workflow as the reference pattern
  - sets explicit empty GitHub token permissions
- Pins remaining unpinned actions in active workflows:
  - `actions/setup-python` upgraded to v6.2.0 and pinned by SHA
  - `googleapis/release-please-action` pinned to the current v4 SHA
- Updates exact version comments for already-pinned PR title actions so zizmor no longer reports ref-version mismatch.
- Expands `zizmor-audit.yml` to run on changes to any active workflow and scan all active `.github/workflows/*.yml` / `.yaml` files.
- Removes stale structural-lint baselines for the workflow findings fixed here.

## Reuse & Duplication

Not applicable — this changes GitHub Actions workflow definitions and workflow lint baselines only. No production runtime logic in a `via_*` path is added or changed.

The `release-stable-en.yml` `alpha_tag` fix was compared against `/home/romano/github/vianetwork-repos/zksync-era-v29.15.2/.github/workflows/release-stable-en.yml`; only the missing tag construction pattern was reused.

## Performance, Complexity, and Resource Impact

| Dimension | Before | After | Notes |
|---|---|---|---|
| Runtime behavior | unchanged | unchanged | Workflow-only change. |
| Zizmor audit scope | clean core subset only | all active workflow YAML files | More CI coverage when workflow files change. |
| Workflow security findings | 41 active zizmor findings | 0 active zizmor findings | Local full active-workflow run is clean. |
| GitHub token permissions | implicit/default in some workflows | explicit minimal/empty where applicable | No broader token permissions added. |
| Net production LOC | 0 | 0 | No runtime source changes. |

## Boundaries and non-goals

This PR does not rename, delete, or consolidate workflows. It does not convert the legacy image/prover workflows into reusable `workflow_call` workflows; that remains a possible later cleanup.

This PR does not change live deployment desired state, registry credentials, secret values, runner labels, Docker image contents, Rust code, or release manifests. It changes source workflow definitions only.

## How to review

Focus on the active workflows changed by this PR:

- `.github/workflows/build-prover-components.yml`
- `.github/workflows/tests-via.yml`
- `.github/workflows/release-stable-en.yml`
- `.github/workflows/issue-template-lint.yml`
- `.github/workflows/release-please.yml`
- `.github/workflows/check-pr-title.yml`
- `.github/workflows/zizmor-audit.yml`

The main review points are whether dispatch inputs are validated before environment-file writes, whether shell blocks use environment variables rather than raw GitHub expressions, and whether the broader zizmor gate scans exactly the active workflow files without pulling in `.disabled` files.

## Checks run

```bash
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml .github/lint/via-structural/ast-grep/baseline.txt

zizmor --gh-token "$(gh auth token)" --no-config --strict-collection --format plain .github/workflows/*.yml

just via-check-strict

git diff --check

gitleaks protect --staged --redact --no-banner
gitleaks git --log-opts="main..HEAD" --redact --no-banner
```

`zizmor` reported no active findings for all active workflow YAML files. `just via-check-strict` passed with only the remaining pre-existing Rust structural baselines.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.
- [x] Ran `just via-check-strict` and recorded results in the Checks run section.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR changes GitHub Actions workflow source only. It does not run deployments, restart workloads, mutate databases, change secrets, or modify cloud resources by itself.