### PR TITLE
fix(via): expose liveness for components that emit only on events

### DIFF
--- a/core/node/via_btc_watch/src/lib.rs
+++ b/core/node/via_btc_watch/src/lib.rs
@@ -10,7 +10,7 @@ pub use via_btc_client::types::BitcoinNetwork;
 use via_btc_client::{client::BitcoinClient, indexer::BitcoinInscriptionIndexer};
 use zksync_config::{configs::via_btc_watch::L1_BLOCKS_CHUNK, ViaBtcWatchConfig};
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
-use zksync_types::via_wallet::SystemWallets;
+use zksync_types::{helpers::unix_timestamp_ms, via_wallet::SystemWallets};
 
 #[cfg(test)]
 mod test;
@@ -38,6 +38,7 @@ impl BtcWatch {
         pool: ConnectionPool<Core>,
         is_main_node: bool,
     ) -> anyhow::Result<Self> {
+        METRICS.initialize();
         let system_wallet_processor = Box::new(SystemWalletProcessor::new(btc_client.clone()));
 
         // Only build message processors that match the actor role:
@@ -83,7 +84,9 @@ impl BtcWatch {
 
             let mut storage = pool.connection_tagged(BtcWatch::module_name()).await?;
             match self.loop_iteration(&mut storage).await {
-                Ok(()) => { /* everything went fine */ }
+                Ok(()) => {
+                    METRICS.last_iteration_timestamp.set(unix_timestamp_ms() / 1_000);
+                }
                 Err(err) => {
                     METRICS.errors.inc();
                     tracing::error!("Failed to process new blocks: {err}");

--- a/core/node/via_btc_watch/src/metrics.rs
+++ b/core/node/via_btc_watch/src/metrics.rs
@@ -1,4 +1,4 @@
-use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, LabeledFamily, Metrics};
+use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, LabeledFamily, Metrics, Unit};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "stage", rename_all = "snake_case")]
@@ -21,7 +21,34 @@ pub struct ViaBtcWatcherMetrics {
 
     /// Counter to store the layer errors.
     pub errors: Counter,
+
+    /// Unix timestamp of the last completed loop iteration. Liveness only; does not assert that the iteration's work succeeded.
+    #[metrics(unit = Unit::Seconds)]
+    pub last_iteration_timestamp: Gauge<u64>,
+}
+
+impl ViaBtcWatcherMetrics {
+    pub(crate) fn initialize(&self) {
+        self.inscriptions_processed[&InscriptionStage::Vote].inc_by(0);
+        self.inscriptions_processed[&InscriptionStage::Upgrade].inc_by(0);
+        self.deposit.inc_by(0);
+        self.errors.inc_by(0);
+        self.last_iteration_timestamp.inc_by(0);
+    }
 }
 
 #[vise::register]
 pub static METRICS: vise::Global<ViaBtcWatcherMetrics> = vise::Global::new();
+
+#[cfg(test)]
+#[test]
+fn materializes_metrics_before_work() {
+    let registry = vise::MetricsCollection::lazy().filter(|group| group.module_path == module_path!()).collect();
+    METRICS.initialize();
+    let mut output = String::new();
+    registry.encode(&mut output, vise::Format::OpenMetricsForPrometheus).unwrap();
+    let samples: Vec<_> = output.lines().filter(|line| !line.starts_with('#')).collect();
+    assert!(samples.len() >= 5, "{samples:#?}");
+    assert!(["stage=\"vote\"", "stage=\"upgrade\""].iter().all(|label| output.contains(label)));
+    assert!(samples.contains(&"via_server_btc_watch_last_iteration_timestamp_seconds 0"));
+}

