### PR TITLE
chore(via-da): bump local Celestia Mocha image

### DIFF
--- a/docker-compose-via.yml
+++ b/docker-compose-via.yml
@@ -241,7 +241,7 @@ services:
       - POSTGRES_PASSWORD=notsecurepassword
 
   celestia-node-init:
-    image: &celestia-image "ghcr.io/celestiaorg/celestia-node:v0.29.3-mocha"
+    image: &celestia-image "ghcr.io/celestiaorg/celestia-node:v0.31.1-mocha"
     volumes:
       - ./etc/docker-data/celestia/keys:/keys
       - celestia:/home/celestia


### PR DESCRIPTION
## Why

The local Via Docker environment still used `ghcr.io/celestiaorg/celestia-node:v0.29.3-mocha` for the Celestia init and runtime containers. The current Mocha network has moved on again: production desired state was already at `v0.30.2-mocha`, live logs now show Mocha headers with version 9, and the current Mocha documentation lists `celestia-node v0.31.1-mocha` with `celestia-app v9.0.2-mocha`.

Leaving local development on the older image repeats the drift fixed by the previous local Celestia bump. A developer can reproduce an obsolete protocol failure locally while kube-state and the live recovery path require a newer node. The Docker compose file should track the current Mocha-compatible node image so DA troubleshooting and local startup behavior remain representative.

## What changed

- The shared `celestia-image` anchor in `docker-compose-via.yml` now points at `ghcr.io/celestiaorg/celestia-node:v0.31.1-mocha`.
- Both `celestia-node-init` and `celestia-node` continue to use the same image through that anchor.
- No compose services, volumes, ports, commands, env vars, keys, or trusted-checkpoint logic changed.

## Reuse & Duplication

Not applicable — this PR changes local Docker image configuration only and does not add or change production logic in a `via_*` path.

## Performance, Complexity, and Resource Impact

No runtime code path changes. Local Docker pulls a newer Celestia image for init/runtime containers; CPU, memory, DB, RPC, and allocation behavior in Via code are unchanged.

## Boundaries and non-goals

- Source/config only; no live deployment, restart, database write, secret read/write, Kubernetes change, Helm release, host service, DNS, or cloud resource was changed from this branch.
- This PR updates the local/dev compose image in `via-core`; kube-state desired state is handled by a separate PR.
- The existing dynamic trusted hash/height init flow is unchanged.
- Merging this PR does not deploy live services by itself. It only affects future local Docker compose runs or images/config derived from this source file.

## How to review

Review `docker-compose-via.yml` around the `celestia-node-init` service. The only intended change is the shared `celestia-image` tag from `v0.29.3-mocha` to `v0.31.1-mocha`; the `celestia-node` service should continue to consume the same anchor.

Compare against the current Mocha network docs and the kube-state desired-state PR so local development and testnet desired state point at the same Celestia Mocha node release.

## Checks run

```bash
git diff --check -- docker-compose-via.yml
docker compose -f docker-compose-via.yml config --quiet
gitleaks protect --staged --redact --no-banner
npx gitnexus analyze --force
```

## Author checklist

- [x] PR title follows Conventional Commits.
- [x] Tests, docs, formatting, and linting were updated or marked not applicable.
- [x] `just via-check` is not applicable because this PR does not touch production logic or sibling-paired paths.

## Live infrastructure and deployment impact

No live infrastructure actions were run.

Merging this PR changes local Docker compose configuration only and is not expected to deploy live services by itself. Live Celestia rollout is governed by kube-state desired state and a separate operator-approved manual deployment.