### PR TITLE
ci(via): allow Docker Hub core image publish without GAR key

### DIFF
--- a/.github/via-core-image-builds.md
+++ b/.github/via-core-image-builds.md
@@ -108,11 +108,17 @@ The pipeline has three phases:
    per-platform tags with `docker manifest create`. This is why Buildx `provenance` is
    **disabled** on the push step: attestation descriptors would break `manifest create`.
 
-Images publish to **both** registries with identical tags:
-`vianetwork/<component>` (Docker Hub) and
-`europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/<component>` (Google
-Artifact Registry). Publishing requires the `GAR_JSON_KEY` secret; the push and
-manifest jobs fail fast without it.
+Images always publish Docker Hub tags as `vianetwork/<component>`. When
+`GAR_JSON_KEY` is set, the same run also publishes matching Google Artifact Registry
+tags as
+`europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/<component>`. When
+`GAR_JSON_KEY` is absent, the push and manifest jobs skip Artifact Registry login,
+tags, and manifests and continue with Docker Hub only.
+
+Publishing still requires the Docker Hub secrets `DOCKERHUB_USER` and
+`DOCKERHUB_TOKEN`. `build-and-push-images` computes the Buildx `IMAGE_TAGS` list from
+the available registry credentials, so missing `GAR_JSON_KEY` is not a workflow
+failure by itself.
 
 ### Base images
 
@@ -267,7 +273,8 @@ For any change to this path, verify:
 - Runners stay GitHub-hosted (`ubuntu-24.04` / `ubuntu-24.04-arm`).
 - Any new workspace path the build needs is allow-listed in `.dockerignore`.
 - Runtime images copy only the intended binaries and runtime assets.
-- Publishing still targets both registries and still guards on `GAR_JSON_KEY`.
+- Publishing still targets Docker Hub, and still targets Artifact Registry when
+  `GAR_JSON_KEY` is available.
 
 If a change *intentionally* invalidates the dependency cache, say so in the PR
 description and weigh the cold-build cost against the benefit.

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -21,6 +21,10 @@ on:
         type: string
         required: false
         default: "do nothing"
+      source_ref:
+        description: "Git ref, tag, or SHA to checkout for the image build"
+        type: string
+        required: false
       export_build_cache:
         description: "Export BuildKit cache from trusted build-only callers"
         type: boolean
@@ -37,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           submodules: "recursive"
           persist-credentials: false
 
@@ -85,6 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           submodules: "recursive"
           persist-credentials: false
 
@@ -179,6 +185,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           submodules: "recursive"
           persist-credentials: false
 