--- a/core/node/via_da_dispatcher/src/da_dispatcher.rs
+++ b/core/node/via_da_dispatcher/src/da_dispatcher.rs
@@ -40,6 +40,7 @@ impl ViaDataAvailabilityDispatcher {
         blob_store: Arc<dyn ObjectStore>,
         dispatch_real_proof: bool,
     ) -> Self {
+        METRICS.initialize();
         Self {
             pool,
             config,

--- a/core/node/via_da_dispatcher/src/metrics.rs
+++ b/core/node/via_da_dispatcher/src/metrics.rs
@@ -38,5 +38,26 @@ pub(super) struct DataAvailabilityDispatcherMetrics {
     pub errors: Counter,
 }
 
+impl DataAvailabilityDispatcherMetrics {
+    pub(super) fn initialize(&self) {
+        self.last_dispatched_l1_batch.inc_by(0);
+        self.last_dispatched_proof_batch.inc_by(0);
+        self.last_included_l1_batch.inc_by(0);
+        self.last_included_proof_batch.inc_by(0);
+        self.errors.inc_by(0);
+    }
+}
+
 #[vise::register]
 pub(super) static METRICS: vise::Global<DataAvailabilityDispatcherMetrics> = vise::Global::new();
+
+#[cfg(test)]
+#[test]
+fn materializes_metrics_before_work() {
+    let registry = vise::MetricsCollection::lazy().filter(|group| group.module_path == module_path!()).collect();
+    METRICS.initialize();
+    let mut output = String::new();
+    registry.encode(&mut output, vise::Format::OpenMetricsForPrometheus).unwrap();
+    assert_eq!(output.matches("_batch 0\n").count(), 4, "{output}");
+    assert!(output.contains("\nvia_server_da_dispatcher_errors 0\n"), "{output}");
+}

--- a/via_verifier/node/via_btc_watch/src/lib.rs
+++ b/via_verifier/node/via_btc_watch/src/lib.rs
@@ -11,7 +11,7 @@ use via_btc_client::{client::BitcoinClient, indexer::BitcoinInscriptionIndexer};
 use via_verifier_dal::{Connection, ConnectionPool, Verifier, VerifierDal};
 use via_verifier_types::protocol_version::check_if_supported_sequencer_version;
 use zksync_config::{configs::via_btc_watch::L1_BLOCKS_CHUNK, ViaBtcWatchConfig};
-use zksync_types::via_wallet::SystemWallets;
+use zksync_types::{helpers::unix_timestamp_ms, via_wallet::SystemWallets};
 
 use self::message_processors::{MessageProcessor, MessageProcessorError};
 use crate::{
@@ -38,6 +38,7 @@ impl VerifierBtcWatch {
         btc_client: Arc<BitcoinClient>,
         pool: ConnectionPool<Verifier>,
     ) -> anyhow::Result<Self> {
+        METRICS.initialize();
         let system_wallet_processor = Box::new(SystemWalletProcessor::new(btc_client.clone()));
 
         let message_processors: Vec<Box<dyn MessageProcessor>> = vec![
@@ -70,7 +71,9 @@ impl VerifierBtcWatch {
                 .connection_tagged(VerifierBtcWatch::module_name())
                 .await?;
             match self.loop_iteration(&mut storage).await {
-                Ok(()) => { /* everything went fine */ }
+                Ok(()) => {
+                    METRICS.last_iteration_timestamp.set(unix_timestamp_ms() / 1_000);
+                }
                 Err(err) => {
                     METRICS.errors.inc();
                     tracing::error!("Error processing new blocks: {err:?}");

--- a/via_verifier/node/via_btc_watch/src/metrics.rs
+++ b/via_verifier/node/via_btc_watch/src/metrics.rs
@@ -1,4 +1,4 @@
-use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, LabeledFamily, Metrics};
+use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, LabeledFamily, Metrics, Unit};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "stage", rename_all = "snake_case")]
@@ -27,7 +27,40 @@ pub struct ViaVerifierBtcWatcherMetrics {
 
     /// Errors
     pub errors: Counter,
+
+    /// Unix timestamp of the last completed loop iteration. Liveness only; does not assert that the iteration's work succeeded.
+    #[metrics(unit = Unit::Seconds)]
+    pub last_iteration_timestamp: Gauge<u64>,
+}
+
+impl ViaVerifierBtcWatcherMetrics {
+    pub(crate) fn initialize(&self) {
+        self.inscriptions_processed[&InscriptionStage::IndexedL1Batch].inc_by(0);
+        self.inscriptions_processed[&InscriptionStage::Upgrade].inc_by(0);
+        self.inscriptions_processed[&InscriptionStage::Finalized].inc_by(0);
+        self.inscriptions_processed[&InscriptionStage::Reorg].inc_by(0);
+        self.inscriptions_processed[&InscriptionStage::Vote].inc_by(0);
+        self.deposit.inc_by(0);
+        self.withdrawal_confirmed.inc_by(0);
+        self.errors.inc_by(0);
+        self.last_iteration_timestamp.inc_by(0);
+    }
 }
 
 #[vise::register]
 pub static METRICS: vise::Global<ViaVerifierBtcWatcherMetrics> = vise::Global::new();
+
+#[cfg(test)]
+#[test]
+fn materializes_metrics_before_work() {
+    let registry = vise::MetricsCollection::lazy().filter(|group| group.module_path == module_path!()).collect();
+    METRICS.initialize();
+    let mut output = String::new();
+    registry.encode(&mut output, vise::Format::OpenMetricsForPrometheus).unwrap();
+    let samples: Vec<_> = output.lines().filter(|line| !line.starts_with('#')).collect();
+    assert!(samples.len() >= 9, "{samples:#?}");
+    assert!(["indexed_l1_batch", "upgrade", "finalized", "reorg", "vote"]
+        .iter()
+        .all(|stage| output.contains(&format!("stage=\"{stage}\""))));
+    assert!(samples.contains(&"via_verifier_btc_watch_last_iteration_timestamp_seconds 0"));
+}

--- a/via_verifier/node/via_zk_verifier/src/lib.rs
+++ b/via_verifier/node/via_zk_verifier/src/lib.rs
@@ -18,7 +18,9 @@ use via_verifier_types::protocol_version::check_if_supported_sequencer_version;
 use zksync_config::{ViaBtcWatchConfig, ViaVerifierConfig};
 use zksync_da_client::{types::InclusionData, DataAvailabilityClient};
 use zksync_object_store::ObjectStore;
-use zksync_types::{via_wallet::SystemWallets, L1BatchNumber, H160, H256};
+use zksync_types::{
+    helpers::unix_timestamp_ms, via_wallet::SystemWallets, L1BatchNumber, H160, H256,
+};
 
 mod metrics;
 
@@ -43,6 +45,7 @@ impl ViaVerifier {
         via_btc_watch_config: ViaBtcWatchConfig,
         blob_store: Arc<dyn ObjectStore>,
     ) -> anyhow::Result<Self> {
+        METRICS.initialize();
         let state = ViaState::new(pool.clone(), btc_client.clone(), via_btc_watch_config);
 
         Ok(Self {
@@ -67,7 +70,11 @@ impl ViaVerifier {
 
             let mut storage = pool.connection_tagged("via_zk_verifier").await?;
             match self.loop_iteration(&mut storage).await {
-                Ok(()) => {}
+                Ok(()) => {
+                    METRICS
+                        .last_iteration_timestamp
+                        .set(unix_timestamp_ms() / 1_000);
+                }
                 Err(err) => {
                     METRICS.errors.inc();
                     tracing::error!("Failed to process via_zk_verifier: {err}")

--- a/via_verifier/node/via_zk_verifier/src/metrics.rs
+++ b/via_verifier/node/via_zk_verifier/src/metrics.rs
@@ -16,7 +16,36 @@ pub struct ViaZKVerifierMetrics {
 
     /// Errors
     pub errors: Counter,
+
+    /// Unix timestamp of the last completed loop iteration. Liveness only; does not assert that the iteration's work succeeded.
+    #[metrics(unit = Unit::Seconds)]
+    pub last_iteration_timestamp: Gauge<u64>,
+}
+
+impl ViaZKVerifierMetrics {
+    pub(crate) fn initialize(&self) {
+        self.last_valid_l1_batch.inc_by(0);
+        self.last_invalid_l1_batch.inc_by(0);
+        self.errors.inc_by(0);
+        self.last_iteration_timestamp.inc_by(0);
+    }
 }
 
 #[vise::register]
 pub static METRICS: vise::Global<ViaZKVerifierMetrics> = vise::Global::new();
+
+#[cfg(test)]
+#[test]
+fn materializes_metrics_before_work() {
+    let registry = vise::MetricsCollection::lazy()
+        .filter(|group| group.module_path == module_path!())
+        .collect();
+    METRICS.initialize();
+    let mut output = String::new();
+    registry
+        .encode(&mut output, vise::Format::OpenMetricsForPrometheus)
+        .unwrap();
+    assert_eq!(output.matches("_l1_batch 0\n").count(), 2, "{output}");
+    assert!(output.contains("\nvia_verifier_zk_errors 0\n"), "{output}");
+    assert!(output.contains("\nvia_verifier_zk_last_iteration_timestamp_seconds 0\n"));
+}


### PR DESCRIPTION
## What is wrong

Four components export no metrics while they operate correctly. The BTC watcher on the sequencer, the
BTC watcher on the verifier, the DA dispatcher, and the ZK verifier are affected.

Every metric in these components is written only when an event occurs. The `vise` library registers a
metric when the code first uses it. A component that runs correctly and finds no work therefore
registers no metric at all.

The result is that a healthy component and a stopped component look the same. An operator cannot tell
the difference, and no alert can detect the difference.

## Evidence

The metrics endpoint of a running node was read directly. The node had operated for eight days.

```
via_server_btc_watch          0 series
via_server_da_dispatcher      0 series
via_btc_sender               53 series
```

The logs of the same node show that the BTC watcher processed blocks every 20 minutes during that
period. The component did the work. The component reported nothing.

## What this change does

The change adds two things to each affected component.

First, it materializes the event-driven metrics at startup. The code calls `inc_by(0)` on each counter
and on each fixed enum label value. This is the pattern that `via_main_node_reorg_detector`,
`via_reorg_detector`, and `via_block_reverter` already use. The metrics now appear in a scrape
immediately, with the value 0.

Second, it adds one gauge for each component:

```
<component_prefix>_last_iteration_timestamp_seconds
```

The component sets this gauge after each completed loop iteration. This includes an iteration that
finds no work, which is the important condition. An operator can then calculate
`time() - <metric>` to find how long ago the component last ran.

The gauge records liveness only. It does not assert that the work of the iteration succeeded. The
help text states this, because the loop of the ZK verifier returns `Ok` on some paths that log an
error.

## What this change does not do

The DA dispatcher does not receive a liveness gauge. Its three concurrent tasks record their own
errors and then return `()`. The outer branch therefore completes whether the operations succeeded or
failed. A gauge at that point can report a successful iteration after a handled failure.

A truthful gauge for the DA dispatcher requires a change to how the tasks return their results. That
change is outside the scope of this pull request. The DA dispatcher does receive the startup
materialization.

No dynamic label value is materialized. The `system_wallets{role,address}` family keeps its current
behavior, because its label values are not a fixed set.

## Tests

Each component has a unit test. The test collects the metrics registry, encodes it in the
OpenMetrics format, and asserts that the expected series are present in the output.

The test reads the encoded output and not a structure field. A structure field can hold the value 0
while the series is absent from a scrape. The absent series is the defect, so the test must examine
the scrape.

The test for the sequencer BTC watcher also asserts that the liveness gauge advances after a
successful iteration that finds no work.

## Risk

The change adds no dependency, no task, no database query, and no network call. It does not change
control flow, error handling, or timing.

A successful iteration now performs one clock read and one atomic gauge write. Startup creates two
fixed series for the sequencer BTC watcher and five for the verifier BTC watcher.