@@ -221,12 +228,41 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          if [ -z "$GAR_JSON_KEY" ]; then
-            echo "GAR_JSON_KEY is required when publishing images to Artifact Registry" >&2
+          set -euo pipefail
+
+          if [ -z "$DOCKERHUB_USER" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "DOCKERHUB_USER and DOCKERHUB_TOKEN are required when publishing images" >&2
             exit 1
           fi
+
           printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
-          printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
+
+          if [ -n "$GAR_JSON_KEY" ]; then
+            printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
+          else
+            echo "GAR_JSON_KEY not set; publishing Docker Hub images only."
+          fi
+
+      - name: Set image publish tags
+        shell: bash
+        env:
+          COMPONENT: ${{ matrix.components }}
+          GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
+        run: |
+          set -euo pipefail
+
+          tags="vianetwork/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}"
+          if [ -n "$GAR_JSON_KEY" ]; then
+            tags="${tags}"$'\n'"europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}"
+          else
+            echo "GAR_JSON_KEY not set; publishing Docker Hub image only for ${COMPONENT} ${PLATFORM}."
+          fi
+
+          {
+            echo "IMAGE_TAGS<<EOF"
+            echo "$tags"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Build and push docker image
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
@@ -235,9 +271,7 @@ jobs:
           push: true
           platforms: ${{ matrix.platforms }}
           file: docker/${{ matrix.components }}/Dockerfile
-          tags: |
-            europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
-            vianetwork/${{ matrix.components }}:${{ env.IMAGE_TAG_SHA_TS }}-${{ env.PLATFORM }}
+          tags: ${{ env.IMAGE_TAGS }}
           # Release manifests are assembled from these platform tags with
           # `docker manifest create`; keep tags free of Buildx attestation
           # descriptors. SBOM generation is controlled separately.
@@ -267,6 +301,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           persist-credentials: false
 
       - name: login to Docker registries
@@ -276,25 +311,45 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
         run: |
-          if [ -z "$GAR_JSON_KEY" ]; then
-            echo "GAR_JSON_KEY is required when publishing manifests to Artifact Registry" >&2
+          set -euo pipefail
+
+          if [ -z "$DOCKERHUB_USER" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "DOCKERHUB_USER and DOCKERHUB_TOKEN are required when publishing manifests" >&2
             exit 1
           fi
+
           printf '%s' "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
-          printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
+
+          if [ -n "$GAR_JSON_KEY" ]; then
+            printf '%s' "$GAR_JSON_KEY" | docker login -u _json_key --password-stdin https://europe-west3-docker.pkg.dev
+          else
+            echo "GAR_JSON_KEY not set; publishing Docker Hub manifests only."
+          fi
 
       - name: Create Docker manifest
+        env:
+          COMPONENT: ${{ matrix.component.name }}
+          GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
+          MATRIX_PLATFORMS: ${{ matrix.component.platform }}
         run: |
-          docker_repositories=("vianetwork/${{ matrix.component.name }}" "europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${{ matrix.component.name }}")
-          platforms=${{ matrix.component.platform }}
+          set -euo pipefail
+
+          docker_repositories=("vianetwork/${COMPONENT}")
+          if [ -n "$GAR_JSON_KEY" ]; then
+            docker_repositories+=("europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${COMPONENT}")
+          else
+            echo "GAR_JSON_KEY not set; creating Docker Hub manifest only for ${COMPONENT}."
+          fi
+
+          platforms="${MATRIX_PLATFORMS}"
           for repo in "${docker_repositories[@]}"; do
-            platform_tags=""
+            platform_tags=()
             for platform in ${platforms//,/ }; do
-              platform=$(echo $platform | tr '/' '-')
-              platform_tags+=" --amend ${repo}:${IMAGE_TAG_SUFFIX}-${platform}"
+              platform=$(echo "$platform" | tr '/' '-')
+              platform_tags+=(--amend "${repo}:${IMAGE_TAG_SUFFIX}-${platform}")
             done
             for manifest in "${repo}:${IMAGE_TAG_SUFFIX}"; do
-              docker manifest create ${manifest} ${platform_tags}
-              docker manifest push ${manifest}
+              docker manifest create "${manifest}" "${platform_tags[@]}"
+              docker manifest push "${manifest}"
             done
           done

--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -39,25 +39,41 @@ jobs:
     runs-on: [ubuntu-latest]
     outputs:
       image_tag_suffix: ${{ steps.set.outputs.image_tag_suffix }}
+      source_ref: ${{ steps.set.outputs.source_ref }}
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - name: Generate output with git tag
         id: set
         env:
           INPUT_TAG_NAME: ${{ inputs.tag_name }}
         run: |
+          set -euo pipefail
+
           git_tag=""
           if [[ -z "$INPUT_TAG_NAME" ]]; then
-            git_tag="${GITHUB_REF#refs/*/}"
+            git_tag="${GITHUB_REF#refs/tags/}"
           else
-            git_tag="$INPUT_TAG_NAME"
+            git_tag="${INPUT_TAG_NAME#refs/tags/}"
           fi
-          version=$(cut -d "-" -f2 <<< "$git_tag")
-          echo "image_tag_suffix=${version}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$git_tag" == *$'\n'* || "$git_tag" == *$'\r'* || "$git_tag" == -* || "$git_tag" == */* ]] || ! git check-ref-format --allow-onelevel "$git_tag"; then
+            echo "::error::Invalid git tag/ref: ${git_tag}"
+            exit 1
+          fi
+
+          version="${git_tag#*-}"
+          if [[ -z "$version" || ! "$version" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::Invalid image tag suffix derived from ${git_tag}: ${version}"
+            exit 1
+          fi
+
+          printf 'image_tag_suffix=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'source_ref=refs/tags/%s\n' "$git_tag" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.set.outputs.source_ref }}
+          persist-credentials: false
 
       - name: Generate outputs with Prover FRI setup data keys IDs
         id: extract-prover-fri-setup-key-ids
@@ -75,6 +91,7 @@ jobs:
       GAR_JSON_KEY: ${{ secrets.GAR_JSON_KEY }}
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
+      source_ref: ${{ needs.setup.outputs.source_ref }}
       action: "push"
 
 #  build-push-tee-prover-images:


### PR DESCRIPTION
## Why

The `core-v28.1.0` tag contains the Via external-node reorg fix from issue #354 / PR #365 and the core release PR #367. The tagged image needs to be published so the Hetzner private testnet external node can temporarily validate `vianetwork/via-external-node:v28.1.0` by digest.

The current core image publish path exits before building when `GAR_JSON_KEY` is absent, because it requires Artifact Registry authentication for every publish. That blocks this validation path: the repository does not have `GAR_JSON_KEY`, and the GCP organization policy blocks creating service-account JSON keys. Docker Hub credentials exist and are sufficient for a temporary validation image.

This change lets the existing core image publish workflow proceed to Docker Hub when GAR credentials are absent, while preserving GAR publishing when `GAR_JSON_KEY` is available. It also makes the source ref explicit so a manual publish for `core-v28.1.0` builds that tag instead of accidentally building the workflow run ref and labeling it as `v28.1.0`.

## What changed

- Added optional `source_ref` input to `.github/workflows/build-core-template.yml`.
- Updated all core-image checkout steps to use `inputs.source_ref || github.sha`.
- Updated `.github/workflows/build-docker-from-tag.yml` to:
  - validate the requested tag/ref before checkout and output writes
  - checkout the fully qualified tag ref, e.g. `refs/tags/core-v28.1.0`
  - pass the fully qualified `source_ref` into the core image reusable workflow
  - preserve hyphenated image suffixes such as `v28.1.0-rc1`
- Kept Docker Hub credentials required for `inputs.action == 'push'`.
- Made GAR login conditional on `GAR_JSON_KEY`.
- Built the Buildx publish tag list dynamically:
  - always includes Docker Hub platform tags
  - includes GAR platform tags only when `GAR_JSON_KEY` is present
- Built the release manifest repository list dynamically:
  - always creates Docker Hub manifests
  - creates GAR manifests only when `GAR_JSON_KEY` is present
- Added explicit logs when GAR is skipped, without printing secret values.
- Updated `.github/via-core-image-builds.md` to document the Docker Hub-only fallback and the remaining GAR behavior.

## Reuse & Duplication

Not applicable — this changes GitHub Actions workflow definitions and maintainer/operator documentation only. No production runtime logic in a `via_*` path is added or changed.

The existing core image workflow structure is preserved: the same reusable workflow still owns contract preparation, per-platform image builds, and manifest creation. This PR only gates GAR-specific publish targets and passes the source ref explicitly from the existing tag workflow.

## Performance, Complexity, and Resource Impact

| Dimension | Before | After | Notes |
|---|---|---|---|
| Non-push image builds | unchanged | unchanged | Non-push jobs still build/load images and do not publish. |
| Docker Hub publish | blocked if `GAR_JSON_KEY` absent | works with Docker Hub credentials only | Temporary validation path for `vianetwork/via-external-node:v28.1.0`. |
| GAR publish | always attempted | attempted only when `GAR_JSON_KEY` is present | GAR support is gated, not deleted. |
| Source ref for tag publish | implicit or short ref | explicit `refs/tags/<tag>` | Avoids branch/tag name ambiguity. |
| Hyphenated image suffixes | truncated after the first suffix segment | preserved after the first dash | `core-v28.1.0-rc1` publishes as `v28.1.0-rc1`. |
| Runtime behavior | unchanged | unchanged | Workflow/docs-only change. |
| Net production LOC | 0 | 0 | No runtime source changes. |

## Boundaries and non-goals

This PR does not touch live Hetzner, via-infra-hetzner, Docker Compose files, GCP organization policy, service-account key creation, registry policy, or the existing `core-v28.1.0` tag.

This PR does not permanently replace GAR with Docker Hub. Docker Hub is only a temporary publishing path for the external-node validation image while GAR key-based auth is unavailable.

After merge, an operator can manually run the image workflow for `core-v28.1.0`, then inspect `vianetwork/via-external-node:v28.1.0` and capture its digest. Any Hetzner digest pin remains a separate via-infra-hetzner PR and separate deployment approval.

## How to review

Focus on:

- `.github/workflows/build-core-template.yml`
- `.github/workflows/build-docker-from-tag.yml`
- `.github/via-core-image-builds.md`

Review that Docker Hub publish still requires `DOCKERHUB_USER` and `DOCKERHUB_TOKEN`, GAR is skipped only when `GAR_JSON_KEY` is empty, and GAR tags/manifests are still included when `GAR_JSON_KEY` exists.

Also verify that `source_ref` and `image_tag_suffix` remain separate: `source_ref` selects the Git tag ref to build, while `image_tag_suffix` controls the Docker tag suffix.

## Checks run

```bash
git check-ref-format --allow-onelevel core-v28.1.0

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/workflows/build-core-template.yml \
  .github/workflows/build-docker-from-tag.yml

zizmor --gh-token "$(gh auth token)" --no-config --strict-collection --format plain .github/workflows/*.yml

python3 - <<'PY'
from pathlib import Path
core = Path('.github/workflows/build-core-template.yml').read_text()
from_tag = Path('.github/workflows/build-docker-from-tag.yml').read_text()
doc = Path('.github/via-core-image-builds.md').read_text()
assert 'GAR_JSON_KEY is required' not in core
assert 'GAR_JSON_KEY is required' not in from_tag
assert 'DOCKERHUB_USER and DOCKERHUB_TOKEN are required when publishing images' in core
assert 'GAR_JSON_KEY not set; publishing Docker Hub image only' in core
assert 'vianetwork/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}' in core
assert 'europe-west3-docker.pkg.dev/viaorg-prod-net-landing-0/via/${COMPONENT}:${IMAGE_TAG_SHA_TS}-${PLATFORM}' in core
assert 'version="${git_tag#*-}"' in from_tag
assert 'printf \'source_ref=refs/tags/%s\\n\' "$git_tag" >> "$GITHUB_OUTPUT"' in from_tag
assert 'ref: ${{ steps.set.outputs.source_ref }}' in from_tag
assert 'source_ref: ${{ steps.set.outputs.source_ref }}' in from_tag
assert 'source_ref: ${{ needs.setup.outputs.source_ref }}' in from_tag
assert 'skip Artifact Registry login' in doc
assert 'IMAGE_TAGS' in doc
assert 'failure by itself' in doc
print('basic workflow text checks passed')
PY

bash -euo pipefail <<'BASH'
for input in core-v28.1.0 core-v28.1.0-rc1 refs/tags/core-v28.1.0-rc1; do
  git_tag="${input#refs/tags/}"
  if [[ "$git_tag" == *$'\n'* || "$git_tag" == *$'\r'* || "$git_tag" == -* || "$git_tag" == */* ]] || ! git check-ref-format --allow-onelevel "$git_tag"; then
    echo "invalid: $input -> $git_tag" >&2
    exit 1
  fi
  version="${git_tag#*-}"
  if [[ -z "$version" || ! "$version" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
    echo "invalid version: $input -> $version" >&2
    exit 1
  fi
  printf '%s -> source_ref=refs/tags/%s image_tag_suffix=%s\n' "$input" "$git_tag" "$version"
done
BASH

git diff --check

just via-check-strict

gitleaks protect --staged --redact --no-banner
gitleaks git --log-opts="main..HEAD" --redact --no-banner
```

`zizmor` reported no active findings for all active workflow YAML files. `just via-check-strict` passed with only the remaining pre-existing Rust structural baselines.

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.
- [x] Ran `just via-check-strict` and recorded results in the Checks run section.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR changes GitHub Actions workflow source and maintainer documentation only. It does not publish images by itself, deploy services, restart workloads, mutate databases, change secrets, create service-account keys, modify GCP organization policy, or touch Hetzner infrastructure.
